### PR TITLE
Document `contour(::Matrix)` in docstring and with example

### DIFF
--- a/docs/examples/plotting_functions/contour.md
+++ b/docs/examples/plotting_functions/contour.md
@@ -22,3 +22,22 @@ contour!(xs, ys, zs)
 f
 ```
 \end{examplefigure}
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+f = Figure()
+Axis(f[1, 1])
+
+xs = LinRange(0, 10, 100)
+ys = LinRange(0, 15, 100)
+zs = [cos(x) * sin(y) for x in xs, y in ys]
+
+contour!(zs)
+
+f
+```
+\end{examplefigure}

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -1,8 +1,10 @@
 
 """
     contour(x, y, z)
+    contour(z::Matrix)
 
 Creates a contour plot of the plane spanning x::Vector, y::Vector, z::Matrix
+If only `z::Matrix` is supplied, the indices of the elements in `z` will be used as the x and y locations when plotting the contour.
 
 ## Attributes
 $(ATTRIBUTES)


### PR DESCRIPTION
Ref #1249 

This PR adds a bit of documentation to `contour`'s docstring and to its docs page, to document `contour(::Matrix)` and usage of `contour!(::Axis, ::Matrix)`.