### PR TITLE
use mask for fxaa, instead of separate rendering pass

### DIFF
--- a/GLMakie/assets/shader/fragment_output.frag
+++ b/GLMakie/assets/shader/fragment_output.frag
@@ -5,7 +5,7 @@ layout(location=1) out uvec2 fragment_groupid;
 {{buffers}}
 // resolves to:
 // // if transparency == true
-// layout(location=2) out float coverage; 
+// layout(location=2) out float coverage;
 
 // // if transparency == false && enable_SSAO[] = true
 // layout(location=2) out vec3 fragment_position;
@@ -15,13 +15,19 @@ layout(location=1) out uvec2 fragment_groupid;
 in vec3 o_view_pos;
 in vec3 o_normal;
 
+uniform bool fxaa;
+
 void write2framebuffer(vec4 color, uvec2 id){
     if(color.a <= 0.0)
         discard;
 
     // For plot/sprite picking
-    fragment_groupid = id;
-    
+    if (fxaa) {
+        fragment_groupid = uvec2(0, id.y);
+    } else {
+        fragment_groupid = id;
+    }
+
     {{buffer_writes}}
     // resolves to:
 

--- a/GLMakie/assets/shader/fragment_output.frag
+++ b/GLMakie/assets/shader/fragment_output.frag
@@ -15,18 +15,12 @@ layout(location=1) out uvec2 fragment_groupid;
 in vec3 o_view_pos;
 in vec3 o_normal;
 
-uniform bool fxaa;
-
 void write2framebuffer(vec4 color, uvec2 id){
     if(color.a <= 0.0)
         discard;
 
     // For plot/sprite picking
-    if (fxaa) {
-        fragment_groupid = uvec2(0, id.y);
-    } else {
-        fragment_groupid = id;
-    }
+    fragment_groupid = id;
 
     {{buffer_writes}}
     // resolves to:

--- a/GLMakie/assets/shader/postprocessing/postprocess.frag
+++ b/GLMakie/assets/shader/postprocessing/postprocess.frag
@@ -3,12 +3,13 @@
 in vec2 frag_uv;
 
 uniform sampler2D color_texture;
+uniform usampler2D object_ids;
 
 layout(location=0) out vec4 fragment_color;
 
 vec3 linear_tone_mapping(vec3 color, float gamma)
 {
-    color = clamp(color, 0., 1.);
+    color = clamp(color, 0.0, 1.0);
     color = pow(color, vec3(1. / gamma));
     return color;
 }
@@ -19,9 +20,14 @@ void main(void)
     if(color.a <= 0){
         discard;
     }
-    // do tonemapping
+    uvec2 ids = texture(object_ids, frag_uv).xy;
+    // do tonemappings
     //opaque = linear_tone_mapping(color.rgb, 1.8);  // linear color output
     fragment_color.rgb = color.rgb;
     // save luma in alpha for FXAA
-    fragment_color.a = dot(color.rgb, vec3(0.299, 0.587, 0.114)); // compute luma
+    if (ids.x != uint(0)) {
+        fragment_color.a = 1.0;
+    } else {
+        fragment_color.a = dot(color.rgb, vec3(0.299, 0.587, 0.114)); // compute luma
+    }
 }

--- a/GLMakie/assets/shader/postprocessing/postprocess.frag
+++ b/GLMakie/assets/shader/postprocessing/postprocess.frag
@@ -34,6 +34,7 @@ void main(void)
     if (unpack_bool(id)) {
         fragment_color.a = dot(color.rgb, vec3(0.299, 0.587, 0.114)); // compute luma
     } else {
+        // we disable fxaa by setting luma to 1
         fragment_color.a = 1.0;
     }
 }

--- a/GLMakie/assets/shader/postprocessing/postprocess.frag
+++ b/GLMakie/assets/shader/postprocessing/postprocess.frag
@@ -14,20 +14,26 @@ vec3 linear_tone_mapping(vec3 color, float gamma)
     return color;
 }
 
