### PR TITLE
Fixed broken link to Makie docs

### DIFF
--- a/CairoMakie/README.md
+++ b/CairoMakie/README.md
@@ -2,7 +2,7 @@
 
 The Cairo Backend for Makie
 
-Read the docs for Makie and it's backends [here](http://makie.juliaplots.org/.dev)
+Read the docs for Makie and it's backends [here](http://makie.juliaplots.org/stable)
 
 
 ## Issues


### PR DESCRIPTION
`http://makie.juliaplots.org/.dev` gave me a 404

Also changed it to `/stable` since that's where makie.org points to.