### PR TITLE
Test: skip downloading ref imgs tar if env var REUSE_IMAGES_TAR is set to 1

### DIFF
--- a/ReferenceTests/src/ReferenceTests.jl
+++ b/ReferenceTests/src/ReferenceTests.jl
@@ -16,6 +16,7 @@ using Downloads
 using Pkg.TOML
 using Statistics
 using ImageShow
+using Downloads: download
 
 basedir(files...) = normpath(joinpath(@__DIR__, "..", files...))
 loadasset(files...) = FileIO.load(assetpath(files...))

--- a/ReferenceTests/src/image_download.jl
+++ b/ReferenceTests/src/image_download.jl
@@ -24,9 +24,15 @@ function download_refimages(tag=last_major_version(); name="refimages")
     url = "https://github.com/JuliaPlots/Makie.jl/releases/download/$(tag)/$(name).tar"
     images_tar = basedir("$(name).tar")
     images = basedir(name)
-    isfile(images_tar) && rm(images_tar)
+    if isfile(images_tar)
+        if Bool(parse(Int, get(ENV, "REUSE_IMAGES_TAR", "0")))
+            @info "$images_tar already exists, skipping download as requested"
+        else
+            rm(images_tar)
+        end
+    end
+    !isfile(images_tar) && download(url, images_tar)
     isdir(images) && rm(images, recursive=true, force=true)
-    Base.download(url, images_tar)
     Tar.extract(images_tar, images)
     return images
 end


### PR DESCRIPTION
a.k.a. "spare my bandwidth"

(and `Base.download` replaced (deprecated))