### PR TITLE
Fixed gpu_setindex! writing to the wrong offset.

### DIFF
--- a/src/glbackend/GLAbstraction/GLBuffer.jl
+++ b/src/glbackend/GLAbstraction/GLBuffer.jl
@@ -110,7 +110,7 @@ end
 function gpu_setindex!(b::GLBuffer{T}, value::Vector{T}, offset::Integer) where T
     multiplicator = sizeof(T)
     bind(b)
-    glBufferSubData(b.buffertype, multiplicator*offset-1, sizeof(value), value)
+    glBufferSubData(b.buffertype, multiplicator*(offset-1), sizeof(value), value)
     bind(b, 0)
 end
 function gpu_setindex!(b::GLBuffer{T}, value::Vector{T}, offset::UnitRange{Int}) where T


### PR DESCRIPTION
In the old variant, e.g. writing 4-byte elements to index 1 (the beginning) of a GLBuffer, would put them at byte offset 4*1-1 = 3, rather than the correct 4*(1-1) = 0.