### PR TITLE
fix iswhitespace(l::LaTeXString)

### DIFF
--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -249,4 +249,4 @@ function texelems_and_glyph_collection(str::LaTeXString, fontscale_px, halign, v
     all_els, pre_align_gl, Point2f(xshift, yshift)
 end
 
-MakieLayout.iswhitespace(l::LaTeXString) = MakieLayout.iswhitespace(l.s[2:end-1])
+MakieLayout.iswhitespace(l::LaTeXString) = MakieLayout.iswhitespace(replace(l.s, '$' => ""))


### PR DESCRIPTION
# Description

Fixes #1315

Probably the intention behind `l.s[2:end-1]` in `iswhitespace(l::LaTeXStrings)` is to remove the `$`. This does not work for mixed LaTeX and normal text (like `L"$j$ (A/m²)"`). If there is any Unicode near the edges of the string as its the case in the previous example or the linked issue, this even produces an error.

In the PR the `$` are removed from the string, even if they are not at indices `1` or `end`.
This also detects LaTeXStrings like `l=L"   $ $   "` as white space.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
