### PR TITLE
Draft: Tests wrt opening multiple windows

### DIFF
--- a/GLMakie/src/display.jl
+++ b/GLMakie/src/display.jl
@@ -1,4 +1,5 @@
 function Makie.backend_display(::GLBackend, scene::Scene)
+    @show "in backend display 1"
     screen = global_gl_screen(size(scene), Makie.use_display[])
     display_loading_image(screen)
     Makie.backend_display(screen, scene)
@@ -6,7 +7,9 @@ function Makie.backend_display(::GLBackend, scene::Scene)
 end
 
 function Makie.backend_display(screen::Screen, scene::Scene)
-    empty!(screen)
+    @show "in backend display 2"
+    @show screen
+    empty!(screen) # clears the content of the screen
     # So, the GLFW window events are not guarantee to fire
     # when we close a window, so we ensure this here!
     window_open = events(scene).window_open

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -66,7 +66,7 @@ function Figure(; kwargs...)
 
     kwargs_dict = Dict(kwargs)
     padding = pop!(kwargs_dict, :figure_padding, current_default_theme()[:figure_padding])
-
+    @show "in figure"
     scene = Scene(; camera = campixel!, kwargs_dict...)
 
     padding = padding isa Observable ? padding : Observable{Any}(padding)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -97,7 +97,7 @@ function Scene(
         theme::Attributes, # the default values a scene owns
         attributes::Attributes, # the actual attribute values of a scene
         children::Vector{Scene},
-        current_screens::Vector{AbstractScreen},
+        current_screens::Vector{<:AbstractScreen},
         parent=nothing,
     )
 
@@ -131,7 +131,8 @@ function Scene(
 end
 
 
-function Scene(;clear=true, transform_func=identity, scene_attributes...)
+function Scene(;clear=true, transform_func=identity, current_screens = AbstractScreen[],scene_attributes...)
+    @show current_screens
     events = Events()
     theme = current_default_theme(; scene_attributes...)
     attributes = deepcopy(theme)
@@ -156,7 +157,7 @@ function Scene(;clear=true, transform_func=identity, scene_attributes...)
         theme,
         attributes,
         Scene[],
-        AbstractScreen[]
+        current_screens
     )
     # Set the transformation parent
     scene.transformation.parent[] = scene


### PR DESCRIPTION
This just modified the code to do some test to prepare for a version of GLMakie that supports opening multiple figures.
With this modified code, you can open multiple figures, but only the last one opened is active.
Here is some test code:
```julia
using GLMakie
fig_p = plot(sin.(1:0.1:10))
fig_p2 = plot(cos.(1:0.1:10))
fig_p3 = plot((1:0.1:10))
```
However, there are multiple problems: 
1. To "activate" a second figure, for some reason not clear to me, I had to set the window `handle` to zero. Maybe this avoids the render loop to go over the previous figure. If the `handle` is not set to zero, there are some strange results, letting the figures continuously blink and not accepting display in the new figure.
2. If you do not set the figure handle to zero, interestingly multiple screens created via `Screen()` can happily coexist even without context change, and the user can move them and close them freely. Nice. However, I was unable to make these figures accept content. If I assign a plot to a screen, this sort of works but only for the first one and the plot is totally messed up.
3. Currently I do context switching to the new figures, and for some reason I had to call the high lever AND the low level version. This looks wrong and ugly.

Would be great, if some day Makie could do multiple figures and hopefully even non-modal and modal dialogue windows. Then it would be ready for larger real-world GUIs. 