### PR TITLE
Make Lorenz example copy-pasteable

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ fig, ax, l = lines(points, color = colors,
     axis = (; type = Axis3, protrusions = (0, 0, 0, 0),
         viewmode = :fit, limits = (-30, 30, -30, 30, 0, 50)))
 
-record(fig, joinpath(@OUTPUT, "lorenz.mp4"), 1:120) do frame
+record(fig, joinpath(@__DIR__, "lorenz.mp4"), 1:120) do frame
     for i in 1:50
         push!(points[], step!(attractor))
         push!(colors[], frame)


### PR DESCRIPTION
For me (on Linux with Julia 1.6.2) I get the error `UndefVarError: @OUTPUT not defined` when I try to run the example as is. What about replacing it with `@__DIR__` instead*? 

*Or some other, standard location. (As a matter of fact, I can't find any documentation on the `@OUTPUT` macro anywhere, which suggests that this is the author's own convenience macro...)