### PR TITLE
make default marker themable

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -219,7 +219,7 @@ $(ATTRIBUTES)
         color = theme(scene, :markercolor),
         colormap = theme(scene, :colormap),
         colorrange = automatic,
-        marker = Circle,
+        marker = theme(scene, :marker),
         markersize = theme(scene, :markersize),
 
         strokecolor = theme(scene, :markerstrokecolor),


### PR DESCRIPTION
There is a global `marker` attibute in the default theme, but `scatter` ignores it. I think it makes sense to make this customizable. #957 also ports `boxplot` to use the default marker from the theme. 