### PR TITLE
Ignore aspect ratio adjustment if plot size is 0

### DIFF
--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -879,14 +879,14 @@ end
 function adjustlimits!(la)
     asp = la.autolimitaspect[]
     target = la.targetlimits[]
+    area = la.scene.px_area[]
 
     # in the simplest case, just update the final limits with the target limits
-    if isnothing(asp)
+    if isnothing(asp) || width(area) == 0 || height(area) == 0
         la.finallimits[] = target
         return
     end
 
-    area = la.scene.px_area[]
     xlims = (left(target), right(target))
     ylims = (bottom(target), top(target))
 


### PR DESCRIPTION
# Description

I've been seeing a lot of these being logged, which has been very difficult to debug.
```
┌ Warning: No strict ticks found
└ @ PlotUtils ~/Documents/GitHub/PlotUtils.jl/src/ticks.jl:334
```
Inspecting that location identified that 
```
x_min = -Inf
x_max = NaN
```
but none of the input data was Inf or NaN.

I turns out that the height of the `px_area` was 0, and `autolimitaspect` was set to 1, causing a divide by zero here
https://github.com/JuliaPlots/Makie.jl/blob/8e07051d065f2505680bac28ce084d16ea1fbac3/src/makielayout/layoutables/axis.jl#L893

I think it's ok for a plot area to be zero, or at least that should throw an error somewhere a bit easier to debug (i.e. inform the user which axes, give a stack trace etc.).

So this PR goes for the approach of skipping the aspect ratio correction if the `px_area` is zero width or height.


I haven't managed to put together a MWE/test for this yet.

cc. @jkrumbiegel 

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
