### PR TITLE
Clean up color handling in shaders

### DIFF
--- a/GLMakie/assets/shader/colors.frag
+++ b/GLMakie/assets/shader/colors.frag
@@ -1,0 +1,98 @@
+{{GLSL_VERSION}}
+{{GLSL_EXTENSIONS}}
+{{SUPPORTED_EXTENSIONS}}
+
+struct Nothing{ //Nothing type, to encode if some variable doesn't contain any data
+    bool _; //empty structs are not allowed
+};
+
+{{image_type}} image;
+{{pattern_type}} pattern;
+{{matcap_type}} matcap;
+{{color_map_type}}  color_map;
+{{color_range_type}} color_range; 
+
+uniform vec4 highclip;
+uniform vec4 lowclip;
+uniform vec4 nan_color;
+uniform vec2 uv_scale;
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// fragment shader functions
+////////////////////////////////////////////////////////////////////////////////
+
+
+// implementations 
+vec4 _texture_color(sampler1D t, float u){return texture(t, u);}
+vec4 _texture_color(sampler2D t, vec2 uv){return texture(t, uv);}
+vec4 _texture_color(samplerBuffer t, int i){return texelFetch(t, i);}
+// assumes 0..1 normalization
+vec4 _texture_color(samplerBuffer t, float u){return texelFetch(t, int(u * textureSize(t)));}
+vec4 _texture_color(sampler2DArray t, vec2 uv, float i){return texture(t, vec3(uv, i));}
+
+vec4 _texture_color(Nothing t, float i){return vec4(1);}
+vec4 _texture_color(Nothing t, int i){return vec4(1);}
+vec4 _texture_color(Nothing t, vec2 uv){return vec4(1);}
+vec4 _texture_color(Nothing t, vec2 uv, float i){return vec4(1);}
+
+vec4 _texture_color(sampler2D t, ivec2 uv){
+    ivec2 size = textureSize(t, 0);
+    return texelFetch(t, ivec2(mod(uv.x, size.x), mod(uv.y, size.y)), 0);
+}
+
+
+vec4 _color(Nothing c){return vec4(1);}
+vec4 _color(vec3 c){return vec4(c, 1);}
+vec4 _color(vec4 c){return c;}
+
+
+
+ivec2 pattern_uv(){return ivec2(gl_FragCoord.xy * uv_scale);}
+ivec2 pos2uv(){return ivec2(gl_FragCoord.xy * uv_scale);}
+vec2 normal2uv(vec3 normal){
+    // -1..1 range -> 0..1 range and (x, y) -> (1-y, x)
+    return normal.yx * vec2(-0.5, 0.5) + vec2(0.5, 0.5);
+}
+
+
+float _normalize(float val, float from, float to){
+    return (val-from) / (to - from);
+}
+vec4 _get_colormap_color(Nothing cm, Nothing cr, float i){return vec4(1);}
+vec4 _get_colormap_color(sampler1D cm, vec2 colorrange, float cm_index){
+    vec4 color = texture(cm, _normalize(cm_index, colorrange.x, colorrange.y));
+    if (isnan(cm_index)) {
+        color = nan_color;
+    } else if (cm_index < colorrange.x) {
+        color = lowclip;
+    } else if (cm_index > colorrange.y) {
+        color = highclip;
+    }
+    return color;
+}
+
+vec4 get_colormap_color(float cm_index){
+    return _get_colormap_color(color_map, color_range, cm_index);
+}
+vec4 get_texture_color(vec2 uv){return _texture_color(image, uv);}
+vec4 get_pattern_color(){return _texture_color(pattern, pattern_uv());}
+vec4 get_matcap_color(vec3 normal){
+    return _texture_color(matcap, normal2uv(normal));
+}
+
+vec4 get_color(vec4 color, vec2 uv, vec3 normal){
+    return 
+        color *
+        get_texture_color(uv) *
+        get_pattern_color() *
+        get_matcap_color(normal);
+}
+vec4 get_color(vec4 color, float cm_index, vec2 uv, vec3 normal){
+    return 
+        color *
+        get_colormap_color(cm_index) *
+        get_texture_color(uv) *
+        get_pattern_color() *
+        get_matcap_color(normal);
+}

