### PR TITLE
Fix #1505

### DIFF
--- a/GLMakie/src/GLVisualize/visualize_interface.jl
+++ b/GLMakie/src/GLVisualize/visualize_interface.jl
@@ -167,7 +167,7 @@ function visualize(@nospecialize(main), @nospecialize(s), @nospecialize(data))
 end
 
 # Make changes to fragment_output to match what's needed for postprocessing
-using ..GLMakie: enable_SSAO
+using ..GLMakie: enable_SSAO, transparency_weight_scale
 
 function output_buffers(transparency = false)
     if transparency
@@ -186,8 +186,9 @@ end
 
 function output_buffer_writes(transparency = false)
     if transparency
+        scale = transparency_weight_scale[]
         """
-        float weight = color.a * max(0.01, 3000 * pow((1 - gl_FragCoord.z), 3));
+        float weight = color.a * max(0.01, $scale * pow((1 - gl_FragCoord.z), 3));
         coverage = color.a;
         fragment_color.rgb = weight * color.rgb;
         fragment_color.a = weight;

--- a/GLMakie/src/gl_backend.jl
+++ b/GLMakie/src/gl_backend.jl
@@ -55,8 +55,14 @@ function get_texture!(atlas)
 end
 
 # TODO
+# find a better way to handle this
+# enable_SSAO and FXAA adjust the rendering pipeline and are currently per screen
 const enable_SSAO = Ref(false)
 const enable_FXAA = Ref(true)
+# This adjusts a factor in the rendering shaders for order independent 
+# transparency. This should be the same for all of them (within one rendering 
+# pipeline) otherwise depth "order" will be broken.
+const transparency_weight_scale = Ref(1000f0)
 
 include("GLVisualize/GLVisualize.jl")
 using .GLVisualize

--- a/docs/documentation/transparency.md
+++ b/docs/documentation/transparency.md
@@ -140,3 +140,10 @@ fig
 \end{examplefigure}
 
 Note that you can mix opaque `transparency = false` plots with transparent OIT plots without problems. So the first issue is not really an issue for truly opaque plots but rather close to opaque plots.
+
+Another problem you may run into is that part of your plot becomes black or white. This is a result of floats becoming infinite during the OIT calculation because of a large number of transparent colors being added close to the camera. You can fix this in two way:
+
+1. Move the `near` clipping plane closer to the camera. For an `ax::LScene` this can be done by adjusting `ax.scene.camera_controls.near[]` closer to 0 and calling `update_cam!(ax.scene, ax.scene.camera_controls)`.
+2. Reducing `GLMakie.transparency_weight_scale[]` which controls the maximum weight given to a transparent color. The default is `1000f0`.
+
+Adjusting the latter may also help with sharpness.

--- a/src/makielayout/layoutables/axis3d.jl
+++ b/src/makielayout/layoutables/axis3d.jl
@@ -220,7 +220,7 @@ function calculate_matrices(limits, px_area, elev, azim, perspectiveness, aspect
 end
 
 function projectionmatrix(viewmatrix, limits, eyepos, radius, azim, elev, angle, width, height, scales, viewmode)
-    near = 1f-2
+    near = 0.01f0
     far = radius + 2 * sqrt(3)
 
     aspect_ratio = width / height

--- a/src/makielayout/layoutables/axis3d.jl
+++ b/src/makielayout/layoutables/axis3d.jl
@@ -220,7 +220,7 @@ function calculate_matrices(limits, px_area, elev, azim, perspectiveness, aspect
 end
 
 function projectionmatrix(viewmatrix, limits, eyepos, radius, azim, elev, angle, width, height, scales, viewmode)
-    near = radius - sqrt(3)
+    near = 1f-2
     far = radius + 2 * sqrt(3)
 
     aspect_ratio = width / height


### PR DESCRIPTION
- add `GLMakie.transparency_weight_scale::Ref{Float32}` to make the scaling factor in the weight function of order independent transparency adjustable. I made this a global constant because it has to be the same for all transparent renders. If it's not the approximate depth order will be wrong.
- reduced default scale from 3000 -> 1000
- adjusted `near` in `Axis3` to be 0.01. This is fine for all `0 <= perspectiveness <= 1` as far as I can tell.