### PR TITLE
Revert campixel and camrelative to old near/far values

### DIFF
--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -308,7 +308,7 @@ struct PixelCamera <: AbstractCamera end
 
 Creates a pixel-level camera for the `Scene`.  No controls!
 """
-function campixel!(scene; nearclip=-1000f0, farclip=1000f0)
+function campixel!(scene; nearclip=-10_000f0, farclip=10_000f0)
     disconnect!(camera(scene))
     update_once = Observable(false)
     on(camera(scene), update_once, pixelarea(scene)) do u, window_size
@@ -329,7 +329,7 @@ struct RelativeCamera <: AbstractCamera end
 
 Creates a pixel-level camera for the `Scene`.  No controls!
 """
-function cam_relative!(scene; nearclip=-1000f0, farclip=1000f0)
+function cam_relative!(scene; nearclip=-10_000f0, farclip=10_000f0)
     projection = orthographicprojection(0f0, 1f0, 0f0, 1f0, nearclip, farclip)
     set_proj_view!(camera(scene), projection, Mat4f(I))
     cam = RelativeCamera()


### PR DESCRIPTION
Fixes the missing frame (and ticks) in Axis3, e.g. the animation on the front page of the documentation. https://makie.juliaplots.org/dev/

Alternatively we could also adjust

https://github.com/JuliaPlots/Makie.jl/blob/fd54f014fb1c4a3d72a40f1d46b019efa6990404/src/makielayout/layoutables/axis3d.jl#L447-L453

and probably

https://github.com/JuliaPlots/Makie.jl/blob/fd54f014fb1c4a3d72a40f1d46b019efa6990404/src/makielayout/layoutables/axis.jl#L127-L142