### PR TITLE
Improve Latex docs

### DIFF
--- a/docs/documentation/latex.md
+++ b/docs/documentation/latex.md
@@ -1,12 +1,14 @@
 # LaTeX
 
-Makie can render LaTeX strings from the LaTeXStrings.jl package using [MathTeXEngine.jl](https://github.com/Kolaru/MathTeXEngine.jl/).
+Makie can render LaTeX strings from the [LaTeXStrings.jl](https://github.com/stevengj/LaTeXStrings.jl) package using [MathTeXEngine.jl](https://github.com/Kolaru/MathTeXEngine.jl/).
 
 This engine supports a subset of LaTeX's most used commands, which are rendered quickly enough for responsive use in GLMakie.
 
 ## Using L-strings
 
 You can pass `LaTeXString` objects to almost any object with text labels. They are constructed using the `L` string macro prefix.
+The whole string is interpreted as an equation if it doesn't contain an unescaped `$`.
+
 
 ```!
 # hideall
@@ -30,7 +32,8 @@ f
 ```
 \end{examplefigure}
 
-You can also mix math-mode and text-mode:
+You can also mix math-mode and text-mode.
+For [string interpolation](https://docs.julialang.org/en/v1/manual/strings/#string-interpolation) use `%$`instead of `$`:
 
 \begin{examplefigure}{svg = true}
 ```julia
@@ -38,8 +41,8 @@ using CairoMakie
 CairoMakie.activate!() # hide
 
 f = Figure(fontsize = 18)
-
-Axis(f[1,1], title=L"Some text and some math: $\frac{2\alpha+1}{y}$")
+t = "text"
+Axis(f[1,1], title=L"Some %$(t) and some math: $\frac{2\alpha+1}{y}$")
 
 f
 ```


### PR DESCRIPTION
Adds a link to the LaTeXStrings package and a hint about string interpolation.

I needed the information today and I think this could be provided by the Makie docs. 
I am not sure, whether it is good to mix the string interpolation with the text and math mode mixing example, but I thought, that we don't need to add another full example. 

