### PR TITLE
remove time + pessimistic_sleep

### DIFF
--- a/src/plotsbase/scene.jl
+++ b/src/plotsbase/scene.jl
@@ -201,12 +201,14 @@ function render_loop(tsig, screen, framerate = 1/60)
     while isopen(screen)
         t = time()
         GLWindow.poll_glfw() # GLFW poll
-        push!(tsig, t)
         if Base.n_avail(Reactive._messages) > 0
             render_frame(screen)
         end
         t = time() - t
-        GLWindow.sleep_pessimistic(framerate - t)
+        to_sleep = framerate - t
+        if to_sleep > 0.001 # minimal sleep time
+            sleep(to_sleep)
+        end
     end
     GLWindow.destroy!(screen)
     return


### PR DESCRIPTION
this will remove the time attribute from a scene, since this was always waking up the whole event loop.
Removing it decreased the time spent on the cpu from ~20% to ~0  cpu usage for idle time.

I'd say, people should just implement their own loop for doing animations relying on the time.
cc @jpsamaroo
@ssfrr, what do you think, you used `scene[:time]` so far.