### PR TITLE
smarter defaults for tellheight and tellwidth

### DIFF
--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -742,9 +742,9 @@ function default_attributes(::Type{Legend}, scene)
         "The height setting of the legend."
         height = Auto()
         "Controls if the parent layout can adjust to this element's width"
-        tellwidth = true
+        tellwidth = automatic
         "Controls if the parent layout can adjust to this element's height"
-        tellheight = false
+        tellheight = automatic
         "The font family of the legend group titles."
         titlefont = lift_parent_attribute(scene, :font, "DejaVu Sans")
         "The font size of the legend group titles."

--- a/src/makielayout/layoutables/colorbar.jl
+++ b/src/makielayout/layoutables/colorbar.jl
@@ -58,7 +58,6 @@ end
 
 function layoutable(::Type{<:Colorbar}, fig_or_scene; bbox = nothing, kwargs...)
     topscene = get_topscene(fig_or_scene)
-    attrs = merge!(Attributes(kwargs), default_attributes(Colorbar, topscene).attributes)
 
     default_attrs = default_attributes(Colorbar, topscene).attributes
     theme_attrs = subtheme(topscene, :Colorbar)

--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -6,8 +6,14 @@ function layoutable(::Type{Legend},
     topscene = get_topscene(fig_or_scene)
 
     default_attrs = default_attributes(Legend, topscene).attributes
+    attrs = Attributes(kwargs)
+    orientation = get(attrs, :orientation, nothing)
+    if !isnothing(orientation)
+        default_attrs[:tellheight] = lift(==(:horizontal), orientation)
+        default_attrs[:tellwidth] = lift(==(:vertical), orientation)
+    end
     theme_attrs = subtheme(topscene, :Legend)
-    attrs = merge!(merge!(Attributes(kwargs), theme_attrs), default_attrs)
+    merge!(merge!(attrs, theme_attrs), default_attrs)
 
     @extract attrs (
         halign, valign, padding, margin,

--- a/src/makielayout/layoutables/legend.jl
+++ b/src/makielayout/layoutables/legend.jl
@@ -6,14 +6,8 @@ function layoutable(::Type{Legend},
     topscene = get_topscene(fig_or_scene)
 
     default_attrs = default_attributes(Legend, topscene).attributes
-    attrs = Attributes(kwargs)
-    orientation = get(attrs, :orientation, nothing)
-    if !isnothing(orientation)
-        default_attrs[:tellheight] = lift(==(:horizontal), orientation)
-        default_attrs[:tellwidth] = lift(==(:vertical), orientation)
-    end
     theme_attrs = subtheme(topscene, :Legend)
-    merge!(merge!(attrs, theme_attrs), default_attrs)
+    attrs = merge!(merge!(Attributes(kwargs), theme_attrs), default_attrs)
 
     @extract attrs (
         halign, valign, padding, margin,
@@ -24,14 +18,19 @@ function layoutable(::Type{Legend},
         nbanks,
         colgap, rowgap, patchlabelgap,
         titlegap, groupgap,
-        orientation,
+        orientation, tellwidth, tellheight,
         titleposition,
         gridshalign, gridsvalign,
     )
 
     decorations = Dict{Symbol, Any}()
 
-    layoutobservables = LayoutObservables{Legend}(attrs.width, attrs.height, attrs.tellwidth, attrs.tellheight,
+    # by default, `tellwidth = true` and `tellheight = false` for vertical legends
+    # and vice versa for horizontal legends
+    real_tellwidth = @lift $tellwidth === automatic ? $orientation == :vertical : $tellwidth
+    real_tellheight = @lift $tellheight === automatic ? $orientation == :horizontal : $tellheight
+
+    layoutobservables = LayoutObservables{Legend}(attrs.width, attrs.height, real_tellwidth, real_tellheight,
         halign, valign, attrs.alignmode; suggestedbbox = bbox)
 
     scenearea = lift(round_to_IRect2D, layoutobservables.computedbbox)


### PR DESCRIPTION
This updates the defaults for `tellheight` and `tellwidth` if the orientation of the legend is horizontal. In the current implementation, if the user does not set `tellheight` and `tellwidth`, they update with the legend orientation. If we don't like that, we can set them just the first time using `to_value`.

I was thinking `Colorbar` also needed this, but it actually already "tells" both dimensions by default, so flipping that doesn't make a difference.