### PR TITLE
Fix orthographic translations and zoom

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -239,7 +239,7 @@ function add_translation!(scene, cam::Camera3D)
     last_mousepos = RefValue(Vec2f0(0, 0))
     dragging = RefValue(false)
 
-    compute_diff(delta) = begin
+    function compute_diff(delta)
         if cam.attributes[:projectiontype][] == Orthographic
             aspect = Float32((/)(widths(scene.px_area[])...))
             aspect_scale = Vec2f0(1f0 + aspect, 1f0 + 1f0 / aspect)

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -290,7 +290,6 @@ function add_translation!(scene, cam::Camera3D)
 
     on(camera(scene), scene.events.scroll) do scroll
         if is_mouseinside(scene) && ispressed(scene, mod[])
-            cam_res = Vec2f0(widths(scene.px_area[]))
             zoom_step = (1f0 + 0.1f0 * zoomspeed[]) ^ -scroll[2]
             zoom!(scene, cam, zoom_step, shift_lookat[], cad[])
             update_cam!(scene, cam)
@@ -570,7 +569,6 @@ function update_cam!(scene::Scene, camera::Camera3D, area3d::Rect)
     bb = FRect3D(area3d)
     width = widths(bb)
     half_width = width/2f0
-    lower_corner = minimum(bb)
     middle = maximum(bb) - half_width
     old_dir = normalize(eyeposition .- lookat)
     camera.lookat[] = middle

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -583,7 +583,11 @@ function update_cam!(scene::Scene, camera::Camera3D, area3d::Rect)
     if camera.attributes[:far][] === automatic
         camera.far[]  = 3f0 * norm(widths(bb))
     end
-    camera.zoom_mult[] = 1f0
+    if camera.attributes[:projectiontype][] == Orthographic
+        camera.zoom_mult[] = 0.6 * norm(width)
+    else 
+        camera.zoom_mult[] = 1f0
+    end
     update_cam!(scene, camera)
     return
 end

--- a/src/camera/old_camera3d.jl
+++ b/src/camera/old_camera3d.jl
@@ -337,7 +337,6 @@ function update_cam!(scene::Scene, camera::OldCamera3D, area3d::Rect)
     bb = FRect3D(area3d)
     width = widths(bb)
     half_width = width/2f0
-    lower_corner = minimum(bb)
     middle = maximum(bb) - half_width
     old_dir = normalize(eyeposition .- lookat)
     camera.lookat[] = middle

--- a/test/events.jl
+++ b/test/events.jl
@@ -112,21 +112,21 @@ end
         # 1) In scene, in drag
         e.mousebutton[] = MouseButtonEvent(Mouse.right, Mouse.press)
         e.mouseposition[] = (600, 250)
-        @test cc.lookat[]       ≈ Vec3f0(4.409082, -4.409082, -2.598076)
-        @test cc.eyeposition[]  ≈ Vec3f0(7.409082, -1.4090819, 0.4019239)
+        @test cc.lookat[]       ≈ Vec3f0(5.4697413, -3.3484206, -2.1213205)
+        @test cc.eyeposition[]  ≈ Vec3f0(8.469742, -0.34842062, 0.8786795)
         @test cc.upvector[]     ≈ Vec3f0(0.0, 0.0, 1.0)
 
         # 2) Outside scene, in drag
         e.mouseposition[] = (1000, 450)
-        @test cc.lookat[]       ≈ Vec3f0(7.3484697, -7.3484697, -4.676537)
-        @test cc.eyeposition[]  ≈ Vec3f0(10.34847, -4.3484697, -1.676537)
+        @test cc.lookat[]       ≈ Vec3f0(9.257657, -5.4392805, -3.818377)
+        @test cc.eyeposition[]  ≈ Vec3f0(12.257658, -2.4392805, -0.81837714)
         @test cc.upvector[]     ≈ Vec3f0(0.0, 0.0, 1.0)
 
         # 3) not in drag
         e.mousebutton[] = MouseButtonEvent(Mouse.right, Mouse.release)
         e.mouseposition[] = (400, 250)
-        @test cc.lookat[]       ≈ Vec3f0(7.3484697, -7.3484697, -4.676537)
-        @test cc.eyeposition[]  ≈ Vec3f0(10.34847, -4.3484697, -1.676537)
+        @test cc.lookat[]       ≈ Vec3f0(9.257657, -5.4392805, -3.818377)
+        @test cc.eyeposition[]  ≈ Vec3f0(12.257658, -2.4392805, -0.81837714)
         @test cc.upvector[]     ≈ Vec3f0(0.0, 0.0, 1.0)
 
 


### PR DESCRIPTION
This should make `Camera3D(scene, projectiontype=Orthographic)` pixel perfect in terms of translations. Also fixes the initial zoom level.

Fix https://github.com/JuliaPlots/Makie.jl/issues/1142.