### PR TITLE
jk/legend attr fix

### DIFF
--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -157,7 +157,7 @@ f = Figure()
 Axis(f[1, 1])
 
 elem_1 = [LineElement(linecolor = :red, linestyle = nothing),
-          MarkerElement(markercolor = :blue, marker = 'x',
+          MarkerElement(markercolor = :blue, marker = 'x', markersize = 15,
           markerstrokecolor = :black)]
 
 elem_2 = [PolyElement(polycolor = :red, polystrokecolor = :blue),
@@ -166,8 +166,7 @@ elem_2 = [PolyElement(polycolor = :red, polystrokecolor = :blue),
 elem_3 = LineElement(linecolor = :green, linestyle = nothing,
         linepoints = Point2f0[(0, 0), (0, 1), (1, 0), (1, 1)])
 
-elem_4 = MarkerElement(markercolor = :blue, marker = 'π',
-        markerstrokecolor = :transparent,
+elem_4 = MarkerElement(markercolor = :blue, marker = 'π', markersize = 15,
         markerpoints = Point2f0[(0.2, 0.2), (0.5, 0.8), (0.8, 0.2)])
 
 elem_5 = PolyElement(polycolor = :green, polystrokecolor = :black,

--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -22,7 +22,7 @@ Axis(f[1, 1])
 xs = 0:0.5:10
 ys = sin.(xs)
 lin = lines!(xs, ys, color = :blue)
-sca = scatter!(xs, ys, color = :red, markersize = 15)
+sca = scatter!(xs, ys, color = :red)
 
 Legend(f[1, 2], [lin, sca, [lin, sca]], ["a line", "some dots", "both together"])
 

--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -156,23 +156,22 @@ f = Figure()
 
 Axis(f[1, 1])
 
+elem_1 = [LineElement(linecolor = :red, linestyle = nothing),
+          MarkerElement(markercolor = :blue, marker = 'x',
+          markerstrokecolor = :black)]
 
-elem_1 = [LineElement(color = :red, linestyle = nothing),
-          MarkerElement(color = :blue, marker = 'x', strokecolor = :black)]
+elem_2 = [PolyElement(polycolor = :red, polystrokecolor = :blue),
+          LineElement(linecolor = :black, linestyle = :dash)]
 
-elem_2 = [PolyElement(color = :red, strokecolor = :blue),
-          LineElement(color = :black, linestyle = :dash)]
-
-elem_3 = LineElement(color = :green, linestyle = nothing,
+elem_3 = LineElement(linecolor = :green, linestyle = nothing,
         linepoints = Point2f0[(0, 0), (0, 1), (1, 0), (1, 1)])
 
-elem_4 = MarkerElement(color = :blue, marker = 'π',
-        strokecolor = :transparent,
+elem_4 = MarkerElement(markercolor = :blue, marker = 'π',
+        markerstrokecolor = :transparent,
         markerpoints = Point2f0[(0.2, 0.2), (0.5, 0.8), (0.8, 0.2)])
 
-elem_5 = PolyElement(color = :green, strokecolor = :black,
+elem_5 = PolyElement(polycolor = :green, polystrokecolor = :black,
         polypoints = Point2f0[(0, 0), (1, 0), (0, 1)])
-
 
 Legend(f[1, 2],
     [elem_1, elem_2, elem_3, elem_4, elem_5],

--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -12,6 +12,14 @@ You can create a basic Legend by passing a vector of legend entries and a vector
 The elements in the vector of legend entries can either be plot objects or LegendElements like LineElement, MarkerElement and PolyElement.
 Or they can be vectors of such objects that will be layered together as one.
 
+### Legend element attributes
+
+The standard plot objects like `Scatter` or `Lines` have predefined conversions to `MarkerElement`s and `LineElement`s that copy the relevant plot attributes to the legend element.
+If an attribute has a vector-like value, it falls back to the scalar default of the legend.
+The legend defaults themselves are by default inherited from the main theme.
+For example, `polystrokewidth` of the legend falls back to `patchstrokewidth` of the main theme.
+In the following example, you can see that the legend for `sca2` copies the `:rect` marker but not the vector-valued color.
+
 ```@example
 using CairoMakie
 
@@ -23,8 +31,11 @@ xs = 0:0.5:10
 ys = sin.(xs)
 lin = lines!(xs, ys, color = :blue)
 sca = scatter!(xs, ys, color = :red)
+sca2 = scatter!(xs, ys .+ 0.5, color = 1:length(xs), marker = :rect)
 
-Legend(f[1, 2], [lin, sca, [lin, sca]], ["a line", "some dots", "both together"])
+Legend(f[1, 2],
+    [lin, sca, [lin, sca], sca2],
+    ["a line", "some dots", "both together", "rect markers"])
 
 f
 ```
@@ -138,16 +149,23 @@ f
 
 Sometimes you might want to construct legend entries from scratch to have maximum
 control. So far you can use `LineElement`s, `MarkerElement`s or `PolyElement`s.
-Some attributes that can't have a meaningful preset and would usually be inherited
-from plot objects (like color) have to be explicitly specified. Others are
-inherited from the legend if they are not specified. These include marker
-arrangement for `MarkerElement`s or poly shape for `PolyElement`s. You can check
-the list using this function:
+The attributes for these elements are the following:
 
-```@example
-using Makie
-MakieLayout.attributenames(LegendEntry)
+```julia
+# LineElement
+linepoints, linecolor, linestyle, linewidth
+
+# MarkerElement
+markerpoints, marker, markersize, markercolor,
+markerstrokewidth, markerstrokecolor
+
+# PolyElement
+polypoints, polycolor, polystrokewidth, polystrokecolor
 ```
+
+The attributes `linepoints`, `markerpoints` and `polypoints` decide where in the legend entry patch rectangle the plot objects are placed.
+These values should be normalized to a 1 by 1 rectangle, and the final shape depends on the `patchsize` of the legend.
+For example, if you want wider line and poly markers, you could set the `patchsize` of the legend to `(50, 30)`.
 
 ```@example
 using CairoMakie

--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -232,10 +232,11 @@ for ms in markersizes, color in colors
     scatter!(randn(5, 2), markersize = ms, color = color)
 end
 
-group_size = [MarkerElement(marker = :circle, color = :black, strokecolor = :transparent,
+group_size = [MarkerElement(marker = :circle, markercolor = :black,
+    markerstrokecolor = :transparent,
     markersize = ms) for ms in markersizes]
 
-group_color = [PolyElement(color = color, strokecolor = :transparent)
+group_color = [PolyElement(polycolor = color, polystrokecolor = :transparent)
     for color in colors]
 
 legends = [Legend(f,

--- a/docs/src/makielayout/legend.md
+++ b/docs/src/makielayout/legend.md
@@ -160,7 +160,7 @@ elem_1 = [LineElement(linecolor = :red, linestyle = nothing),
           MarkerElement(markercolor = :blue, marker = 'x', markersize = 15,
           markerstrokecolor = :black)]
 
-elem_2 = [PolyElement(polycolor = :red, polystrokecolor = :blue),
+elem_2 = [PolyElement(polycolor = :red, polystrokecolor = :blue, polystrokewidth = 1),
           LineElement(linecolor = :black, linestyle = :dash)]
 
 elem_3 = LineElement(linecolor = :green, linestyle = nothing,
@@ -169,7 +169,7 @@ elem_3 = LineElement(linecolor = :green, linestyle = nothing,
 elem_4 = MarkerElement(markercolor = :blue, marker = 'π', markersize = 15,
         markerpoints = Point2f0[(0.2, 0.2), (0.5, 0.8), (0.8, 0.2)])
 
-elem_5 = PolyElement(polycolor = :green, polystrokecolor = :black,
+elem_5 = PolyElement(polycolor = :green, polystrokecolor = :black, polystrokewidth = 2,
         polypoints = Point2f0[(0, 0), (1, 0), (0, 1)])
 
 Legend(f[1, 2],

--- a/docs/src/plotting_functions/barplot.md
+++ b/docs/src/plotting_functions/barplot.md
@@ -91,7 +91,7 @@ let
 
     # Legend
     labels = ["group 1", "group 2", "group 3"]
-    elements = [PolyElement(color = colors[i], strokecolor = :transparent) for i in 1:length(labels)]
+    elements = [PolyElement(polycolor = colors[i], polystrokecolor = :transparent) for i in 1:length(labels)]
     title = "Groups"
 
     Legend(fig[1,2], elements, labels, title)

--- a/docs/src/plotting_functions/barplot.md
+++ b/docs/src/plotting_functions/barplot.md
@@ -76,26 +76,24 @@ barplot(tbl.x, tbl.height,
 ```
 
 ```@example bar
-let
-    colors = Makie.wong_colors()
+colors = Makie.wong_colors()
 
-    # Figure and Axis
-    fig = Figure()
-    ax = Axis(fig[1,1], xticks = (1:3, ["left", "middle", "right"]),
-              title = "Dodged bars with legend")
+# Figure and Axis
+fig = Figure()
+ax = Axis(fig[1,1], xticks = (1:3, ["left", "middle", "right"]),
+        title = "Dodged bars with legend")
 
-    # Plot
-    barplot!(ax, tbl.x, tbl.height,
-             dodge = tbl.grp,
-             color = colors[tbl.grp])
+# Plot
+barplot!(ax, tbl.x, tbl.height,
+        dodge = tbl.grp,
+        color = colors[tbl.grp])
 
-    # Legend
-    labels = ["group 1", "group 2", "group 3"]
-    elements = [PolyElement(polycolor = colors[i], polystrokecolor = :transparent) for i in 1:length(labels)]
-    title = "Groups"
+# Legend
+labels = ["group 1", "group 2", "group 3"]
+elements = [PolyElement(polycolor = colors[i]) for i in 1:length(labels)]
+title = "Groups"
 
-    Legend(fig[1,2], elements, labels, title)
+Legend(fig[1,2], elements, labels, title)
 
-    fig
-end
+fig
 ```

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -800,17 +800,31 @@ function default_attributes(::Type{Legend}, scene)
         "The default points used for LineElements in normalized coordinates relative to each label patch."
         linepoints = [Point2f0(0, 0.5), Point2f0(1, 0.5)]
         "The default line width used for LineElements."
-        linewidth = 3
+        linewidth = theme(scene, :linewidth)
+        "The default line color used for LineElements"
+        linecolor = theme(scene, :linecolor)
+        "The default line style used for LineElements"
+        linestyle = :solid
+        "The default marker color for MarkerElements"
+        markercolor = theme(scene, :markercolor)
+        "The default marker for MarkerElements"
+        marker = theme(scene, :marker)
         "The default marker points used for MarkerElements in normalized coordinates relative to each label patch."
         markerpoints = [Point2f0(0.5, 0.5)]
         "The default marker size used for MarkerElements."
-        markersize = 12
+        markersize = theme(scene, :markersize)
         "The default marker stroke width used for MarkerElements."
-        markerstrokewidth = 1
+        markerstrokewidth = theme(scene, :markerstrokewidth)
+        "The default marker stroke color used for MarkerElements."
+        markerstrokecolor = theme(scene, :markerstrokecolor)
         "The default poly points used for PolyElements in normalized coordinates relative to each label patch."
         polypoints = [Point2f0(0, 0), Point2f0(1, 0), Point2f0(1, 1), Point2f0(0, 1)]
         "The default poly stroke width used for PolyElements."
-        polystrokewidth = 1
+        polystrokewidth = theme(scene, :patchstrokewidth)
+        "The default poly color used for PolyElements."
+        polycolor = theme(scene, :patchcolor)
+        "The default poly stroke color used for PolyElements."
+        polystrokecolor = theme(scene, :patchstrokecolor)
         "The orientation of the legend (:horizontal or :vertical)."
         orientation = :vertical
         "The gap between each group title and its group."

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -854,8 +854,9 @@ Legend
 function attributenames(::Type{LegendEntry})
     (:label, :labelsize, :labelfont, :labelcolor, :labelhalign, :labelvalign,
         :patchsize, :patchstrokecolor, :patchstrokewidth, :patchcolor,
-        :linepoints, :markerpoints, :markersize, :markerstrokewidth, :linewidth,
-        :polypoints, :polystrokewidth)
+        :linepoints, :linewidth, :linecolor, :linestyle,
+        :markerpoints, :markersize, :markerstrokewidth, :markercolor, :markerstrokecolor, 
+        :polypoints, :polystrokewidth, :polycolor, :polystrokecolor)
 end
 
 function extractattributes(attributes::Attributes, typ::Type)

--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -314,8 +314,8 @@ function Base.propertynames(lentry::LegendEntry)
     [fieldnames(T)..., keys(lentry.attributes)...]
 end
 
-legendelements(le::LegendElement) = LegendElement[le]
-legendelements(les::AbstractArray{<:LegendElement}) = LegendElement[les...]
+legendelements(le::LegendElement, legend) = LegendElement[le]
+legendelements(les::AbstractArray{<:LegendElement}, legend) = LegendElement[les...]
 
 
 function LegendEntry(label::String, contentelements::AbstractArray, legend; kwargs...)
@@ -393,7 +393,7 @@ function legendelements(plot, legend)::Vector{LegendElement}
     if isempty(plot.plots)
         error("No child plot elements found in plot of type $(typeof(plot)) but also no `legendelements` method defined.")
     end
-    reduce(vcat, [legendelements(childplot) for childplot in plot.plots])
+    reduce(vcat, [legendelements(childplot, legend) for childplot in plot.plots])
 end
 
 function Base.getproperty(legendelement::T, s::Symbol) where T <: LegendElement

--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -263,10 +263,10 @@ function legendelement_plots!(scene, element::MarkerElement, bbox::Node{FRect2D}
 
     fracpoints = attrs.markerpoints
     points = @lift(fractionpoint.(Ref($bbox), $fracpoints))
-    scat = scatter!(scene, points, color = attrs.color, marker = attrs.marker,
+    scat = scatter!(scene, points, color = attrs.markercolor, marker = attrs.marker,
         markersize = attrs.markersize,
         strokewidth = attrs.markerstrokewidth,
-        strokecolor = attrs.strokecolor, raw = true, inspectable = false)
+        strokecolor = attrs.markerstrokecolor, raw = true, inspectable = false)
     [scat]
 end
 
@@ -276,7 +276,7 @@ function legendelement_plots!(scene, element::LineElement, bbox::Node{FRect2D}, 
 
     fracpoints = attrs.linepoints
     points = @lift(fractionpoint.(Ref($bbox), $fracpoints))
-    lin = lines!(scene, points, linewidth = attrs.linewidth, color = attrs.color,
+    lin = lines!(scene, points, linewidth = attrs.linewidth, color = attrs.linecolor,
         linestyle = attrs.linestyle,
         raw = true, inspectable = false)
     [lin]
@@ -288,8 +288,8 @@ function legendelement_plots!(scene, element::PolyElement, bbox::Node{FRect2D}, 
 
     fracpoints = attrs.polypoints
     points = @lift(fractionpoint.(Ref($bbox), $fracpoints))
-    pol = poly!(scene, points, strokewidth = attrs.polystrokewidth, color = attrs.color,
-        strokecolor = attrs.strokecolor,
+    pol = poly!(scene, points, strokewidth = attrs.polystrokewidth, color = attrs.polycolor,
+        strokecolor = attrs.polystrokecolor,
         raw = true, inspectable = false)
     [pol]
 end
@@ -318,7 +318,7 @@ legendelements(le::LegendElement) = LegendElement[le]
 legendelements(les::AbstractArray{<:LegendElement}) = LegendElement[les...]
 
 
-function LegendEntry(label::String, contentelements::AbstractArray; kwargs...)
+function LegendEntry(label::String, contentelements::AbstractArray, legend; kwargs...)
     attrs = Attributes(label = label)
 
     kwargattrs = Attributes(kwargs)
@@ -328,13 +328,13 @@ function LegendEntry(label::String, contentelements::AbstractArray; kwargs...)
     LegendEntry(elems, attrs)
 end
 
-function LegendEntry(label::String, contentelement; kwargs...)
+function LegendEntry(label::String, contentelement, legend; kwargs...)
     attrs = Attributes(label = label)
 
     kwargattrs = Attributes(kwargs)
     merge!(attrs, kwargattrs)
 
-    elems = legendelements(contentelement)
+    elems = legendelements(contentelement, legend)
     LegendEntry(elems, attrs)
 end
 
@@ -350,28 +350,46 @@ function PolyElement(;kwargs...)
     PolyElement(Attributes(kwargs))
 end
 
-function legendelements(plot::Union{Lines, LineSegments})
-    LegendElement[LineElement(color = plot.color, linestyle = plot.linestyle)]
+function scalar_lift(attr, default)
+    lift(Any, attr, default) do at, def
+        Makie.is_scalar_attribute(at) ? at : def
+    end
 end
 
-function legendelements(plot::Scatter)
+function legendelements(plot::Union{Lines, LineSegments}, legend)
+    LegendElement[LineElement(
+        linecolor = scalar_lift(plot.color, legend.linecolor),
+        linestyle = scalar_lift(plot.linestyle, legend.linestyle),
+        linewidth = scalar_lift(plot.linewidth, legend.linewidth))]
+end
+
+
+function legendelements(plot::Scatter, legend)
     LegendElement[MarkerElement(
-        color = plot.color, marker = plot.marker,
-        strokecolor = plot.strokecolor)]
+        markercolor = scalar_lift(plot.color, legend.markercolor),
+        marker = scalar_lift(plot.marker, legend.marker),
+        markersize = scalar_lift(plot.markersize, legend.markersize),
+        markerstrokewidth = scalar_lift(plot.strokewidth, legend.markerstrokewidth),
+        markerstrokecolor = scalar_lift(plot.strokecolor, legend.markerstrokecolor),
+    )]
 end
 
-function legendelements(plot::Union{Poly, Violin, BoxPlot, CrossBar})
-    LegendElement[PolyElement(color = plot.color, strokecolor = plot.strokecolor)]
+function legendelements(plot::Union{Poly, Violin, BoxPlot, CrossBar}, legend)
+    LegendElement[PolyElement(
+        polycolor = scalar_lift(plot.color, legend.polycolor),
+        polystrokecolor = scalar_lift(plot.strokecolor, legend.polystrokecolor),
+        polystrokewidth = scalar_lift(plot.strokewidth, legend.polystrokewidth),
+    )]
 end
 
-function legendelements(plot::Band)
+function legendelements(plot::Band, legend)
     # there seems to be no stroke for Band, so we set it invisible
-    LegendElement[PolyElement(color = plot.color, strokecolor = :transparent)]
+    LegendElement[PolyElement(polycolor = scalar_lift(plot.color, legend.polystrokecolor), polystrokecolor = :transparent, polystrokewidth = 0)]
 end
 
 # if there is no specific overload available, we go through the child plots and just stack
 # those together as a simple fallback
-function legendelements(plot)::Vector{LegendElement}
+function legendelements(plot, legend)::Vector{LegendElement}
     if isempty(plot.plots)
         error("No child plot elements found in plot of type $(typeof(plot)) but also no `legendelements` method defined.")
     end
@@ -423,9 +441,11 @@ function layoutable(::Type{Legend}, fig_or_scene,
         error("Number of elements not equal: $(length(contents)) content elements and $(length(labels)) labels.")
     end
 
-    entries = [LegendEntry(label, content) for (content, label) in zip(contents, labels)]
-    entrygroups = Node{Vector{EntryGroup}}([(title, entries)])
+    entrygroups = Node{Vector{EntryGroup}}([])
     legend = layoutable(Legend, fig_or_scene, entrygroups; kwargs...)
+    entries = [LegendEntry(label, content, legend) for (content, label) in zip(contents, labels)]
+    entrygroups[] = [(title, entries)]
+    legend
 end
 
 
@@ -456,11 +476,13 @@ function layoutable(::Type{Legend}, fig_or_scene,
         error("Number of elements not equal: $(length(titles)) titles, $(length(contentgroups)) content groups and $(length(labelgroups)) label groups.")
     end
 
-    entries = [[LegendEntry(l, pg) for (l, pg) in zip(labelgroup, contentgroup)]
-        for (labelgroup, contentgroup) in zip(labelgroups, contentgroups)]
-
-    entrygroups = Node{Vector{EntryGroup}}([(t, en) for (t, en) in zip(titles, entries)])
+    
+    entrygroups = Node{Vector{EntryGroup}}([])
     legend = layoutable(Legend, fig_or_scene, entrygroups; kwargs...)
+    entries = [[LegendEntry(l, pg, legend) for (l, pg) in zip(labelgroup, contentgroup)]
+        for (labelgroup, contentgroup) in zip(labelgroups, contentgroups)]
+    entrygroups[] = [(t, en) for (t, en) in zip(titles, entries)]
+    legend
 end
 
 

--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -324,7 +324,7 @@ function LegendEntry(label::String, contentelements::AbstractArray, legend; kwar
     kwargattrs = Attributes(kwargs)
     merge!(attrs, kwargattrs)
 
-    elems = vcat(legendelements.(contentelements)...)
+    elems = vcat(legendelements.(contentelements, Ref(legend))...)
     LegendEntry(elems, attrs)
 end
 


### PR DESCRIPTION
- add utility functions for scalar / vector attributes
- get all relevant legend marker attributes from plot objects, or theme
