### PR TITLE
disable rectangle zoom if we don't have inverse

### DIFF
--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -352,6 +352,7 @@ inverse_transform(::typeof(pseudolog10)) = inv_pseudolog10
 inverse_transform(F::Tuple) = map(inverse_transform, F)
 inverse_transform(::typeof(logit)) = logistic
 inverse_transform(s::Symlog10) = x -> inv_symlog10(x, s.low, s.high)
+inverse_transform(s) = nothing
 
 function is_identity_transform(t)
     return t === identity || t isa Tuple && all(x-> x === identity, t)

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -150,7 +150,7 @@ function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
     inv_transf = Makie.inverse_transform(transf)
 
     if isnothing(inv_transf)
-        @warn "Can't rectangle zoom without inverse transform"
+        @warn "Can't rectangle zoom without inverse transform" maxlog=1
         # TODO, what can we do without inverse?
         return Consume(false)
     end
@@ -188,9 +188,10 @@ function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
 end
 
 function rectclamp(p::Point, r::Rect)
-    map(p, minimum(r), maximum(r)) do pp, mi, ma
+    p = map(p, minimum(r), maximum(r)) do pp, mi, ma
         clamp(pp, mi, ma)
-    end |> Point
+    end
+    return Point(p)
 end
 
 function process_interaction(r::RectangleZoom, event::KeysEvent, ax::Axis)
@@ -202,12 +203,11 @@ function process_interaction(r::RectangleZoom, event::KeysEvent, ax::Axis)
     return Consume(true)
 end
 
-
 function positivize(r::Rect2f)
     negwidths = r.widths .< 0
     newori = ifelse.(negwidths, r.origin .+ r.widths, r.origin)
     newwidths = ifelse.(negwidths, -r.widths, r.widths)
-    Rect2f(newori, newwidths)
+    return Rect2f(newori, newwidths)
 end
 
 function process_interaction(l::LimitReset, event::MouseEvent, ax::Axis)


### PR DESCRIPTION
The warning was there correctly, but somehow `inverse_transform(s) = nothing` got lost...
Also improves the warning, by only displaying it one time.