### PR TITLE
docs: admonitions need blocks

### DIFF
--- a/docs/src/basic-tutorial.md
+++ b/docs/src/basic-tutorial.md
@@ -35,8 +35,8 @@ Makie has many different plotting functions, one of the most common ones is [lin
 You can just call such a function and your plot will appear if your coding environment can show png or svg files.
 
 !!! note
-Objects such as [Figure](@ref), `FigureAxisPlot` or `Scene` are usually displayed whenever they are returned in global scope (e.g. in the REPL).
-To display such objects from within a local scope, like from within a function, you can directly call `display(figure)`, for example.
+    Objects such as [Figure](@ref), `FigureAxisPlot` or `Scene` are usually displayed whenever they are returned in global scope (e.g. in the REPL).
+    To display such objects from within a local scope, like from within a function, you can directly call `display(figure)`, for example.
 
 ```@example 1
 x = range(0, 10, length=100)

--- a/docs/src/interaction/nodes.md
+++ b/docs/src/interaction/nodes.md
@@ -57,8 +57,8 @@ nothing # hide
 ```
 
 !!! note
-All registered functions in a `Node` are executed synchronously in the order of registration.
-This means that if you change two Nodes after one another, all effects of the first change will happen before the second change.
+    All registered functions in a `Node` are executed synchronously in the order of registration.
+    This means that if you change two Nodes after one another, all effects of the first change will happen before the second change.
 
 There are two ways to access the value of a `Node`.
 You can use the indexing syntax or the `to_value` function:

--- a/docs/src/makielayout/gridlayout.md
+++ b/docs/src/makielayout/gridlayout.md
@@ -113,7 +113,6 @@ scene
 ```
 
 !!! note
-
     Keep in mind that if you set too many constraints on row and column sizes, a GridLayout can easily be too big or too small. It's good to have variable-width elements to fill the remaining space if you use an element with fixed size or fixed aspect ratio.
 
 ## Nesting

--- a/docs/src/makielayout/layoutables.md
+++ b/docs/src/makielayout/layoutables.md
@@ -1,9 +1,9 @@
 # `Layoutables`
 
 !!! note
-All examples in this section are presented as static CairoMakie vector graphics for clarity of visuals.
-Keep in mind that CairoMakie is not interactive.
-Use GLMakie for interactive widgets, as WGLMakie currently doesn't have picking implemented.
+    All examples in this section are presented as static CairoMakie vector graphics for clarity of visuals.
+    Keep in mind that CairoMakie is not interactive.
+    Use GLMakie for interactive widgets, as WGLMakie currently doesn't have picking implemented.
 
 `Layoutables` are objects which can be added to a `Figure` or `Scene` and have their location and size controlled by a `GridLayout`. In of itself, a `Layoutable` is an abstract type.
 A `Figure` has its own internal `GridLayout` and therefore offers simplified syntax for adding layoutables to it.
@@ -11,9 +11,9 @@ If you want to work with a bare `Scene`, you can attach a `GridLayout` to its pi
 The `layoutscene` function is supplied for this purpose.
 
 !!! note
-A layout only controls an object's position or bounding box.
-A `Layoutable` can be controlled by the GridLayout of a Figure but not be added as a visual to the Figure.
-A `Layoutable` can also be added to a Scene without being inside any GridLayout, if you specify the bounding box yourself.
+    A layout only controls an object's position or bounding box.
+    A `Layoutable` can be controlled by the GridLayout of a Figure but not be added as a visual to the Figure.
+    A `Layoutable` can also be added to a Scene without being inside any GridLayout, if you specify the bounding box yourself.
 
 ## Adding to a `Figure`
 

--- a/docs/src/recipes.md
+++ b/docs/src/recipes.md
@@ -29,7 +29,7 @@ Makie.convert_arguments(x::Circle) = (decompose(Point2f, x),)
 ```
 
 !!! warning
-`convert_arguments` must always return a Tuple.
+    `convert_arguments` must always return a Tuple.
 
 You can restrict conversion to a subset of plot types, like only for scatter plots:
 


### PR DESCRIPTION
Right now in the docs there are several admonitions where the content appears below the block. This should fix this issue
![image](https://user-images.githubusercontent.com/4471859/119325746-7d10fb00-bc81-11eb-901c-b1284fe75830.png)

See e.g. https://raw.githubusercontent.com/JuliaDocs/Documenter.jl/5b34b6a65d1085f996400287ff65ff0782b53d82/docs/src/showcase.md