### PR TITLE
Remove redundant imports

### DIFF
--- a/GLMakie/src/GLVisualize/visualize/particles.jl
+++ b/GLMakie/src/GLVisualize/visualize/particles.jl
@@ -43,7 +43,6 @@ function to_mesh(mesh::TOrSignal{<: GeometryBasics.Mesh})
     return NativeMesh(mesh)
 end
 
-using Makie
 using Makie: get_texture_atlas
 
 vec2quaternion(rotation::StaticVector{4}) = rotation

--- a/RPRMakie/src/meshes.jl
+++ b/RPRMakie/src/meshes.jl
@@ -144,8 +144,6 @@ function to_rpr_object(context, matsys, scene, plot::Makie.Surface)
     return rpr_mesh
 end
 
-using FileIO
-
 @recipe(Matball, material) do scene
     return Attributes(
         base = Makie.automatic,

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -1,4 +1,3 @@
-using Colors
 using ShaderAbstractions: InstancedProgram, Program
 using Makie: Key, plotkey
 using Colors: N0f8

--- a/src/interaction/PriorityObservable.jl
+++ b/src/interaction/PriorityObservable.jl
@@ -1,4 +1,3 @@
-using Observables
 using Observables: AbstractObservable, ObserverFunction, notify
 import Observables: observe, listeners, on, off, notify
 

--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -8,8 +8,6 @@ function convert_arguments(P::Type{<:AbstractPlot}, h::StatsBase.Histogram{<:Any
 end
 
 
-import StatsBase
-
 """
     hist(values; bins = 15, normalization = :none)
 

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -1,4 +1,3 @@
-using Serialization
 using FreeTypeAbstraction: iter_or_array
 
 mutable struct TextureAtlas


### PR DESCRIPTION
Removes a bunch of imports that are already imported elsewhere.

Some other things we may want to remove/clean up
- src/scene.jl (testing file?)
- src/utilities/quaternions.jl (not used anymore?)
- GLMakie/src/experiments (testing?)
- src/jl_rasterizer (WIP?)

See also #1511