### PR TITLE
Disconnect other cameras when switching to PixelCamera

### DIFF
--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -309,6 +309,7 @@ struct PixelCamera <: AbstractCamera end
 Creates a pixel-level camera for the `Scene`.  No controls!
 """
 function campixel!(scene; nearclip=-1000f0, farclip=1000f0)
+    disconnect!(camera(scene))
     update_once = Observable(false)
     on(camera(scene), update_once, pixelarea(scene)) do u, window_size
         w, h = Float32.(widths(window_size))


### PR DESCRIPTION
If you do something like this
```julia
fig = Figure()
scene = LScene(fig[1, 1], show_axis = false)
campixel!(scene.scene)
scatter!(scene, 400rand(10), 400rand(10))
fig
```
and then click (and drag) the plot area everything will disappear. That happens because `campixel!` does not disconnect the previous camera, in this case `Camera3D`. The pr fixes that.