### PR TITLE
Update PackageCompiler steps to include dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ To do that, you need to check out the additional packages for precompilation.
 Then you can build a system image like this:
 
 ```julia
-# add PackageCompiler
-Pkg.add("PackageCompiler")
+# add PackageCompiler and other dependencies
+Pkg.add.(["PackageCompiler", "AbstractPlotting", "GDAL", "GeometryTypes", "MakieGallery", "RDatasets"])
 using PackageCompiler
 # This is not well tested, so please be careful - I don't take any responsibilities for a messed up Julia install.
 


### PR DESCRIPTION
Generating a system image seems to require additional dependencies beyond just Makie - this adds the extra required packages to the README.md. I'm not entirely sure why this is the case but precompilation kept crashing for me until I added these packages explicitly to my default environment.