### PR TITLE
Add custom colorization to boxplot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
     branches:
       - master
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
     branches:
       - master
     tags: '*'

--- a/docs/src/plotting_functions/boxplot.md
+++ b/docs/src/plotting_functions/boxplot.md
@@ -26,5 +26,20 @@ xs = rand(1:3, 1000)
 ys = randn(1000)
 dodge = rand(1:2, 1000)
 
-boxplot(xs, ys, dodge = dodge, show_notch = true)
+boxplot(xs, ys, dodge = dodge, show_notch = true, color = dodge)
+```
+
+Colors are customizable, the `color` attribute refers to the color of the boxes, `outliercolor` refers to the color of the outliers. If not scalars (e.g. :red), these attributes
+must have the length of the data. If `outliercolor` is not provided, outliers will have the same color as their box, as shown above. The `color` of each data point in the same box must have the same color, use the `outliercolor` to customize the outliers.
+
+```@example
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+xs = rand(1:3, 1000)
+ys = randn(1000)
+dodge = rand(1:2, 1000)
+
+boxplot(xs, ys, dodge = dodge, show_notch = true, color = map(d->d==1 ? :blue : :red, dodge) , outliercolor = rand([:red, :green, :blue, :black, :yellow], 1000))
 ```

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -114,12 +114,12 @@ function Makie.plot!(plot::BoxPlot)
             if Float64(range) != 0.0  # if the range is 0.0, the whiskers will extend to the data
                 limit = range * (q4 - q2)
                 inside = Float64[]
-                for value in values
+                for (value, idx) in zip(values,idxs)
                     if (value < (q2 - limit)) || (value > (q4 + limit))
                         if show_outliers
                             push!(outlier_points, (center, value))
                             # register outlier box indices
-                            push!(outlier_indices, i)
+                            push!(outlier_indices, idx)
                         end
                     else
                         push!(inside, value)
@@ -184,7 +184,7 @@ function Makie.plot!(plot::BoxPlot)
             color isa AbstractVector || return color
             return [color[i] for i in outlier_indices]
         elseif outliercolor isa AbstractVector
-            return [outliercolor[i] for i in outlier_indices]
+            return outliercolor[outlier_indices]
         else
             return outliercolor
         end

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -75,7 +75,6 @@ _flip_xy(r::Rect{2,T}) where {T} = Rect{2,T}(reverse(r.origin), reverse(r.widths
 
 function Makie.plot!(plot::BoxPlot)
     args = @extract plot (width, range, show_outliers, whiskerwidth, show_notch, orientation, x_gap, dodge, n_dodge, dodge_gap)
-
     signals = lift(
         plot[1],
         plot[2],
@@ -138,7 +137,7 @@ function Makie.plot!(plot::BoxPlot)
             push!(medians, q3)
             push!(boxmax, q4)
         end
-
+        
         # for horizontal boxplots just flip all components
         if orientation == :horizontal
             outlier_points = _flip_xy.(outlier_points)
@@ -171,7 +170,7 @@ function Makie.plot!(plot::BoxPlot)
 
     outliercolor = lift(plot[:outliercolor], plot[:color], centers, outliers, orientation) do outliercolor, color, centers, outliers, orientation
         if outliercolor === automatic
-            color isa Symbol && return color
+            color isa AbstractVector || return color
             center_colors = Dict{eltype(centers), eltype(color)}()
             for (col, center) in zip(color, centers)
                 center_colors[center] = col

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -95,7 +95,7 @@ function Makie.plot!(plot::BoxPlot)
         notchmax = Float32[]
         t_segments = Point2f0[]
         outlier_indices = Int[]
-        boxcolor = []
+        boxcolor = eltype(plot[:color].val)[]
         for (i, (center, idxs)) in enumerate(StructArrays.finduniquesorted(x̂))
             values = view(y, idxs)
 
@@ -118,6 +118,8 @@ function Makie.plot!(plot::BoxPlot)
                     if (value < (q2 - limit)) || (value > (q4 + limit))
                         if show_outliers
                             push!(outlier_points, (center, value))
+                            # register outlier box indices
+                            push!(outlier_indices, i)
                         end
                     else
                         push!(inside, value)
@@ -126,10 +128,8 @@ function Makie.plot!(plot::BoxPlot)
                 # change q1 and q5 to show outliers
                 # using maximum and minimum values inside the limits
                 q1, q5 = extrema_nan(inside)
-                # register outlier box indices
-                append!(outlier_indices, fill(i, length(outlier_points)))
                 # register boxcolor
-                push!(boxcolor, getuniquevalue(plot[:color], idxs))
+                push!(boxcolor, getuniquevalue(plot[:color].val, idxs))
             end
 
             # whiskers

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -131,7 +131,7 @@ function Makie.plot!(plot::BoxPlot)
                 # using maximum and minimum values inside the limits
                 q1, q5 = extrema_nan(inside)
                 # register boxcolor
-                push!(boxcolor, getuniquevalue(plot[:color].val, idxs))
+                push!(boxcolor, getuniquevalue(color, idxs))
             end
 
             # whiskers

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -95,6 +95,7 @@ function Makie.plot!(plot::BoxPlot)
         notchmax = Float32[]
         t_segments = Point2f0[]
         outlier_indices = Int[]
+        boxcolor = []
         for (i, (center, idxs)) in enumerate(StructArrays.finduniquesorted(x̂))
             values = view(y, idxs)
 
@@ -127,6 +128,8 @@ function Makie.plot!(plot::BoxPlot)
                 q1, q5 = extrema_nan(inside)
                 # register outlier box indices
                 append!(outlier_indices, fill(i, length(outlier_points)))
+                # register boxcolor
+                push!(boxcolor, getuniquevalue(plot[:color], idxs))
             end
 
             # whiskers
@@ -161,6 +164,7 @@ function Makie.plot!(plot::BoxPlot)
             t_segments = t_segments,
             boxwidth = boxwidth,
             outlier_indices = outlier_indices,
+            boxcolor = boxcolor,
         )
     end
     centers = @lift($signals.centers)
@@ -173,6 +177,7 @@ function Makie.plot!(plot::BoxPlot)
     t_segments = @lift($signals.t_segments)
     boxwidth = @lift($signals.boxwidth)
     outlier_indices = @lift($signals.outlier_indices)
+    boxcolor = @lift($signals.boxcolor)
 
     outliercolor = lift(plot[:outliercolor], plot[:color], outlier_indices) do outliercolor, color, outlier_indices
         if outliercolor === automatic
@@ -183,7 +188,7 @@ function Makie.plot!(plot::BoxPlot)
         else
             return outliercolor
         end
-    end   
+    end
 
     scatter!(
         plot,
@@ -204,7 +209,7 @@ function Makie.plot!(plot::BoxPlot)
     )
     crossbar!(
         plot,
-        color = plot[:color],
+        color = boxcolor,
         colorrange = plot[:colorrange],
         colormap = plot[:colormap],
         strokecolor = plot[:strokecolor],

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -96,7 +96,8 @@ function Makie.plot!(plot::BoxPlot)
         notchmax = Float32[]
         t_segments = Point2f0[]
         outlier_indices = Int[]
-        boxcolor = eltype(color)[]
+        T = color isa AbstractVector ? eltype(color) : typeof(color)
+        boxcolor = T[]
         for (i, (center, idxs)) in enumerate(StructArrays.finduniquesorted(x̂))
             values = view(y, idxs)
 

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -75,6 +75,7 @@ _flip_xy(r::Rect{2,T}) where {T} = Rect{2,T}(reverse(r.origin), reverse(r.widths
 
 function Makie.plot!(plot::BoxPlot)
     args = @extract plot (width, range, show_outliers, whiskerwidth, show_notch, orientation, x_gap, dodge, n_dodge, dodge_gap)
+
     signals = lift(
         plot[1],
         plot[2],
@@ -137,7 +138,7 @@ function Makie.plot!(plot::BoxPlot)
             push!(medians, q3)
             push!(boxmax, q4)
         end
-        
+
         # for horizontal boxplots just flip all components
         if orientation == :horizontal
             outlier_points = _flip_xy.(outlier_points)


### PR DESCRIPTION
Hello, 

I have noticed a missing feature in Makies boxplots which is that you cannot make boxplots with different colors, which is a very common use of boxplots to show multiple experiments separated by a dodge. After looking into the code, I understood that this is because the way it handles the color of the outliers. Specifically, the length of the `color` attribute had to match the number of boxes (if not a scalar) but the `outliercolor` attribute was passed to `scatter!`, which means that its length has to match the number of outliers. Currently, when the outliercolor attribute is left to automatic, specifying boxes colors fails:

```
Julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1;2])
ERROR: MethodError: no method matching red(::Vector{Int64})
Closest candidates are:
  red(::ColorTypes.RGB24) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:16
  red(::ColorTypes.AbstractRGB) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:14
  red(::ColorTypes.ARGB32) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:17
  ...
