### PR TITLE
add logical expressions for `ispressed`

### DIFF
--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -195,7 +195,7 @@ export pixelarea, plots, cameracontrols, cameracontrols!, camera, events
 export to_world
 
 # picking + interactive use cases + events
-export mouseover, ispressed, onpick, pick, Events, Keyboard, Mouse, mouse_selection
+export mouseover, ispressed, onpick, pick, Events, Keyboard, Mouse, mouse_selection, @logical
 export register_callbacks
 export window_area
 export window_open

--- a/src/interaction/events.jl
+++ b/src/interaction/events.jl
@@ -89,7 +89,7 @@ ispressed(scene, result::Bool) = result
 
 ispressed(scene, op::And) = ispressed(scene, op.l) && ispressed(scene, op.r)
 ispressed(scene, op::Or)  = ispressed(scene, op.l) || ispressed(scene, op.r)
-ispressed(scene, op::Not) = !ispressed(scene, op.l)
+ispressed(scene, op::Not) = !ispressed(scene, op.x)
 
 ispressed(scene, set::Set) = all(x -> ispressed(scene, x), set)
 ispressed(scene, set::Vector) = all(x -> ispressed(scene, x), set)


### PR DESCRIPTION
Adds the possibility to pass logical expressions to `ispressed`, for example

```julia
scene = Scene()

trigger = Node(nothing)
on(x -> trigger[] = nothing, events(scene).keyboardbutton)
on(x -> trigger[] = nothing, events(scene).mousebutton)

hotkey = Node(Makie.@logical Keyboard.left_shift && !Keyboard.left_control && Mouse.left)
on(trigger) do _
    println(ispressed(scene, hotkey[]))
end
scene
```

where `hotkey` lowers to `And(Keyboard.left_shift, And(Not(Keyboard.left_control), Mouse.left))`. So you could set up key combinations (a && b), alternative hotkeys (a || b) and everything in between. Performance is the same if not a bit better (BenchmarkTools is given me less frequent and lower max times for the case above).

With these changes things like
https://github.com/JuliaPlots/Makie.jl/blob/194e767e207b8b67796412b1fe40fd7fd18f54c6/src/camera/camera3d.jl#L275
could be simplified to `if dragging[] && ispressed(scene, button[])`.

I also added a `ispressed(scene, ::Bool)` so you can have a hotkey be always active (true) or always inactive (false). This would add a way to disable an interaction that relies on `ispressed`.