### PR TITLE
Camera 3d fixes

### DIFF
--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -26,34 +26,22 @@ function disconnect!(nodes::Vector)
     return
 end
 
-struct CameraLift{F, Args}
-    f::F
-    args::Args
-end
-
-function (cl::CameraLift{F, Args})(val) where {F, Args}
-    cl.f(map(to_value, cl.args)...)
-end
-
 """
     on(f, c::Camera, nodes::Node...)
+
 When mapping over nodes for the camera, we store them in the `steering_node` vector,
 to make it easier to disconnect the camera steering signals later!
 """
 function Observables.on(f::Function, camera::Camera, nodes::AbstractObservable...; priority=Int8(0))
-    # this basically reimplements onany, which is a bit annoying, but like
-    # this we don't have such a closure hell and CameraLift will be nicely
-    # identifiable when we disconnect the nodes!
-    cl = CameraLift(f, nodes)
+    # PriorityObservables don't implement on_any
     for n in nodes
         obs = if n isa PriorityObservable
-            on(cl, n, priority=priority)
+            on(f, n, priority=priority)
         else
-            on(cl, n)
+            on(f, n)
         end
         push!(camera.steering_nodes, obs)
     end
-    # push!(camera.steering_nodes, nodes...)
     return f
 end
 

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -279,7 +279,7 @@ function zoom!(scene, point, zoom_step, shift_lookat::Bool)
     else
         # Rotations need more extreme eyeposition shifts
         step = zoom_step
-        while abs(step) > 1f0
+        while abs(step) > 0f0
             cam.eyeposition[] = cam.eyeposition[] + sign(zoom_step) * (ray_dir - dir * 0.1f0)
             dir = cam.eyeposition[] - lookat
             step -= sign(step)

--- a/src/types.jl
+++ b/src/types.jl
@@ -237,7 +237,7 @@ mutable struct Camera
     projectionview::Node{Mat4f0}
     resolution::Node{Vec2f0}
     eyeposition::Node{Vec3f0}
-    steering_nodes::Vector{Any}
+    steering_nodes::Vector{ObserverFunction}
 end
 
 """


### PR DESCRIPTION
* fix `cam3d_cad` not zooming
* fix cleanup of camera nodes

The latter fixes issues where 3d scenes become non-interactive when another is added, e.g.

```julia
fig = Figure()
mesh(fig[1, 1], Rect3D(Point3f0(0), Point3f0(1)))
mesh(fig[1, 2], Rect3D(Point3f0(0), Point3f0(1)))
```

Note that I also removed `CameraLift` - I don't think it's needed anymore. I'm also not sure if this works with Observables 0.3, but WGLMakie and GLMakie restrict to 0.4 anyway...