### PR TITLE
Fix depth buffer issue in WGLMakie

### DIFF
--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -292,8 +292,8 @@ function serialize_three(scene::Scene, plot::AbstractPlot)
     mesh[:name] = string(Makie.plotkey(plot)) * "-" * string(objectid(plot))
     mesh[:visible] = plot.visible
     mesh[:uuid] = js_uuid(plot)
-    mesh[:transparency] = plot.transparency
-    mesh[:overdraw] = plot.overdraw
+    mesh[:transparency] = plot.transparency[]
+    mesh[:overdraw] = plot.overdraw[]
     uniforms = mesh[:uniforms]
     updater = mesh[:uniform_updater]
 

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -292,8 +292,8 @@ function serialize_three(scene::Scene, plot::AbstractPlot)
     mesh[:name] = string(Makie.plotkey(plot)) * "-" * string(objectid(plot))
     mesh[:visible] = plot.visible
     mesh[:uuid] = js_uuid(plot)
-    mesh[:transparency] = plot.transparency[]
-    mesh[:overdraw] = plot.overdraw[]
+    mesh[:transparency] = plot.transparency
+    mesh[:overdraw] = plot.overdraw
     uniforms = mesh[:uniforms]
     updater = mesh[:uniform_updater]
 

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -380,8 +380,8 @@ const WGLMakie = (function () {
             fragmentShader: deserialize_three(program.fragment_source),
             side: is_volume ? THREE.BackSide : THREE.DoubleSide,
             transparent: true,
-            depthTest: !program.overdraw,
-            depthWrite: !program.transparency
+            depthTest: !JSServe.get_observable(program.overdraw),
+            depthWrite: !JSServe.get_observable(program.transparency)
         });
     }
 


### PR DESCRIPTION
Make the attributes `transparency` and `overdraw` `Bool` instead of `Observable` in the return value of 'serialize_three(scene::Scene, plot::AbstractPlot)' (`serialization.jl` file).

In `create_material(program)` (`wglmakie.js` file), these attributes are passed directly to their corresponding javascript variables. This was setting `depthTest` and `depthWrite` to `false` regardless of the actual values of `transparency` and `overdraw`.

Fix #1294 and #1280 .

An alternative solution would be to create an update function that could recompile the shader whenever `transparency` or `overdraw` changed. However, **GLMakie** also doesn't seem to change these values dynamically.

The attached images show Pluto sessions after the fix, for the issues #1294 and #1280 respectively.

![image](https://user-images.githubusercontent.com/11084889/134163391-0174c93a-e200-4cee-8a83-2f2e1f40932c.png)
![image](https://user-images.githubusercontent.com/11084889/134163469-653e2c3d-8366-4092-9015-a7346b7ed1dd.png)
