### PR TITLE
Fix occasional long ticks

### DIFF
--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -115,8 +115,8 @@ function default_ticks(
     )
     # scale the limits
     scaled_ticks, mini, maxi = optimize_ticks(
-        scale_func(lmin),
-        scale_func(lmax);
+        Float64(scale_func(lmin)),
+        Float64(scale_func(lmax));
         k_min = 4, # minimum number of ticks
         k_max = 8, # maximum number of ticks
     )
@@ -128,8 +128,8 @@ function default_ticks(
         lmin::Number, lmax::Number, ticks::Integer, scale_func = identity
     )
     scaled_ticks, mini, maxi = optimize_ticks(
-        scale_func(lmin),
-        scale_func(lmax);
+        Float64(scale_func(lmin)),
+        Float64(scale_func(lmax));
         k_min = ticks, # minimum number of ticks
         k_max = ticks, # maximum number of ticks
         k_ideal = ticks,

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -18,7 +18,7 @@ get_tickvalues(ticks::WilkinsonTicks, vmin, vmax) = get_tickvalues(ticks, Float6
 
 function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
 
-    tickvalues, _ = PlotUtils.optimize_ticks(vmin, vmax;
+    tickvalues, _ = PlotUtils.optimize_ticks(Float64(vmin), Float64(vmax);
         extend_ticks = false, strict_span=true, span_buffer = nothing,
         k_min = ticks.k_min,
         k_max = ticks.k_max,


### PR DESCRIPTION
I didn't look into the details, but I think `optimize_ticks` used to convert any input to Float64 when calculating ticks. This was changed in https://github.com/JuliaPlots/PlotUtils.jl/pull/124 so a Float32 input now results in Float32 ticks. Occasionally ticks are off by a bit, e.g. 
```julia
ticks = PlotUtils.optimize_ticks(0.25314125f0, 0.94421935f0, k_min = 4, k_max = 8)[1]
# Float32[0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.90000004]
```
This also happened before, but on the Float64 level. 

Showoff.jl ignored the single bit differences in Float64, but not in Float32, so now we get long tick labels:
```julia
Showoff.showoff(Float32[0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.90000004], :plain)
# ["0.30000001", "0.40000001", "0.50000000", "0.60000002", "0.69999999", "0.80000001", "0.90000004"]
```
See https://github.com/JuliaGraphics/Showoff.jl/issues/44

As a quick fix converting our ticks to Float64 before passing them should work.

Example from CI in #1512: (This is short_test_67.png)
![short_tests_67](https://user-images.githubusercontent.com/10947937/146075292-64c99642-1ebf-4a1a-8e98-32f83f3c4c0d.png)
 