### PR TITLE
workaround for 1 elem hists

### DIFF
--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -85,8 +85,8 @@ function Makie.plot!(plot::Hist)
             return bins
         end
     end
-    points = lift(edges, plot.normalization, plot.scale_to) do edges, normalization, scale_to
 
+    points = lift(edges, plot.normalization, plot.scale_to) do edges, normalization, scale_to
         h = StatsBase.fit(StatsBase.Histogram, values[], edges)
         h_norm = StatsBase.normalize(h, mode = normalization)
         centers = edges[1:end-1] .+ (diff(edges) ./ 2)


### PR DESCRIPTION
`hist([8,8,8,8,8])` would yield histograms with nothing.
With this PR, they get one bar at 8:
![image](https://user-images.githubusercontent.com/1010467/130125231-e13064f9-504d-47c3-9126-d1bde49a5d7c.png)

Not sure if it's the nicest way to set edges to nothing in that case, but since the edges are kind of undefined in that case, most other values would not work out?