Stacktrace:
 [1] (::Makie.var"#797#808")(outliercolor::Makie.Automatic, color::Vector{Int64})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\stats\boxplot.jl:175
 [2] lift(f::Function, o1::Observable{Any}, rest::Observable{Any}; kw::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interaction\nodes.jl:13
 [3] lift(f::Function, o1::Observable{Any}, rest::Observable{Any})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interaction\nodes.jl:10
 [4] plot!(plot::BoxPlot{Tuple{Vector{Int64}, Vector{Float64}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\stats\boxplot.jl:172
 [5] plot!(scene::Scene, P::Type{BoxPlot{Tuple{Vector{Int64}, Vector{Float64}}}}, attributes::Attributes, input::Tuple{Observable{Vector{Int64}}, Observable{Vector{Float64}}}, args::Observable{Tuple{Vector{Int64}, Vector{Float64}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interfaces.jl:787
 [6] plot!(::Scene, ::Type{BoxPlot{ArgType} where ArgType}, ::Attributes, ::Vector{Int64}, ::Vararg{Any, N} where N; kw_attributes::Base.Iterators.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:show_axis,), Tuple{Bool}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interfaces.jl:698
 [7] plot(::Type{BoxPlot{ArgType} where ArgType}, ::Vector{Int64}, ::Vararg{Any, N} where N; axis::NamedTuple{(), Tuple{}}, figure::NamedTuple{(), Tuple{}}, kw_attributes::Base.Iterators.Pairs{Symbol, Vector{Int64}, Tuple{Symbol, Symbol}, NamedTuple{(:dodge, :color), Tuple{Vector{Int64}, Vector{Int64}}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\figureplotting.jl:28
 [8] boxplot(::Vector{Int64}, ::Vararg{Any, N} where N; attributes::Base.Iterators.Pairs{Symbol, Vector{Int64}, Tuple{Symbol, Symbol}, NamedTuple{(:dodge, :color), Tuple{Vector{Int64}, Vector{Int64}}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\recipes.jl:15
 [9] top-level scope
   @ REPL[6]:1
```
Or with symbol colors:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [:red, :blue, :red, :blue, :red, :blue])
ERROR: MethodError: no method matching red(::Vector{ColorTypes.RGBA{Float32}})
Closest candidates are:
  red(::ColorTypes.RGB24) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:16
  red(::ColorTypes.AbstractRGB) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:14
  red(::ColorTypes.ARGB32) at C:\Users\Henri\.julia\packages\ColorTypes\7OlxI\src\traits.jl:17
  ...
Stacktrace:
 [1] (::Makie.var"#797#808")(outliercolor::Makie.Automatic, color::Vector{Symbol})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\stats\boxplot.jl:175
 [2] lift(f::Function, o1::Observable{Any}, rest::Observable{Any}; kw::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interaction\nodes.jl:13
 [3] lift(f::Function, o1::Observable{Any}, rest::Observable{Any})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interaction\nodes.jl:10
 [4] plot!(plot::BoxPlot{Tuple{Vector{Int64}, Vector{Float64}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\stats\boxplot.jl:172
 [5] plot!(scene::Scene, P::Type{BoxPlot{Tuple{Vector{Int64}, Vector{Float64}}}}, attributes::Attributes, input::Tuple{Observable{Vector{Int64}}, Observable{Vector{Float64}}}, args::Observable{Tuple{Vector{Int64}, Vector{Float64}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interfaces.jl:787
 [6] plot!(::Scene, ::Type{BoxPlot{ArgType} where ArgType}, ::Attributes, ::Vector{Int64}, ::Vararg{Any, N} where N; kw_attributes::Base.Iterators.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:show_axis,), Tuple{Bool}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\interfaces.jl:698
 [7] plot(::Type{BoxPlot{ArgType} where ArgType}, ::Vector{Int64}, ::Vararg{Any, N} where N; axis::NamedTuple{(), Tuple{}}, figure::NamedTuple{(), Tuple{}}, kw_attributes::Base.Iterators.Pairs{Symbol, Vector{T} where T, Tuple{Symbol, Symbol}, NamedTuple{(:dodge, :color), Tuple{Vector{Int64}, Vector{Symbol}}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\figureplotting.jl:28
 [8] boxplot(::Vector{Int64}, ::Vararg{Any, N} where N; attributes::Base.Iterators.Pairs{Symbol, Vector{T} where T, Tuple{Symbol, Symbol}, NamedTuple{(:dodge, :color), Tuple{Vector{Int64}, Vector{Symbol}}}})
   @ Makie ~\OneDrive - UCL\Doctorat\Makie.jl\src\recipes.jl:15
 [9] top-level scope
   @ REPL[8]:1
```
That is because a scalar `color` is assumed when determining the `outliercolor` automatically. A partial workaround was thus to pass a custom value:
```
Julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1;2], outliercolor = :red)
```
![image](https://user-images.githubusercontent.com/47037088/121213094-3d9bfe80-c87e-11eb-9392-1523c98c703b.png)

But maybe we want the outlier colors to match that of the boxes. It is currently impossible to do this.

This PR fixes this. Now the automatic behavior is to color the outliers w.r.t. their boxes:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1:2])
```
![image](https://user-images.githubusercontent.com/47037088/121213181-4db3de00-c87e-11eb-9b55-30c79aa5f985.png)

This works also horizontally:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1:2], orientation = :horizontal)
```
![image](https://user-images.githubusercontent.com/47037088/121213208-53a9bf00-c87e-11eb-9070-a6eb0c6c3d72.png)

One can still pass a custom scalar color for the boxes:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = :red)
```
makes 6 red boxplots with red outliers

Or a mapping for the boxes and a scalar for the outliers:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1:2], outliercolor = :red)
```
makes 6 purple and yellow boxes with red outliers

Or a custom mapping for the outliers, different from the boxes:
```
julia> boxplot(rand(1:3, 1000), randn(1000), dodge = repeat([1,2], inner = 500), color = [1:2;1:2;1:2], outliercolor = 1:6)
```
![image](https://user-images.githubusercontent.com/47037088/121213377-73d97e00-c87e-11eb-8f25-e68600089148.png)

If these changes are accepted, I will also make some changes to the documentation to explain how this works.
I'm also open to adding some other features if you think this is incomplete.

Best
 



