### PR TITLE
Remove implicit keyword syntax in `range`

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -443,7 +443,7 @@ function regularly_spaced_array_to_range(arr)
             m, M = M, m
         end
         # don't use stop=M, since that may not include M
-        return range(m; step, length=length(arr))
+        return range(m; step=step, length=length(arr))
     else
         return arr
     end


### PR DESCRIPTION
Solves #1102
(Caught this bug in https://github.com/theogf/Turkie.jl/pull/32/checks?check_run_id=3029084908)

EDIT: The implicit keyword syntax is from 1.5 : https://julialang.org/blog/2020/08/julia-1.5-highlights/#implicit_keyword_argument_values
EDIT:EDIT: I see CairoMakie is only tested from 1.5 actually :sweat_smile: 