### PR TITLE
Clean up volume lighting

### DIFF
--- a/GLMakie/assets/shader/volume.frag
+++ b/GLMakie/assets/shader/volume.frag
@@ -107,11 +107,12 @@ vec3 gennormal(vec3 uvw, float d)
     return normalize(a-b);
 }
 
+// Includes front and back-facing normals (N, -N)
 vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
-    float diff_coeff = max(dot(L, N), 0.0);
+    float diff_coeff = max(dot(L, N), 0.0) + max(dot(L, -N), 0.0);
     // specular coefficient
     vec3 H = normalize(L + V);
-    float spec_coeff = pow(max(dot(H, N), 0.0), shininess);
+    float spec_coeff = pow(max(dot(H, N), 0.0) + max(dot(H, -N), 0.0), shininess);
     if (diff_coeff <= 0.0 || isnan(spec_coeff))
         spec_coeff = 0.0;
     // final lighting model
@@ -253,10 +254,10 @@ vec4 isosurface(vec3 front, vec3 dir)
             // depth = min(depth, frag_coord.z / frag_coord.w);
             vec3 N = gennormal(pos, step_size);
             vec3 L = normalize(o_light_dir - pos);
-            // back & frontface...
-            vec3 c1 = blinnphong(N, camdir, L, diffuse_color.rgb);
-            vec3 c2 = blinnphong(-N, camdir, L, diffuse_color.rgb);
-            c = vec4(0.5*c1 + 0.5*c2, diffuse_color.a);
+            c = vec4(
+                blinnphong(N, camdir, L, diffuse_color.rgb),
+                diffuse_color.a
+            );
             break;
         }
         pos += dir;

--- a/WGLMakie/assets/volume.frag
+++ b/WGLMakie/assets/volume.frag
@@ -55,10 +55,10 @@ vec3 gennormal(vec3 uvw, float d)
 }
 
 vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
-    float diff_coeff = max(dot(L, N), 0.0);
+    float diff_coeff = max(dot(L, N), 0.0) + max(dot(L, -N), 0.0);
     // specular coefficient
     vec3 H = normalize(L + V);
-    float spec_coeff = pow(max(dot(H, N), 0.0), shininess);
+    float spec_coeff = pow(max(dot(H, N), 0.0) + max(dot(H, -N), 0.0), shininess);
     // final lighting model
     return vec3(
         ambient * color +
@@ -171,10 +171,10 @@ vec4 isosurface(vec3 front, vec3 dir)
         if(abs(density - isovalue) < isorange){
             vec3 N = gennormal(pos, step_size);
             vec3 L = normalize(o_light_dir - pos);
-            // back & frontface...
-            vec3 c1 = blinnphong(N, camdir, L, diffuse_color.rgb);
-            vec3 c2 = blinnphong(-N, camdir, L, diffuse_color.rgb);
-            c = vec4(0.5*c1 + 0.5*c2, diffuse_color.a);
+            c = vec4(
+                blinnphong(N, camdir, L, diffuse_color.rgb), 
+                diffuse_color.a
+            );
             break;
         }
         pos += dir;


### PR DESCRIPTION
This cleans up the lighting calculation so that it includes diffuse and specular lighting once for both forward and backwards facing surfaces without counting ambient lighting twice. (Currently `:iso` counts ambient twice and then divides by 2, which means diffuse and specular are halfed. Contours only consider forward facing surfaces)

Before:
![Screenshot from 2021-11-07 13-32-03](https://user-images.githubusercontent.com/10947937/140645640-b0f04b66-1227-487c-a793-f8ab6ec2bb42.png)

After:
![Screenshot from 2021-11-07 13-31-17](https://user-images.githubusercontent.com/10947937/140645645-8577f87c-32f9-4102-ba80-1f5fae8ec73f.png)