### PR TITLE
Font caching info message fix

### DIFF
--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -115,7 +115,7 @@ begin
             end
         end
         atlas = TextureAtlas()
-        @info("Makie/Makie is caching fonts, this may take a while. Needed only on first run!")
+        @info("Makie is caching fonts, this may take a while. Needed only on first run!")
         load_ascii_chars!(atlas)
         to_cache(atlas) # cache it
         return atlas


### PR DESCRIPTION
This doesn't make sense to the end user, and I assume this was just a product of a find-and-replace for `AbstractPlotting`