### PR TITLE
Some fixes

### DIFF
--- a/GLMakie/assets/shader/volume.frag
+++ b/GLMakie/assets/shader/volume.frag
@@ -316,6 +316,8 @@ float min_bigger_0(vec3 v1, vec3 v2){
 
 void main()
 {
+    {{depth_default}}
+    // may write: gl_FragDepth = gl_FragCoord.z;
     vec4 color;
     vec3 eye_unit = vec3(modelinv * vec4(eyeposition, 1));
     vec3 back_position = vec3(modelinv * vec4(frag_vert, 1));

--- a/GLMakie/src/GLVisualize/visualize/image_like.jl
+++ b/GLMakie/src/GLVisualize/visualize/image_like.jl
@@ -114,6 +114,7 @@ function _default(main::VolumeTypes{T}, s::Style, data::Dict) where T <: VolumeE
             "fragment_output.frag", "util.vert", "volume.vert", "volume.frag",
             view = Dict(
                 "depth_init"  => vol_depth_init(to_value(enable_depth)),
+                "depth_default"  => vol_depth_default(to_value(enable_depth)),
                 "depth_main"  => vol_depth_main(to_value(enable_depth)),
                 "depth_write" => vol_depth_write(to_value(enable_depth)),
                 "buffers" => output_buffers(to_value(transparency)),
@@ -127,6 +128,7 @@ function _default(main::VolumeTypes{T}, s::Style, data::Dict) where T <: VolumeE
 end
 
 vol_depth_init(enable) = enable ? "float depth = 100000.0;" : ""
+vol_depth_default(enable) = enable ? "gl_FragDepth = gl_FragCoord.z;" : ""
 function vol_depth_main(enable)
     if enable
         """

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -69,7 +69,7 @@ function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
 
         # These need explicit clean up because (some of) the source nodes
         # remain whe the plot is deleated.
-        for k in (:lightposition, :normalmatrix)
+        for k in (:normalmatrix, )
             if haskey(renderobject.uniforms, k)
                 n = renderobject.uniforms[k]
                 for input in n.inputs

--- a/src/basic_recipes/volumeslices.jl
+++ b/src/basic_recipes/volumeslices.jl
@@ -35,7 +35,6 @@ function plot!(plot::VolumeSlices)
         mz, Mz = extrema(z)
         Rect3D(mx, my, mz, Mx-mx, My-my, Mz-mz)
     end
-    linesegments!(plot, bbox, color = bbox_color, visible = bbox_visible, inspectable = false)
 
     axes = :x, :y, :z
     for (ax, p, r, (X, Y)) ∈ zip(axes, (:yz, :xz, :xy), (x, y, z), ((y, z), (x, z), (x, y)))
@@ -50,5 +49,8 @@ function plot!(plot::VolumeSlices)
         # Trigger once to place heatmaps correctly
         plot[Symbol(:update_, p)][](1)
     end
+
+    linesegments!(plot, bbox, color = bbox_color, visible = bbox_visible, inspectable = false)
+
     plot
 end


### PR DESCRIPTION
Running the depth_shift example with `DataInspector` shows some problems

- [x] moving the mouse over the mesh spews a bunch of errors (because it tries to cleanup a nonexisting uniform)
- [x] volume plots ignore depth_shift and draw in front of everything (?)
- ~~scatter markers generate large indicators~~ I think this is an old issue

```julia
using GLMakie, Random
RNG = Random
# Up to some artifacts from fxaa the left side should be blue and the right red.
fig = Figure(resolution = (800, 400))

prim = Rect3f(Point3f(0), Vec3f(1))
ps  = RNG.rand(Point3f, 10) .+ Point3f(0, 0, 1)
mat = RNG.rand(4, 4)
A   = RNG.rand(4,4,4)

# This generates two sets of plots each on two axis. Both axes have one set
# without depth_shift (0f0, red) and one at ∓10eps(1f0) (blue, left/right axis).
# A negative shift should push the plot in the foreground, positive in the background.
for (i, _shift) in enumerate((-10eps(1f0), 10eps(1f0)))
    ax = LScene(fig[1, i], scenekw=(show_axis = false,))

    for (color, shift) in zip((:red, :blue), (0f0, _shift))
        mesh!(ax, prim, color = color, depth_shift = shift)
        lines!(ax, ps, color = color, depth_shift = shift)
        linesegments!(ax, ps .+ Point3f(-1, 1, 0), color = color, depth_shift = shift)
        scatter!(ax, ps, color = color, markersize=100, depth_shift = shift)
        text!(ax, "Test", position = Point3f(0, 1, 1.1), color = color, depth_shift = shift)
        surface!(ax, -1..0, 1..2, mat, colormap = (color, color), depth_shift = shift)
        meshscatter!(ax, ps .+ Point3f(-1, 1, 0), color = color, depth_shift = shift)
        # # left side in axis
        heatmap!(ax, 0..1, 0..1, mat, colormap = (color, color), depth_shift = shift)
        # # right side in axis
        image!(ax, -1..0, 1..2, mat, colormap = (color, color), depth_shift = shift)
        p = volume!(ax, A, colormap = (:white, color), depth_shift = shift)
        translate!(p, -1, 0, 0)
        scale!(p, 0.25, 0.25, 0.25)
    end
end

DataInspector(fig)

fig
```

![Screenshot from 2022-01-06 16-57-55](https://user-images.githubusercontent.com/10947937/148411574-558cea6c-d68c-4532-8ab8-99359f00c978.png)

Other fixes:
- [x] adjust render order in volumeslices to make lines render smoothly (from https://makie.juliaplots.org/dev/examples/plotting_functions/volumeslices/ back to https://makie.juliaplots.org/stable/examples/plotting_functions/volumeslices/#example_5203360342513263086)