### PR TITLE
Clarify remote servers page

### DIFF
--- a/docs/documentation/headless.md
+++ b/docs/documentation/headless.md
@@ -1,6 +1,6 @@
-# Remote servers
+# Headless
 
-Makie can be used remotely and it supports working headless systems (such as CI servers).
+Makie can be used on headless systems (such as CI servers).
 This page describes what is required to get different back ends working in headless systems.
 
 ## CairoMakie

--- a/docs/documentation/remote.md
+++ b/docs/documentation/remote.md
@@ -1,6 +1,11 @@
 # Remote servers
 
 Makie can be used remotely and it supports working headless systems (such as CI servers).
+This page describes what is required to get different back ends working in headless systems.
+
+## CairoMakie
+
+For CairoMakie, there shouldn't be any difference in using it on a remote or locally.
 
 ## GLMakie
 
@@ -65,7 +70,3 @@ using JSServe
 
 JSServe.configure_server!(listen_port=8081, forwarded_port=8080)
 ```
-
-## CairoMakie
-
-For CairoMakie there shouldn't be any difference in using it on a remote or locally.


### PR DESCRIPTION
I was going to the "remote servers" page and expected some information about running Makie on a server and that kind of stuff. Instead, it was only about running on headless systems. To make this clearer, I've added one sentence.

Also, I've moved the CairoMakie section up because it makes sense to show the easiest option first. It would be unfortunate if someone goes for a difficult option only to find out later that it could have been much easier.