### PR TITLE
add colorrange to error bars

### DIFF
--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -25,6 +25,7 @@ $(ATTRIBUTES)
         direction = :y,
         visible = theme(scene, :visible),
         colormap = theme(scene, :colormap),
+        colorrange = automatic,
         inspectable = theme(scene, :inspectable),
         transparency = false
     )
@@ -52,6 +53,7 @@ $(ATTRIBUTES)
         direction = :y,
         visible = theme(scene, :visible),
         colormap = theme(scene, :colormap),
+        colorrange = automatic,
         inspectable = theme(scene, :inspectable),
         transparency = false
     )
@@ -183,7 +185,7 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
 
     f_if(condition, f, arg) = condition ? f(arg) : arg
 
-    @extract plot (whiskerwidth, color, linewidth, visible, colormap, inspectable, transparency)
+    @extract plot (whiskerwidth, color, linewidth, visible, colormap, colorrange, inspectable, transparency)
 
     scene = parent_scene(plot)
 
@@ -223,12 +225,13 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
 
     linesegments!(
         plot, linesegpairs, color = color, linewidth = linewidth, visible = visible,
-        colormap = colormap, inspectable = inspectable, transparency = transparency
+        colormap = colormap, colorrange = colorrange, inspectable = inspectable,
+        transparency = transparency
     )
     linesegments!(
         plot, whiskers, color = whiskercolors, linewidth = whiskerlinewidths,
-        visible = visible, colormap = colormap, inspectable = inspectable, 
-        transparency = transparency
+        visible = visible, colormap = colormap, colorrange = colorrange,
+        inspectable = inspectable, transparency = transparency
     )
     plot
 end


### PR DESCRIPTION
# Description

Fixes https://github.com/JuliaPlots/AlgebraOfGraphics.jl/issues/288

Error bars and range bars had `colormap` in their theme, but did not have `colorrange`, so they silently ignored a user-passed `colorrange`, causing e.g. https://github.com/JuliaPlots/AlgebraOfGraphics.jl/issues/288. Now `colorrange` is also part of the theme and is forwarded to the `LineSegments` plot.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
