### PR TITLE
fix camera replacement

### DIFF
--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -301,7 +301,6 @@ cameracontrols(scene::Scene) = scene.camera_controls
 cameracontrols(scene::SceneLike) = cameracontrols(scene.parent)
 
 function cameracontrols!(scene::Scene, cam)
-    disconnect!(scene.camera_controls)
     scene.camera_controls = cam
     return cam
 end


### PR DESCRIPTION
On master
```julia
scene = Scene()
cam3d!(scene)
cam3d!(scene)
```
errors because there is no `disconnect!(scene.camera_controls)`. That's by design - all the camera observables are held and cleaned up by `scene.camera`.