### PR TITLE
Reexport StatsMakie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ precompile.jl
 build
 src/glbackend/.cache
 test/testimages/*
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,9 @@ GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
+StatsMakie = "65254759-4cff-5aa5-8326-61ce017a8c70"
 
 [compat]
 AbstractPlotting = ">=0.9.6"
 GLMakie = ">=0.0.5"
+StatsMakie = ">=0.0.3"

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ FileIO
 ImageMagick
 AbstractPlotting 0.9.5
 GLMakie 0.0.5
+StatsMakie 0.0.3

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -1,12 +1,17 @@
 module Makie
 
-using AbstractPlotting, GLMakie
+using AbstractPlotting, GLMakie, StatsMakie
 import FileIO
 using GLMakie
 using GLMakie: assetpath, loadasset
 
 for name in names(AbstractPlotting)
     @eval import AbstractPlotting: $(name)
+    @eval export $(name)
+end
+
+for name in names(StatsMakie)
+    @eval import StatsMakie: $(name)
     @eval export $(name)
 end
 


### PR DESCRIPTION
Given that Makie is the metapackage and that StatsMakie provides some functionality that is reasonably general even outside of statistics (i.e. grouping, smoothing, histograms) and is included in the Makie documentation, maybe we should just reexport it from here. I imagine the extra dependencies are not really a concern as this is a metapackage already.