### PR TITLE
Added axes-linking to layout tutorial

### DIFF
--- a/docs/tutorials/layout-tutorial.md
+++ b/docs/tutorials/layout-tutorial.md
@@ -91,6 +91,18 @@ f
 ```
 \end{examplefigure}
 
+
+The grid lines and their values are not aligned, which we can align by linking.
+
+\begin{examplefigure}{}
+```julia
+linkxaxes!(axmain,axtop)
+linkyaxes!(axmain,axright)
+
+f
+```
+\end{examplefigure}
+
 ### Legend
 
 We have set the `label` attribute in the scatter call so it's easier to construct the legend. We can just pass `axmain` as the second argument to `Legend`.


### PR DESCRIPTION
a) This is a very useful command
b) The finished plot clearly implies the `axtop` and `axmain` have the same x-axis and  `axright` and `axmain` the same y-axis.