### PR TITLE
use standard normal for QQNorm

### DIFF
--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -34,8 +34,8 @@ end
     default_theme(scene, Scatter)
 end
 
-convert_arguments(::Type{<:QQNorm}, args...; kwargs...) =
-    convert_arguments(QQPlot, Distributions.Normal(0, 1), args...; kwargs...)
+convert_arguments(::Type{<:QQNorm}, args...; qqline=:R, kwargs...) =
+    convert_arguments(QQPlot, Distributions.Normal(0, 1), args...; qqline=qqline, kwargs...)
 
 convert_arguments(::Type{<:QQPlot}, args...; kwargs...) =
     convert_arguments(Scatter, qqbuild(loc(args...)...); kwargs...)

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -1,4 +1,4 @@
-#= 
+#=
 Taken from https://github.com/JuliaPlots/StatsMakie.jl/blob/master/src/typerecipes/distribution.jl
 The StatMakie.jl package is licensed under the MIT "Expat" License:
     Copyright (c) 2018: Pietro Vertechi. =#
@@ -35,7 +35,7 @@ end
 end
 
 convert_arguments(::Type{<:QQNorm}, args...; kwargs...) =
-    convert_arguments(QQPlot, Distributions.Normal, args...; kwargs...)
+    convert_arguments(QQPlot, Distributions.Normal(0, 1), args...; kwargs...)
 
 convert_arguments(::Type{<:QQPlot}, args...; kwargs...) =
     convert_arguments(Scatter, qqbuild(loc(args...)...); kwargs...)


### PR DESCRIPTION
In usual statistical practice, qqnorm plots are plotted against the quantiles of the standard normal and not against a normal distribution fitted to the data. This changes the behavior of `qqnorm` to use the standard normal as the reference distribution. I'm somewhat unsure at the moment about the tick labels, but perhaps @dmbates can comment (who brought this issue to my attention).

There is an additional friction point introduced by this change: the default `y=x` line shown in the qqnorm plot is now ridiculous for empirical distributions that aren't unit scaled. I realize that this uses `qqbuild` from Distributions, but perhaps changing the values to be on the quantile/CDF scale instead of the raw scale might help (that ties into the axis labeling as well). 

This type of plot also greatly benefits from a default 1:1 aspect, but I don't know how to make that change quickly.

I'm unsure whether this counts as a breaking change or just a bugfix.