### PR TITLE
fix autolimits for linked axis

### DIFF
--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -834,7 +834,8 @@ function autolimits(ax::Axis, dim::Integer)
     # try getting x limits for the axis and then union them with linked axes
     lims = getlimits(ax, dim)
 
-    for link in ax.xaxislinks
+    links = dim == 1 ? ax.xaxislinks : ax.yaxislinks
+    for link in links
         if isnothing(lims)
             lims = getlimits(link, dim)
         else


### PR DESCRIPTION
# Description

Fixes a problem with `autolimits` for linked axes.
Before `autolimits` only checked for linked x-axes, even if dim=2. This probably has many side effects. For me it produces an error, when `autolimits` is called for an axis with `yscale=log10` which has an linked x-dimension to another axis with negative y-limits.
The intendend behaviour is probably to check for linked x-axes if dim=1 and for linked y-axes if dim=2. This is now implemented in the PR.



## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)