--- a/GLMakie/assets/shader/distance_shape.frag
+++ b/GLMakie/assets/shader/distance_shape.frag
@@ -19,7 +19,8 @@ struct Nothing{ //Nothing type, to encode if some variable doesn't contain any d
 
 
 {{distancefield_type}}  distancefield;
-{{image_type}}          image;
+// {{image_type}}          image;
+// {{pattern_type}} pattern;
 
 uniform float           stroke_width;
 uniform float           glow_width;
@@ -41,7 +42,8 @@ flat in vec4            f_uv_texture_bbox;
 // These versions of aastep assume that `dist` is a signed distance function
 // which has been scaled to be in units of pixels.
 float aastep(float threshold1, float dist) {
-    return min(1.0, f_viewport_from_u_scale)*smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist);
+    return min(1.0, f_viewport_from_u_scale) * 
+        smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist);
 }
 float aastep(float threshold1, float threshold2, float dist) {
     return smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist) -
@@ -74,6 +76,10 @@ float rounded_rectangle(vec2 uv, vec2 tl, vec2 br){
     vec2 d = max(tl-uv, uv-br);
     return -((length(max(vec2(0.0), d)) + min(0.0, max(d.x, d.y)))-tl.x);
 }
+
+
+vec4 get_color(vec4 color, vec2 uv, vec3 normal);
+
 
 void fill(vec4 fillcolor, Nothing image, vec2 uv, float infill, inout vec4 color){
     color = mix(color, fillcolor, infill);
@@ -147,7 +153,9 @@ void main(){
     float inside = aastep(inside_start, signed_distance);
     vec4 final_color = f_bg_color;
 
-    fill(f_color, image, tex_uv, inside, final_color);
+    // fill(f_color, image, tex_uv, inside, final_color);
+    // final_color = mix(final_color, get_color(tex_uv), inside);
+    final_color = mix(final_color, get_color(f_color, tex_uv.yx, vec3(0, 0, -1)), inside);
     stroke(f_stroke_color, signed_distance, -stroke_width, final_color);
     glow(f_glow_color, signed_distance, aastep(-stroke_width, signed_distance), final_color);
     // TODO: In 3D, we should arguably discard fragments outside the sprite

--- a/GLMakie/assets/shader/standard.frag
+++ b/GLMakie/assets/shader/standard.frag
@@ -17,59 +17,61 @@ in vec4 o_color;
 in vec2 o_uv;
 flat in uvec2 o_id;
 
-{{matcap_type}} matcap;
-{{image_type}} image;
-{{color_map_type}} color_map;
-{{color_norm_type}} color_norm;
+// {{matcap_type}} matcap;
+// {{image_type}} image;
+// {{color_map_type}} color_map;
+// {{color_norm_type}} color_norm;
 
-vec4 get_color(Nothing image, vec2 uv, Nothing color_norm, Nothing color_map, Nothing matcap){
-    return o_color;
-}
-vec4 get_color(Nothing color, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){
-    return o_color;
-}
+// vec4 get_color(Nothing image, vec2 uv, Nothing color_norm, Nothing color_map, Nothing matcap){
+//     return o_color;
+// }
+// vec4 get_color(Nothing color, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){
+//     return o_color;
+// }
 
-vec4 get_color(sampler2D color, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){
-    return o_color;
-}
+// vec4 get_color(sampler2D color, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){
+//     return o_color;
+// }
 
-vec4 get_color(sampler2D color, vec2 uv, Nothing color_norm, Nothing color_map, Nothing matcap){
-    return texture(color, uv);
-}
+// vec4 get_color(sampler2D color, vec2 uv, Nothing color_norm, Nothing color_map, Nothing matcap){
+//     return texture(color, uv);
+// }
 
-vec4 matcap_color(sampler2D matcap){
-    vec2 muv = o_normal.xy * 0.5 + vec2(0.5, 0.5);
-    return texture(matcap, vec2(1.0-muv.y, muv.x));
-}
+// vec4 matcap_color(sampler2D matcap){
+//     vec2 muv = o_normal.xy * 0.5 + vec2(0.5, 0.5);
+//     return texture(matcap, vec2(1.0-muv.y, muv.x));
+// }
 
-vec4 get_color(Nothing image, vec2 uv, Nothing color_norm, Nothing color_map, sampler2D matcap){
-    return matcap_color(matcap);
-}
-vec4 get_color(sampler2D color, vec2 uv, Nothing color_norm, Nothing color_map, sampler2D matcap){
-    return matcap_color(matcap);
-}
-vec4 get_color(sampler1D color, vec2 uv, vec2 color_norm, sampler1D color_map, sampler2D matcap){
-    return matcap_color(matcap);
-}
+// vec4 get_color(Nothing image, vec2 uv, Nothing color_norm, Nothing color_map, sampler2D matcap){
+//     return matcap_color(matcap);
+// }
+// vec4 get_color(sampler2D color, vec2 uv, Nothing color_norm, Nothing color_map, sampler2D matcap){
+//     return matcap_color(matcap);
+// }
+// vec4 get_color(sampler1D color, vec2 uv, vec2 color_norm, sampler1D color_map, sampler2D matcap){
+//     return matcap_color(matcap);
+// }
 
-uniform bool fetch_pixel;
-uniform vec2 uv_scale;
+// uniform bool fetch_pixel;
+// uniform vec2 uv_scale;
 
-vec4 get_pattern_color(sampler1D color) {
-    int size = textureSize(color, 0);
-    vec2 pos = gl_FragCoord.xy * uv_scale;
-    int idx = int(mod(pos.x, size));
-    return texelFetch(color, idx, 0);
-}
+// vec4 get_pattern_color(sampler1D color) {
+//     int size = textureSize(color, 0);
+//     vec2 pos = gl_FragCoord.xy * uv_scale;
+//     int idx = int(mod(pos.x, size));
+//     return texelFetch(color, idx, 0);
+// }
 
-vec4 get_pattern_color(sampler2D color){
-    ivec2 size = textureSize(color, 0);
-    vec2 pos = gl_FragCoord.xy * uv_scale;
-    return texelFetch(color, ivec2(mod(pos.x, size.x), mod(pos.y, size.y)), 0);
-}
+// vec4 get_pattern_color(sampler2D color){
+//     ivec2 size = textureSize(color, 0);
+//     vec2 pos = gl_FragCoord.xy * uv_scale;
+//     return texelFetch(color, ivec2(mod(pos.x, size.x), mod(pos.y, size.y)), 0);
+// }
 
-// Needs to exist for opengl to be happy
-vec4 get_pattern_color(Nothing color){return vec4(1,0,1,1);}
+// // Needs to exist for opengl to be happy
+// vec4 get_pattern_color(Nothing color){return vec4(1,0,1,1);}
+
+vec4 get_color(vec4 color, vec2 uv, vec3 normal);
 
 vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
     float diff_coeff = max(dot(L, N), 0.0);
@@ -94,11 +96,12 @@ void write2framebuffer(vec4 color, uvec2 id);
 void main(){
     vec4 color;
     // Should this be a mustache replace?
-    if (fetch_pixel){
-        color = get_pattern_color(image);
-    }else{
-        color = get_color(image, o_uv, color_norm, color_map, matcap);
-    }
+    // if (fetch_pixel){
+    //     color = get_pattern_color(image);
+    // }else{
+    //     color = get_color(image, o_uv, color_norm, color_map, matcap);
+    // }
+    color = get_color(o_color, o_uv, o_normal);
     {{light_calc}}
     write2framebuffer(color, o_id);
 }

--- a/GLMakie/src/GLVisualize/visualize/mesh.jl
+++ b/GLMakie/src/GLVisualize/visualize/mesh.jl
@@ -14,6 +14,7 @@ function _default(mesh::TOrSignal{M}, s::Style, data::Dict) where M <: GeometryB
         uv_scale = Vec2f(1)
         shader = GLVisualizeShader(
             "fragment_output.frag", "util.vert", "standard.vert", "standard.frag",
+            "colors.frag",
             view = Dict("light_calc" => light_calc(shading))
         )
     end

--- a/GLMakie/src/GLVisualize/visualize/particles.jl
+++ b/GLMakie/src/GLVisualize/visualize/particles.jl
@@ -311,7 +311,7 @@ function sprites(p, s, data)
         fxaa             = false
         shader           = GLVisualizeShader(
             "fragment_output.frag", "util.vert", "sprites.geom",
-            "sprites.vert", "distance_shape.frag",
+            "sprites.vert", "colors.frag", "distance_shape.frag",
             view = Dict("position_calc"=>position_calc(position, position_x, position_y, position_z, GLBuffer))
         )
         scale_primitive = true

--- a/GLMakie/src/GLVisualize/visualize_interface.jl
+++ b/GLMakie/src/GLVisualize/visualize_interface.jl
@@ -164,6 +164,12 @@ function visualize(@nospecialize(main), @nospecialize(s), @nospecialize(data))
     data = _default(main, s, copy(data))
     @gen_defaults! data begin # make sure every object has these!
         model = Mat4f(I)
+        image = nothing => Texture
+        pattern = nothing => Texture
+        matcap = nothing => Texture
+        color_map = nothing => Texture
+        color_range = nothing => Vec2f
+        uv_scale = Vec2f(1)
     end
     return assemble_shader(data)
 end


### PR DESCRIPTION
My goal with this is to move most if not all the color fetching code into one shader so we don't have as much duplicate code. 

To avoid having tons of methods differentiating `Nothing image` from `sampler2D image` etc, I'm also proposing that we multiply all the different sources. That shouldn't change anything in most of the current use cases but it would reduce the amount of code in shaders and allow, well, mixing of textures, colors etc. If we go through with these changes it may also make sense to also separate textures, colormap indices and patterns from `color`.

Some wild mixing examples:
```julia
img = FileIO.load(Makie.assetpath("cow.png"))
c1 = RGBAf(1, 1, 1, 1)
c2 = RGBAf(0, 0, 0, 0)
pattern = [
    c1 c1 c2; 
    c1 c1 c1; 
    c1 c1 c1
]
colors = [:red, :green, :blue, :gray, :white]
fig, ax, p = scatter(
    rand(Point2f, 5), 
    color = colors, 
    image = img, 
    pattern = pattern, 
    markersize=80, strokewidth=2, uv_scale = Vec2f(0.2)
)
```

![Screenshot from 2021-11-07 20-06-35](https://user-images.githubusercontent.com/10947937/140658975-300388df-f20b-49d7-b658-74c7cf685795.png)


```julia
cat = FileIO.load(Makie.assetpath("cat.obj"))
img = FileIO.load(Makie.assetpath("diffusemap.tga"))
matcap = FileIO.load(download("https://raw.githubusercontent.com/nidorx/matcaps/master/thumbnail/54584E_B1BAC5_818B91_A7ACA3.jpg"))
c1 = RGBAf(1, 1, 1, 1)
c2 = RGBAf(0.5, 1.5, 1, 1)
pattern = [
    c1 c1 c2; 
    c1 c1 c1; 
    c1 c1 c1
]
mesh(
    cat, 
    color = RGBAf(1, 0.9, 0.4, 1),
    image = img,
    matcap = matcap,
    pattern = pattern,
    uv_scale = Vec2f(0.3),
    lightposition = Vec3f(0, 2, 0)
)
```

![Screenshot from 2021-11-07 20-29-28](https://user-images.githubusercontent.com/10947937/140659103-2865f133-219a-4da5-8280-9aec3a6b0d70.png)

Ref #1388 