### PR TITLE
Fix blurry text

### DIFF
--- a/GLMakie/assets/shader/distance_shape.frag
+++ b/GLMakie/assets/shader/distance_shape.frag
@@ -41,7 +41,7 @@ flat in vec4            f_uv_texture_bbox;
 // These versions of aastep assume that `dist` is a signed distance function
 // which has been scaled to be in units of pixels.
 float aastep(float threshold1, float dist) {
-    return min(1.0, f_viewport_from_u_scale)*smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist);
+    return smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist);
 }
 float aastep(float threshold1, float threshold2, float dist) {
     return smoothstep(threshold1-ANTIALIAS_RADIUS, threshold1+ANTIALIAS_RADIUS, dist) -

--- a/GLMakie/src/gl_backend.jl
+++ b/GLMakie/src/gl_backend.jl
@@ -17,7 +17,6 @@ using .GLAbstraction
 const atlas_texture_cache = Dict{Any, Tuple{Texture{Float16, 2}, Function}}()
 
 function get_texture!(atlas)
-    Makie.set_glyph_resolution!(Makie.High)
     # clean up dead context!
     filter!(atlas_texture_cache) do (ctx, tex_func)
         if GLAbstraction.context_alive(ctx)

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -310,12 +310,14 @@ function text_quads(positions, glyphs::AbstractVector, fonts::AbstractVector, te
     offsets = Vec2f[]
     uv = Vec4f[]
     scales = Vec2f[]
+    pad = GLYPH_PADDING[] / PIXELSIZE_IN_ATLAS[]
     broadcast_foreach(positions, glyphs, fonts, textsizes) do offs, c, font, pixelsize
     # for (c, font, pixelsize) in zipx(glyphs, fonts, textsizes)
         push!(uv, glyph_uv_width!(atlas, c, font))
         glyph_bb, extent = FreeTypeAbstraction.metrics_bb(c, font, pixelsize)
-        push!(scales, widths(glyph_bb))
-        push!(offsets, minimum(glyph_bb))
+
+        push!(scales, widths(glyph_bb) .+ pixelsize * 2pad)
+        push!(offsets, minimum(glyph_bb) .- pixelsize * pad)
     end
     return positions, offsets, uv, scales
 end
@@ -326,13 +328,14 @@ function text_quads(positions, glyphs, fonts, textsizes::Vector{<:ScalarOrVector
     offsets = Vec2f[]
     uv = Vec4f[]
     scales = Vec2f[]
+    pad = GLYPH_PADDING[] / PIXELSIZE_IN_ATLAS[]
 
     broadcast_foreach(positions, glyphs, fonts, textsizes) do positions, glyphs, fonts, textsizes
         broadcast_foreach(positions, glyphs, fonts, textsizes) do offs, c, font, pixelsize
             push!(uv, glyph_uv_width!(atlas, c, font))
             glyph_bb, extent = FreeTypeAbstraction.metrics_bb(c, font, pixelsize)
-            push!(scales, widths(glyph_bb))
-            push!(offsets, minimum(glyph_bb))
+            push!(scales, widths(glyph_bb) .+ pixelsize * 2pad)
+            push!(offsets, minimum(glyph_bb) .- pixelsize * pad)
         end
     end
 


### PR DESCRIPTION
Closes #1470

The problem here was that the glyph padding did not make it into the texture atlas. 

Makie uses a signed distance field approach, which essentially encodes the distance to the closest edge at each pixel. From that you can recover the original symbol by evaluating `color = text_color * (distance > 0)` at each pixel (assuming positive distances inside the symbol). Antialiasing essentially swaps the step function `(distance > 0)` for a smoothed step function (i.e. sigmoid). This means some small negative distances outside the original shape are included. We need to make sure that these are available, otherwise we get artifacts like in #1470.
On current master this is not the case. Padding is included in the texture generation but is discarded when the signed distance fields gets inserted into the texture atlas. This pr changes that - with it the padding is included during insertion and it's increased so that we have 1.5px padding at a textsize of 8px. (1px padding still looked blurry.)

Note that this chunks up the glyph size quite a bit. If we run into "texture atlas is too small. Resizing not implemented yet. Please file an issue at Makie if you encounter this" errors we should be fine decreasing the default glyph resolution to 32px. (In case you find this pr because of that error please do report it. You can clear your cache by deleting the files at `Makie.get_cache_path()` and restarting Julia or `empty!(Makie.global_texture_atlas)`.)

Before and after:
(Textsizes are 8, 10, 16, 20, 32, 64, 100)
![master](https://user-images.githubusercontent.com/10947937/144500095-5b239ed0-346f-4783-998a-701c2c44a66c.png)
![Screenshot from 2021-12-02 21-19-08](https://user-images.githubusercontent.com/10947937/144500158-a17863e5-8929-4f2b-a630-39d5bac9ae11.png)

And specifically the figure from #1470 
![Screenshot from 2021-12-02 21-48-35](https://user-images.githubusercontent.com/10947937/144500626-99695bcf-5ce1-4014-a372-c22508ffb0df.png)

