### PR TITLE
Stairs needs to modify the color attribute (new contributor)

### DIFF
--- a/src/basic_recipes/stairs.jl
+++ b/src/basic_recipes/stairs.jl
@@ -63,7 +63,23 @@ function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
         end
     end
 
-    lines!(p, steppoints; [x for x in pairs(p.attributes) if x[1] != :step]...)
+    if isa(p.color[], AbstractVector)
+        stepcolor = lift(p.color, p.step) do color, step
+            if step == :pre
+                c = [color';color'][2:end]
+            elseif step == :post
+                c = [color';color'][1:end-1]
+            elseif step == :center
+                c = [color';color'][1:end]
+            else
+                error("Invalid step $step. Valid options are :pre, :post and :center")
+            end
+            c
+        end
+        lines!(p, steppoints; color=stepcolor, [x for x in pairs(p.attributes) if x[1] != :step && x[1] != :color]...)
+    else
+        lines!(p, steppoints; [x for x in pairs(p.attributes) if x[1] != :step]...)
+    end
     p
 end
 


### PR DESCRIPTION
If the color attribute is a vector, its components need to be
repeated in order to contain a color for each line segment.

Fixes https://github.com/JuliaPlots/Makie.jl/issues/1342

I marked it as "new contributor", because I am completely unaware of Makie code and testing conventions and would need some "handholding".