### PR TITLE
fix fuzzy contours

### DIFF
--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -92,10 +92,10 @@ function plot!(plot::Contour{<: Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
     cliprange = replace_automatic!(plot, :colorrange) do
         valuerange
     end
-    N = 1024
     cmap = lift(colormap, levels, alpha, cliprange, valuerange) do _cmap, l, alpha, cliprange, vrange
         levels = to_levels(l, vrange)
         nlevels = length(levels)
+        N = 50 * nlevels
 
         iso_eps = if haskey(plot, :isorange)
             plot.isorange[]


### PR DESCRIPTION
This undoes an earlier change from `N = 50 * nlevels` to `N = 1024`. In this example N ends up at `250`. 

```julia
using GLMakie
fig = Figure()
left = LScene(fig[1, 1])
contour!(left, [sin(i+j) * sin(j+k) * sin(i+k) for i in 1:10, j in 1:10, k in 1:10])
right = LScene(fig[1, 2])
contour!(right, [sin(i+j) * sin(j+k) * sin(i+k) for i in 1:10, j in 1:10, k in 1:10], enable_depth = true)
fig
```

On master:
![Screenshot from 2022-01-07 19-44-19](https://user-images.githubusercontent.com/10947937/148654609-3c5f9559-2e74-4b2f-9959-7aae79c11e8e.png)

With the change:
![Screenshot from 2022-01-08 18-57-32](https://user-images.githubusercontent.com/10947937/148654619-b9ee18d6-e8c9-45da-915a-c246cdfa06f9.png)

