### PR TITLE
Improve contour documentation

### DIFF
--- a/docs/examples/plotting_functions/contour.md
+++ b/docs/examples/plotting_functions/contour.md
@@ -23,6 +23,8 @@ f
 ```
 \end{examplefigure}
 
+Omitting the `xs` and `ys` results in the indices of `zs` being used. We can also set arbitrary contour-levels using `levels`
+
 \begin{examplefigure}{}
 ```julia
 using CairoMakie
@@ -36,7 +38,7 @@ xs = LinRange(0, 10, 100)
 ys = LinRange(0, 15, 100)
 zs = [cos(x) * sin(y) for x in xs, y in ys]
 
-contour!(zs)
+contour!(zs,levels=-1:0.1:1)
 
 f
 ```

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -6,6 +6,12 @@
 Creates a contour plot of the plane spanning x::Vector, y::Vector, z::Matrix
 If only `z::Matrix` is supplied, the indices of the elements in `z` will be used as the x and y locations when plotting the contour.
 
+The attribute levels can be either
+
+    an Int that produces n equally wide levels or bands
+
+    an AbstractVector{<:Real} that lists n consecutive edges from low to high, which result in n-1 levels or bands
+
 ## Attributes
 $(ATTRIBUTES)
 """


### PR DESCRIPTION
it took me quite a while (and asking @SimonDanisch) to figure out, that I can simply put an array for `levels` in contour.
This is now clarified (I then noticed it was already clarified in `countourf`).