+bool unpack_bool(uint id) {
+    uint high_bit_mask = uint(1) << uint(31);
+    return id >= high_bit_mask;
+}
+
 void main(void)
 {
     vec4 color = texture(color_texture, frag_uv).rgba;
     if(color.a <= 0){
         discard;
     }
-    uvec2 ids = texture(object_ids, frag_uv).xy;
+
+    uint id = texture(object_ids, frag_uv).x;
     // do tonemappings
     //opaque = linear_tone_mapping(color.rgb, 1.8);  // linear color output
     fragment_color.rgb = color.rgb;
-    // save luma in alpha for FXAA
-    if (ids.x != uint(0)) {
-        fragment_color.a = 1.0;
-    } else {
+    // we store fxaa = true/false in highbit of the object id
+    if (unpack_bool(id)) {
         fragment_color.a = dot(color.rgb, vec3(0.299, 0.587, 0.114)); // compute luma
+    } else {
+        fragment_color.a = 1.0;
     }
 }

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -91,7 +91,7 @@ function render(vao::GLVertexArray{T}, mode::GLenum=GL_TRIANGLES) where T <: Vec
 end
 
 function render(vao::GLVertexArray{T}, mode::GLenum=GL_TRIANGLES) where T <: TOrSignal{UnitRange{Int}}
-    r = to_value(vao.indices)  
+    r = to_value(vao.indices)
     offset = first(r) - 1 # 1 based -> 0 based
     ndraw = length(r)
     nverts = length(vao)

--- a/GLMakie/src/GLAbstraction/GLRenderObject.jl
+++ b/GLMakie/src/GLAbstraction/GLRenderObject.jl
@@ -11,20 +11,16 @@ function Base.show(io::IO, obj::RenderObject)
 end
 
 
-Base.getindex(obj::RenderObject, symbol::Symbol)         = obj.uniforms[symbol]
+Base.getindex(obj::RenderObject, symbol::Symbol) = obj.uniforms[symbol]
 Base.setindex!(obj::RenderObject, value, symbol::Symbol) = obj.uniforms[symbol] = value
 
-Base.getindex(obj::RenderObject, symbol::Symbol, x::Function)     = getindex(obj, Val(symbol), x)
-Base.getindex(obj::RenderObject, ::Val{:prerender}, x::Function)  = obj.prerenderfunctions[x]
+Base.getindex(obj::RenderObject, symbol::Symbol, x::Function) = getindex(obj, Val(symbol), x)
+Base.getindex(obj::RenderObject, ::Val{:prerender}, x::Function) = obj.prerenderfunctions[x]
 Base.getindex(obj::RenderObject, ::Val{:postrender}, x::Function) = obj.postrenderfunctions[x]
 
 Base.setindex!(obj::RenderObject, value, symbol::Symbol, x::Function)     = setindex!(obj, value, Val(symbol), x)
 Base.setindex!(obj::RenderObject, value, ::Val{:prerender}, x::Function)  = obj.prerenderfunctions[x] = value
 Base.setindex!(obj::RenderObject, value, ::Val{:postrender}, x::Function) = obj.postrenderfunctions[x] = value
-
-const empty_signal = Observable(false)
-post_empty() = push!(empty_signal, false)
-
 
 """
 Represents standard sets of function applied before rendering
@@ -58,10 +54,10 @@ function (sp::StandardPrerender)()
         # buffer 0 contains weight * color.rgba, should do sum
         # destination <- 1 * source + 1 * destination
         glBlendFunci(0, GL_ONE, GL_ONE)
-        
+
         # buffer 1 is objectid, do nothing
         glDisablei(1, GL_BLEND)
-        
+
         # buffer 2 is color.a, should do product
         # destination <- 0 * source + (1 - source) * destination
         glBlendFunci(2, GL_ZERO, GL_ONE_MINUS_SRC_COLOR)
@@ -76,22 +72,25 @@ struct StandardPostrender
     vao::GLVertexArray
     primitive::GLenum
 end
+
 function (sp::StandardPostrender)()
     render(sp.vao, sp.primitive)
 end
+
 struct StandardPostrenderInstanced{T}
     main::T
     vao::GLVertexArray
     primitive::GLenum
 end
+
 function (sp::StandardPostrenderInstanced)()
     renderinstanced(sp.vao, to_value(sp.main), sp.primitive)
 end
 
-struct EmptyPrerender
-end
-function (sp::EmptyPrerender)()
-end
+struct EmptyPrerender end
+
+(sp::EmptyPrerender)() = nothing
+
 export EmptyPrerender
 export prerendertype
 

--- a/GLMakie/src/GLAbstraction/GLShader.jl
+++ b/GLMakie/src/GLAbstraction/GLShader.jl
@@ -74,7 +74,6 @@ function uniformlocations(nametypedict::Dict{Symbol, GLenum}, program)
     texturetarget = -1 # start -1, as texture samplers start at 0
     for (name, typ) in nametypedict
         loc = get_uniform_location(program, name)
-        str_name = string(name)
         if istexturesampler(typ)
             texturetarget += 1
             result[name] = (loc, texturetarget)

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -289,7 +289,7 @@ mutable struct RenderObject{Pre}
     prerenderfunction::Pre
     postrenderfunction
     id::UInt32
-    boundingbox          # workaround for having lazy boundingbox queries, while not using multiple dispatch for boundingbox function (No type hierarchy for RenderObjects)
+    boundingbox # TODO, remove, basicaly deprecated
     function RenderObject{Pre}(
             main, uniforms::Dict{Symbol,Any}, vertexarray::GLVertexArray,
             prerenderfunctions, postrenderfunctions,
@@ -297,6 +297,11 @@ mutable struct RenderObject{Pre}
         ) where Pre
         fxaa = to_value(pop!(uniforms, :fxaa, true))
         RENDER_OBJECT_ID_COUNTER[] += one(UInt32)
+        # Store fxaa in ID, so we can access it in the shader to create a mask
+        # for the fxaa render pass
+        # In theory, we need to unpack the id again as well,
+        # But with this implementation, the fxaa flag can't be changed,
+        # and since this is a UUID, it shouldn't matter
         id = pack_bool(RENDER_OBJECT_ID_COUNTER[], fxaa)
         new(
             main, uniforms, vertexarray,

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -204,7 +204,7 @@ function draw_atomic(screen::GLScreen, scene::Scene, @nospecialize(x::Union{Scat
 
         if marker[] isa FastPixel
             filter!(gl_attributes) do (k, v,)
-                k in (:color_map, :color, :color_norm, :scale, :fxaa, :model)
+                k in (:color_map, :color, :color_norm, :scale, :model)
             end
             if !(gl_attributes[:color][] isa AbstractVector{<: Number})
                 delete!(gl_attributes, :color_norm)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -41,7 +41,7 @@ function OIT_postprocessor(framebuffer)
         :prod_alpha => framebuffer[:OIT_weight][2],
     )
     pass = RenderObject(
-        data, shader, 
+        data, shader,
         () -> begin
             glDepthMask(GL_TRUE)
             glDisable(GL_DEPTH_TEST)
@@ -54,7 +54,7 @@ function OIT_postprocessor(framebuffer)
             # opaque.rgb = 1 * src.rgb + src.a * opaque.rgb
             # opaque.a   = 0 * src.a   + 1 * opaque.a
             glBlendFuncSeparate(GL_ONE, GL_SRC_ALPHA, GL_ZERO, GL_ONE)
-        end, 
+        end,
         nothing
     )
     pass.postrenderfunction = () -> draw_fullscreen(pass.vertexarray.id)
@@ -150,7 +150,7 @@ function ssao_postprocessor(framebuffer)
     pass2 = RenderObject(data2, shader2, PostprocessPrerender(), nothing)
     pass2.postrenderfunction = () -> draw_fullscreen(pass2.vertexarray.id)
     color_id = framebuffer[:color][1]
-  
+
     full_render = screen -> begin
         fb = screen.framebuffer
         w, h = size(fb)
@@ -219,7 +219,8 @@ function fxaa_postprocessor(framebuffer)
         loadshader("postprocessing/postprocess.frag")
     )
     data1 = Dict{Symbol, Any}(
-        :color_texture => framebuffer[:color][2]
+        :color_texture => framebuffer[:color][2],
+        :object_ids => framebuffer[:objectid][2]
     )
     pass1 = RenderObject(data1, shader1, PostprocessPrerender(), nothing)
     pass1.postrenderfunction = () -> draw_fullscreen(pass1.vertexarray.id)

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -157,7 +157,7 @@ function render_frame(screen::Screen; resize_buffers=true)
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
     glStencilMask(0x00)
-    GLAbstraction.render(screen, false, true, true)
+    GLAbstraction.render(screen, false, true)
 
     # SSAO
     screen.postprocessors[1].render(screen)
@@ -167,7 +167,7 @@ function render_frame(screen::Screen; resize_buffers=true)
     glEnable(GL_STENCIL_TEST)
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
     glStencilMask(0x00)
-    GLAbstraction.render(screen, false, true, false)
+    GLAbstraction.render(screen, false, false)
     glDisable(GL_STENCIL_TEST)
 
 
@@ -185,10 +185,8 @@ function render_frame(screen::Screen; resize_buffers=true)
     glEnable(GL_STENCIL_TEST)
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
     glStencilMask(0x00)
-    GLAbstraction.render(screen, true, true, true)
-    GLAbstraction.render(screen, true, true, false)
-    GLAbstraction.render(screen, true, false, true)
-    GLAbstraction.render(screen, true, false, false)
+    GLAbstraction.render(screen, true, true)
+    GLAbstraction.render(screen, true, false)
     glDisable(GL_STENCIL_TEST)
 
     # TRANSPARENT BLEND
@@ -197,18 +195,8 @@ function render_frame(screen::Screen; resize_buffers=true)
     # FXAA
     screen.postprocessors[3].render(screen)
 
-    # no FXAA primary render
-    glDrawBuffers(2, [GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1])
-    glEnable(GL_STENCIL_TEST)
-    glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
-    glStencilMask(0x00)
-    GLAbstraction.render(screen, false, false, true)
-    GLAbstraction.render(screen, false, false, false)
-    glDisable(GL_STENCIL_TEST)
-
     # transfer everything to the screen
     screen.postprocessors[4].render(screen)
-
 
     return
 end
@@ -221,14 +209,13 @@ function id2scene(screen, id1)
     return false, nothing
 end
 
-function GLAbstraction.render(screen::GLScreen, transparent::Bool, fxaa::Bool, ssao::Bool)
+function GLAbstraction.render(screen::GLScreen, transparent::Bool, ssao::Bool)
     # Somehow errors in here get ignored silently!?
     try
         # sort by overdraw, so that overdrawing objects get drawn last!
         # sort!(screen.renderlist, by = ((zi, id, robj),)-> robj.prerenderfunction.overdraw[])
         for (zindex, screenid, elem) in screen.renderlist
-            if !((elem[:transparency][] == transparent) &&
-                (elem[:fxaa][] == fxaa) && (elem[:ssao][] == ssao))
+            if !((elem[:transparency][] == transparent) && (elem[:ssao][] == ssao))
                 continue
             end
 

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -493,8 +493,7 @@ function Makie.pick_closest(scene::SceneLike, screen::Screen, xy, range)
     x, y =  xy .+ 1 .- Vec2f(x0, y0)
     for i in 1:dx, j in 1:dy
         d = (x-i)^2 + (y-j)^2
-        if (d < min_dist) && (sid[i, j][1] > 0x00000000) &&
-            (sid[i, j][2] < 0x3f800000) && haskey(screen.cache2plot, sid[i, j][1])
+        if (d < min_dist) && (sid[i, j][1] > 0) && haskey(screen.cache2plot, sid[i, j][1])
             min_dist = d
             id = convert(SelectionID{Int}, sid[i, j])
         end


### PR DESCRIPTION
fixes transparency issues, where objects with `fxaa=false` would draw over `transparency=true` objects.