### PR TITLE
Allow IntervalsBetween(1)

### DIFF
--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -102,10 +102,6 @@ Indicates to create n-1 minor ticks between every pair of adjacent major ticks.
 struct IntervalsBetween
     n::Int
     mirror::Bool
-    function IntervalsBetween(n::Int, mirror::Bool)
-        n < 2 && error("You can't have $n intervals (must be at least 2 which means 1 minor tick)")
-        new(n, mirror)
-    end
 end
 IntervalsBetween(n) = IntervalsBetween(n, true)
 


### PR DESCRIPTION
IntervalsBetween(1) lets the minor ticks use the same spacing as the major ticks.
This is useful when the major ticks don't cover the whole axis space. For example, 
this plots y major grid lines on -2, 0, 2 and minor grid lines on -6, -4, 4, 6.

```jl
draw(spec, axis=(; 
yticks=[-2,0,2], 
limits=(nothing, (-7, 7)), 
yminorticks=IntervalsBetween(1), 
yminorgridvisible=true, 
yminorgridcolor=:purple
))
```