### PR TITLE
fix theming in stats recipes

### DIFF
--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -28,7 +28,6 @@ The boxplot has 3 components:
 - `show_outliers`: show outliers as points
 """
 @recipe(BoxPlot, x, y) do scene
-    scattertheme = default_theme(scene, Scatter)
     Theme(
         color = theme(scene, :patchcolor),
         colormap = theme(scene, :colormap),
@@ -40,27 +39,28 @@ The boxplot has 3 components:
         n_dodge = automatic,
         x_gap = 0.2,
         dodge_gap = 0.03,
-        strokecolor = :white,
-        strokewidth = 0.0,
+        strokecolor = theme(scene, :patchstrokecolor),
+        strokewidth = theme(scene, :patchstrokewidth),
         # notch
         show_notch = false,
         notchwidth = 0.5,
         # median line
         show_median = true,
-        mediancolor = automatic,
-        medianlinewidth = 1.0,
+        mediancolor = theme(scene, :linecolor),
+        medianlinewidth = theme(scene, :linewidth),
         # whiskers
         range = 1.5,
         whiskerwidth = 0.0,
-        whiskercolor = :black,
-        whiskerlinewidth = 1.0,
+        whiskercolor = theme(scene, :linecolor),
+        whiskerlinewidth = theme(scene, :linewidth),
         # outliers points
         show_outliers = true,
-        marker = scattertheme.marker,
-        markersize = scattertheme.markersize,
+        marker = Circle,
+        markersize = theme(scene, :markersize),
         outliercolor = automatic,
-        outlierstrokecolor = scattertheme.strokecolor,
-        outlierstrokewidth = scattertheme.strokewidth,
+        outlierstrokecolor = theme(scene, :markerstrokecolor),
+        outlierstrokewidth = theme(scene, :markerstrokewidth),
+        cycle = [:color => :patchcolor],
         inspectable = theme(scene, :inspectable)
     )
 end

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -55,7 +55,7 @@ The boxplot has 3 components:
         whiskerlinewidth = theme(scene, :linewidth),
         # outliers points
         show_outliers = true,
-        marker = Circle,
+        marker = theme(scene, :marker),
         markersize = theme(scene, :markersize),
         outliercolor = automatic,
         outlierstrokecolor = theme(scene, :markerstrokecolor),

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -170,7 +170,9 @@ function Makie.plot!(plot::BoxPlot)
     boxwidth = @lift($signals.boxwidth)
 
     outliercolor = lift(plot[:outliercolor], plot[:color]) do outliercolor, color
-        outliercolor === automatic ? color : outliercolor
+        outliercolor === automatic || return outliercolor
+        c = to_color(color)
+        return RGB(red(c), green(c), blue(c))
     end
 
     scatter!(

--- a/src/stats/crossbar.jl
+++ b/src/stats/crossbar.jl
@@ -42,7 +42,7 @@ It is most commonly used as part of the `boxplot`.
     # median line
     show_midline=true,
     midlinecolor=automatic,
-    midlinewidth=1.0,
+    midlinewidth=theme(scene, :linewidth),
     inspectable = theme(scene, :inspectable),
     cycle = [:color => :patchcolor],
 )

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -26,7 +26,7 @@ Draw a violin plot.
         datalimits = (-Inf, Inf),
         max_density = automatic,
         show_median = false,
-        mediancolor = automatic,
+        mediancolor = theme(scene, :linecolor),
         medianlinewidth = theme(scene, :linewidth),
     )
 end
@@ -129,11 +129,7 @@ function plot!(plot::Violin)
     linesegments!(
         plot,
         lift(s -> s.lines, signals),
-        color = lift(
-            (mc, sc) -> mc === automatic ? sc : mc,
-            plot[:mediancolor],
-            plot[:strokecolor],
-        ),
+        color = plot[:mediancolor],
         linewidth = plot[:medianlinewidth],
         visible = plot[:show_median],
         inspectable = plot[:inspectable]

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -25,10 +25,9 @@ Draw a violin plot.
         dodge_gap = 0.03,
         datalimits = (-Inf, Inf),
         max_density = automatic,
-        strokecolor = :white,
         show_median = false,
         mediancolor = automatic,
-        medianlinewidth = 1.0,
+        medianlinewidth = theme(scene, :linewidth),
     )
 end
 


### PR DESCRIPTION
The theme is now sufficiently rich that it is possible to give reasonable defaults to all attributes in `boxplot` and `violin` without hardcoding values. The "hardcoded" white color to draw the median is no longer necessary, as they are cycling colors, so the default black works well on the "patchcolor" palette, for example:

![violin](https://user-images.githubusercontent.com/6333339/118955076-aae30080-b95e-11eb-8fa5-2067ed4ae52f.png)

I'm not 100% sure whether the outliers in `boxplot` should inherit from `default_theme(scene, Scatter)[:strokewidth]` (and friends) or `theme(scene, :markerstrokewidth)` (and friends). I guess the latter is a bit cleaner.

Related question: what about the default `outliercolor`? The old behavior of matching the overall color makes less sense now that the default color has some transparency. I imagine it should inherit from `theme(scene, :markercolor)`, but should we also cycle it by default, or could we just keep default black outliers for boxplots?

Side note: kudos on the `theme`  redesign, it has exactly all attributes one might need!