### PR TITLE
Fixes to statistical recipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 - add label_rotation to barplot [#1401](https://github.com/JuliaPlots/Makie.jl/pull/1401)
 - fix issue where `pixelcam!` does not remove controls from other cameras [#1504](https://github.com/JuliaPlots/Makie.jl/pull/1504)
 - add conversion for offsetarrays [#1260](https://github.com/JuliaPlots/Makie.jl/pull/1260)
+- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563).
 
 #### All other changes
 Are collected [in this PR](https://github.com/JuliaPlots/Makie.jl/pull/1521) and in the [release notes](https://github.com/JuliaPlots/Makie.jl/releases/tag/v0.16.0).

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 - add label_rotation to barplot [#1401](https://github.com/JuliaPlots/Makie.jl/pull/1401)
 - fix issue where `pixelcam!` does not remove controls from other cameras [#1504](https://github.com/JuliaPlots/Makie.jl/pull/1504)
 - add conversion for offsetarrays [#1260](https://github.com/JuliaPlots/Makie.jl/pull/1260)
-- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563). Fixed numeric error due to double computation of quantiles when fitting `qqline`.
+- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563). Fixed numeric error due to double computation of quantiles when fitting `qqline`. Deprecate `plot(q::QQPair)` method as it does not have enough information for correct `qqline` fit.
 
 #### All other changes
 Are collected [in this PR](https://github.com/JuliaPlots/Makie.jl/pull/1521) and in the [release notes](https://github.com/JuliaPlots/Makie.jl/releases/tag/v0.16.0).

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 - add label_rotation to barplot [#1401](https://github.com/JuliaPlots/Makie.jl/pull/1401)
 - fix issue where `pixelcam!` does not remove controls from other cameras [#1504](https://github.com/JuliaPlots/Makie.jl/pull/1504)
 - add conversion for offsetarrays [#1260](https://github.com/JuliaPlots/Makie.jl/pull/1260)
-- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563).
+- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563).
 
 #### All other changes
 Are collected [in this PR](https://github.com/JuliaPlots/Makie.jl/pull/1521) and in the [release notes](https://github.com/JuliaPlots/Makie.jl/releases/tag/v0.16.0).

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 - add label_rotation to barplot [#1401](https://github.com/JuliaPlots/Makie.jl/pull/1401)
 - fix issue where `pixelcam!` does not remove controls from other cameras [#1504](https://github.com/JuliaPlots/Makie.jl/pull/1504)
 - add conversion for offsetarrays [#1260](https://github.com/JuliaPlots/Makie.jl/pull/1260)
-- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563).
+- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563). Fixed numeric error due to double computation of quantiles when fitting `qqline`.
 
 #### All other changes
 Are collected [in this PR](https://github.com/JuliaPlots/Makie.jl/pull/1521) and in the [release notes](https://github.com/JuliaPlots/Makie.jl/releases/tag/v0.16.0).

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 - add label_rotation to barplot [#1401](https://github.com/JuliaPlots/Makie.jl/pull/1401)
 - fix issue where `pixelcam!` does not remove controls from other cameras [#1504](https://github.com/JuliaPlots/Makie.jl/pull/1504)
 - add conversion for offsetarrays [#1260](https://github.com/JuliaPlots/Makie.jl/pull/1260)
-- `qqplot` `qqline` options are now `:identity`, `:fit`, `:robust` (the default) and `:none` [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563). Fixed numeric error due to double computation of quantiles when fitting `qqline`. Deprecate `plot(q::QQPair)` method as it does not have enough information for correct `qqline` fit.
+- `qqplot` `qqline` options are now `:identity`, `:fit`, `:fitrobust` and `:none` (the default) [#1563](https://github.com/JuliaPlots/Makie.jl/pull/1563). Fixed numeric error due to double computation of quantiles when fitting `qqline`. Deprecated `plot(q::QQPair)` method as it does not have enough information for correct `qqline` fit.
 
 #### All other changes
 Are collected [in this PR](https://github.com/JuliaPlots/Makie.jl/pull/1521) and in the [release notes](https://github.com/JuliaPlots/Makie.jl/releases/tag/v0.16.0).

--- a/docs/examples/plotting_functions/qqplot.md
+++ b/docs/examples/plotting_functions/qqplot.md
@@ -1,6 +1,7 @@
-# qqplot
+# qqplot and qqnorm
 
 {{doc qqplot}}
+{{doc qqnorm}}
 
 ### Examples
 

--- a/docs/examples/plotting_functions/qqplot.md
+++ b/docs/examples/plotting_functions/qqplot.md
@@ -1,0 +1,34 @@
+# qqplot
+
+{{doc qqplot}}
+
+### Examples
+
+Test if `xs` and `ys` follow the same distribution.
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+xs = randn(100)
+ys = randn(100)
+
+qqplot(xs, ys)
+```
+\end{examplefigure}
+
+Test if `ys` is normally distributed.
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+ys = randn(100)
+
+qqnorm(ys)
+```
+\end{examplefigure}

--- a/docs/examples/plotting_functions/qqplot.md
+++ b/docs/examples/plotting_functions/qqplot.md
@@ -16,7 +16,7 @@ Makie.inline!(true) # hide
 xs = randn(100)
 ys = randn(100)
 
-qqplot(xs, ys)
+qqplot(xs, ys, qqline = :identity)
 ```
 \end{examplefigure}
 
@@ -28,8 +28,8 @@ using CairoMakie
 CairoMakie.activate!() # hide
 Makie.inline!(true) # hide
 
-ys = randn(100)
+ys = 2 .* randn(100) .+ 3
 
-qqnorm(ys)
+qqnorm(ys, qqline = :fitrobust)
 ```
 \end{examplefigure}

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -26,6 +26,33 @@ end
 # -----------------------------------------------------------------------------
 # qqplots (M. K. Borregaard implementation from StatPlots)
 
+"""
+    qqplot(x, y; kwargs...)
+Draw a Q-Q plot, comparing quantiles of two distributions. `y` must be a list of
+samples, i.e., `AbstractVector{<:Real}`, whereas `x` can be
+- a list of samples,
+- an abstract distribution, e.g. `Normal(0, 1)`,
+- a distribution type, e.g. `Normal`.
+In the last case, the Q-Q plot by fitting that distribution type to the data `y`.
+
+The attribute `qqline` determines how to compute a fit line for the Q-Q plot.
+Possible values are the following.
+- `:identity` draws the identity line (useful to see if the two distributions are the same).
+- `:fit` fits the line to the quantile pairs (useful to see if one distribution can be obtained for the other via an affine transformation).
+- `:quantile` is analogous to `:fit` but uses a quantile-based fitting method.
+- `:R` is an alias for `:quantile`, as that is the default behavior in `:R`.
+- `:none` (or any other value) omits drawing the line.
+
+Graphical attributes are
+- `color` to control color of both line and markers
+- `linestyle`
+- `linewidth`
+- `markercolor`
+- `strokecolor`
+- `strokewidth`
+- `marker`
+- `markersize`
+"""
 @recipe(QQPlot) do scene
     s_theme = default_theme(scene, Scatter)
     l_theme = default_theme(scene, Lines)
@@ -43,6 +70,11 @@ end
     )
 end
 
+"""
+    qqnorm(y; kwargs...)
+
+Shorthand for `qqplot(Normal, y)`. See [`qqplot`](@ref) for more details.
+"""
 @recipe(QQNorm) do scene
     default_theme(scene, QQPlot)
 end

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -88,11 +88,11 @@ function fit_qqline(h::QQPair; qqline = :robust)
         ys = xs
     elseif qqline == :fit
         itc, slp = hcat(fill!(similar(h.qx), 1), h.qx) \ h.qy
-        ys = slp .* xs .+ itc
+        ys = @. slp * xs + itc
     else # if qqline == :robust
         quantx, quanty = quantile(h.qx, [0.25, 0.75]), quantile(h.qy, [0.25, 0.75])
-        slp = diff(quanty) ./ diff(quantx)
-        ys = quanty .+ slp .* (xs .- quantx)
+        slp = (quanty[2] - quanty[1]) / (quantx[2] - quantx[1])
+        ys = @. quanty + slp * (xs - quantx)
     end
     return Point2f.(xs, ys)
 end

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -75,7 +75,8 @@ end
 """
     qqnorm(y; kwargs...)
 
-Shorthand for `qqplot(Normal(0,1), y)`. See `qqplot` for more details.
+Shorthand for `qqplot(Normal(0,1), y)`, i.e., draw a Q-Q plot of `y` against the
+standard normal distribution. See `qqplot` for more details.
 """
 @recipe(QQNorm) do scene
     default_theme(scene, QQPlot)
@@ -115,7 +116,6 @@ convert_arguments(::Type{<:QQNorm}, y; qqline = :robust) =
 
 used_attributes(::Type{<:QQNorm}, y) = (:qqline,)
 used_attributes(::Type{<:QQPlot}, x, y) = (:qqline,)
-used_attributes(::PlotFunc, ::QQPair) = (:qqline,)
 
 function plot!(p::QQPlot)
     points, line = p[1], p[2]

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -85,8 +85,8 @@ end
 # Compute points and line for the qqplot
 function fit_qqplot(x, y; qqline = :none)
     if !(qqline in (:identity, :fit, :fitrobust, :none))
-        msg = "valid values for qqline are :identity, :fit, :fitrobust or :none, \
-            encountered $(repr(qqline))"
+        msg = "valid values for qqline are :identity, :fit, :fitrobust or :none, " *
+            "encountered " * repr(qqline)
         throw(ArgumentError(msg))
     end
     h = qqbuild(x, y)

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -35,14 +35,14 @@ samples, i.e., `AbstractVector{<:Real}`, whereas `x` can be
 - a distribution type, e.g. `Normal`.
 In the last case, the distribution type is fitted to the data `y`.
 
-The attribute `qqline` (defaults to `:robust`) determines how to compute a fit line for the Q-Q plot.
+The attribute `qqline` (defaults to `:none`) determines how to compute a fit line for the Q-Q plot.
 Possible values are the following.
 - `:identity` draws the identity line.
 - `:fit` computes a least squares line fit of the quantile pairs.
-- `:robust` computes the line that passes through the first and third quartiles of the distributions.
-- `:none` (or any other value) omits drawing the line.
+- `:fitrobust` computes the line that passes through the first and third quartiles of the distributions.
+- `:none` omits drawing the line.
 Broadly speaking, `qqline = :identity` is useful to see if `x` and `y` follow the same distribution,
-whereas `qqline = :fit` and `qqline = :robust` are useful to see if the distribution of `y` can be
+whereas `qqline = :fit` and `qqline = :fitrobust` are useful to see if the distribution of `y` can be
 obtained from the distribution of `x` via an affine transformation.
 
 Graphical attributes are
@@ -83,17 +83,22 @@ standard normal distribution. See `qqplot` for more details.
 end
 
 # Compute points and line for the qqplot
-function fit_qqplot(x, y; qqline = :robust)
+function fit_qqplot(x, y; qqline = :none)
+    if !(qqline in (:identity, :fit, :fitrobust, :none))
+        msg = "valid values for qqline are :identity, :fit, :fitrobust or :none, \
+            encountered $(repr(qqline))"
+        throw(ArgumentError(msg))
+    end
     h = qqbuild(x, y)
     points = Point2f.(h.qx, h.qy)
-    qqline in (:identity, :fit, :robust) || return points, Point2f[]
+    qqline == :none && return points, Point2f[]
     xs = collect(extrema(h.qx))
     if qqline == :identity
         ys = xs
     elseif qqline == :fit
         itc, slp = hcat(fill!(similar(h.qx), 1), h.qx) \ h.qy
         ys = @. slp * xs + itc
-    else # if qqline == :robust
+    else # if qqline == :fitrobust
         quantx, quanty = quantile(x, [0.25, 0.75]), quantile(y, [0.25, 0.75])
         slp = (quanty[2] - quanty[1]) / (quantx[2] - quantx[1])
         ys = @. quanty + slp * (xs - quantx)
@@ -105,13 +110,13 @@ end
 maybefit(D::Type{<:Distribution}, y) = Distributions.fit(D, y)
 maybefit(x, _) = x
 
-function convert_arguments(::Type{<:QQPlot}, x′, y; qqline = :robust)
+function convert_arguments(::Type{<:QQPlot}, x′, y; qqline = :none)
     x = maybefit(x′, y)
     points, line = fit_qqplot(x, y; qqline = qqline)
     return PlotSpec{QQPlot}(points, line)
 end
 
-convert_arguments(::Type{<:QQNorm}, y; qqline = :robust) =
+convert_arguments(::Type{<:QQNorm}, y; qqline = :none) =
     convert_arguments(QQPlot, Distributions.Normal(0, 1), y; qqline = qqline)
 
 used_attributes(::Type{<:QQNorm}, y) = (:qqline,)

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -35,10 +35,10 @@ samples, i.e., `AbstractVector{<:Real}`, whereas `x` can be
 - a distribution type, e.g. `Normal`.
 In the last case, the Q-Q plot by fitting that distribution type to the data `y`.
 
-The attribute `qqline` determines how to compute a fit line for the Q-Q plot.
+The attribute `qqline` (defaults to `:R`) determines how to compute a fit line for the Q-Q plot.
 Possible values are the following.
-- `:identity` draws the identity line (useful to see if the two distributions are the same).
-- `:fit` fits the line to the quantile pairs (useful to see if one distribution can be obtained for the other via an affine transformation).
+- `:identity` draws the identity line (useful to see `x` and `y` follow the same distribution).
+- `:fit` fits the line to the quantile pairs (useful to see if the distribution of `y` can be obtained from the distribution of `x` via an affine transformation).
 - `:quantile` is analogous to `:fit` but uses a quantile-based fitting method.
 - `:R` is an alias for `:quantile`, as that is the default behavior in `:R`.
 - `:none` (or any other value) omits drawing the line.
@@ -79,7 +79,7 @@ Shorthand for `qqplot(Normal, y)`. See [`qqplot`](@ref) for more details.
     default_theme(scene, QQPlot)
 end
 
-function fit_qqline(h::QQPair; qqline = :identity)
+function fit_qqline(h::QQPair; qqline = :R)
     if qqline in (:fit, :quantile, :identity, :R)
         xs = [extrema(h.qx)...]
         if qqline == :identity
@@ -98,20 +98,20 @@ function fit_qqline(h::QQPair; qqline = :identity)
     end
 end
 
-loc(D::Type{T}, x) where T <: Distribution = Distributions.fit(D, x), x
+loc(D::Type{<:Distribution}, x) = Distributions.fit(D, x), x
 loc(D, x) = D, x
 
-function convert_arguments(::Type{<:QQPlot}, x, y; qqline = :identity)
+function convert_arguments(::Type{<:QQPlot}, x, y; qqline = :R)
     h = qqbuild(loc(x, y)...)
     points = Point2f.(h.qx, h.qy)
     line = fit_qqline(h; qqline = qqline)
     return PlotSpec{QQPlot}(points, line)
 end
 
-convert_arguments(::Type{<:QQNorm}, y; qqline = :identity) =
+convert_arguments(::Type{<:QQNorm}, y; qqline = :R) =
     convert_arguments(QQPlot, Distributions.Normal(0, 1), y; qqline = qqline)
 
-convert_arguments(::PlotFunc, h::QQPair; qqline = :identity) =
+convert_arguments(::PlotFunc, h::QQPair; qqline = :R) =
     convert_arguments(QQPlot, h.qx, h.qy; qqline = qqline)
 
 used_attributes(::Type{<:QQNorm}, y) = (:qqline,)

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -75,7 +75,7 @@ end
 """
     qqnorm(y; kwargs...)
 
-Shorthand for `qqplot(Normal, y)`. See `qqplot` for more details.
+Shorthand for `qqplot(Normal(0,1), y)`. See `qqplot` for more details.
 """
 @recipe(QQNorm) do scene
     default_theme(scene, QQPlot)

--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -3,7 +3,7 @@ const histogram_plot_types = [BarPlot, Heatmap, Volume]
 function convert_arguments(P::Type{<:AbstractPlot}, h::StatsBase.Histogram{<:Any, N}) where N
     ptype = plottype(P, histogram_plot_types[N])
     f(edges) = edges[1:end-1] .+ diff(edges)./2
-    kwargs = N == 1 ? (; width = step(h.edges[1])) : NamedTuple()
+    kwargs = N == 1 ? (; width = step(h.edges[1]), gap = 0, dodge_gap = 0) : NamedTuple()
     to_plotspec(ptype, convert_arguments(ptype, map(f, h.edges)..., Float64.(h.weights)); kwargs...)
 end
 


### PR DESCRIPTION
# Description

Fixes `qqnorm`, `qqplot`, which were broken as they were converted to an odd `Scatter` plot type and that broke with the new internals. They now have a more sensible "standard" implementation as a new plot type.

It also fixed plotting `StatsBase.Histogram` objects. They accidentally ended up having a gap between bars after ,#1223.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added or changed relevant sections in the documentation

I have not added tests as it seems tests exist already (see https://github.com/JuliaPlots/Makie.jl/blob/master/test/statistical_tests.jl) but somehow they stopped being run. It is probably best to update those in a separate PR (it seems all of them need fixing, due to changes in the internals).