### PR TITLE
add multiargument method to annotations

### DIFF
--- a/src/basic_recipes/annotations.jl
+++ b/src/basic_recipes/annotations.jl
@@ -11,6 +11,25 @@ $(ATTRIBUTES)
 end
 
 function convert_arguments(::Type{<: Annotations},
+                           xs::AbstractVector{<: Number},
+                           ys::AbstractVector{<: Number},
+                           strings::AbstractVector{<: AbstractString})
+    return (map(strings, xs, ys) do str, x, y
+        (String(str), Point{2, Float32}(x, y))
+    end,)
+end
+
+function convert_arguments(::Type{<: Annotations},
+                           xs::AbstractVector{<: Number},
+                           ys::AbstractVector{<: Number},
+                           zs::AbstractVector{<: Number},
+                           strings::AbstractVector{<: AbstractString})
+    return (map(strings, xs, ys, zs) do str, x, y, z
+        (String(str), Point{3, Float32}(x, y, z))
+    end,)
+end
+
+function convert_arguments(::Type{<: Annotations},
                            strings::AbstractVector{<: AbstractString},
                            text_positions::AbstractVector{<: Point{N}}) where N
     return (map(strings, text_positions) do str, pos


### PR DESCRIPTION
This way, users can do

```julia
annotations(rand(10), rand(10), rand(["a", "b"], 10))
```

which IMO is a bit simpler and plays a bit nicer with AoG (even though the previous method is now [supported](http://juliaplots.org/AlgebraOfGraphics.jl/dev/generated/gallery/#Pre-scaled-data)).

I confess I could not find the `annotations` doc page to add some example with this syntax, so I'm not too sure how to document it.