### PR TITLE
port @ndinsmore osx retina fix

### DIFF
--- a/.github/workflows/cairomakie.yaml
+++ b/.github/workflows/cairomakie.yaml
@@ -1,15 +1,15 @@
-name: CairoMakie CI
+name: CairoMakie
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - CairoMakie/**
+      - src/**
     branches:
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - CairoMakie/**
+      - src/**
     branches:
       - master
     tags: '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,15 @@
 name: Makie CI
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - MakieCore/**
+      - src/**
     branches:
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - MakieCore/**
+      - src/**
     branches:
       - master
     tags: '*'

--- a/.github/workflows/glmakie.yaml
+++ b/.github/workflows/glmakie.yaml
@@ -1,15 +1,15 @@
-name: GLMakie CI
+name: GLMakie
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - GLMakie/**
+      - src/**
     branches:
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - GLMakie/**
+      - src/**
     branches:
       - master
     tags: '*'

--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -1,15 +1,15 @@
-name: WGLMakie CI
+name: WGLMakie
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - WGLMakie/**
+      - src/**
     branches:
       - master
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
+    paths:
+      - WGLMakie/**
+      - src/**
     branches:
       - master
     tags: '*'

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -56,7 +56,8 @@ function renderloop(screen; framerate=WINDOW_CONFIG.framerate[])
     end
 end
 
-const WINDOW_CONFIG = (renderloop = Ref{Function}(renderloop),
+const WINDOW_CONFIG = (
+    renderloop = Ref{Function}(renderloop),
     vsync = Ref(false),
     framerate = Ref(30.0),
     float = Ref(false),
@@ -64,7 +65,9 @@ const WINDOW_CONFIG = (renderloop = Ref{Function}(renderloop),
     focus_on_show = Ref(false),
     decorated = Ref(true),
     title = Ref("Makie"),
-    exit_renderloop = Ref(false),)
+    exit_renderloop = Ref(false),
+    osx_retina_scaling = Ref(false)
+)
 
 """
     set_window_config!(;
@@ -75,14 +78,21 @@ const WINDOW_CONFIG = (renderloop = Ref{Function}(renderloop),
         pause_rendering = false,
         focus_on_show = false,
         decorated = true,
-        title = "Makie"
+        title = "Makie",
+        # Disables OSX doubling the amount of pixels on high dpi screens
+        # and preserves the mapping 1 makie px -> 1 screen px
+        osx_retina_scaling = false
     )
 Updates the screen configuration, will only go into effect after closing the current
 window and opening a new one!
 """
 function set_window_config!(; kw...)
     for (key, value) in kw
-        getfield(WINDOW_CONFIG, key)[] = value
+        if hasproperty(WINDOW_CONFIG, key)
+            getfield(WINDOW_CONFIG, key)[] = value
+        else
+            error("$key is not a valid window config. Call ?set_window_config!, to see applicable options")
+        end
     end
 end
 

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -304,8 +304,9 @@ function Screen(;
         end
         empty!(gl_screens)
     end
-    # Somehow this constant isn't wrapped by glfw
+    # Somehow these constants aren't wrapped by glfw
     GLFW_FOCUS_ON_SHOW = 0x0002000C
+    GLFW_COCOA_RETINA_FRAMEBUFFER = 0x00023001
     windowhints = [
         (GLFW.SAMPLES,      0),
         (GLFW.DEPTH_BITS,   0),
@@ -319,9 +320,10 @@ function Screen(;
 
         (GLFW.STENCIL_BITS, 0),
         (GLFW.AUX_BUFFERS,  0),
-        (GLFW_FOCUS_ON_SHOW, WINDOW_CONFIG.focus_on_show[]),
         (GLFW.DECORATED, WINDOW_CONFIG.decorated[]),
         (GLFW.FLOATING, WINDOW_CONFIG.float[]),
+        (GLFW_FOCUS_ON_SHOW, WINDOW_CONFIG.focus_on_show[]),
+        (GLFW_COCOA_RETINA_FRAMEBUFFER, WINDOW_CONFIG.osx_retina_scaling[]),
     ]
 
     window = try


### PR DESCRIPTION
This tries to port the fix from https://github.com/JuliaPlots/GLMakie.jl/pull/145 without any breaking changes.
Note, that retina rescaling needs to apply on all platforms (Windows/Linux as well), so that part of the pipeline should stay.
It's implementation should be refactored at some point though ;) 
I don't have a mac, so can @jkrumbiegel or @ndinsmore test this and make sure disabling it per default is ok?
I made it configurable, so the default could also be `enabled`.