### PR TITLE
GLMakie: in render_frame store zvals for sort rather than use `by` for efficiency

### DIFF
--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -126,7 +126,7 @@ function render_frame(screen::Screen; resize_buffers=true)
         return Makie.zvalue2d(plot)
     end
     zvals = sortby.(screen.renderlist)
-    screen.renderlist = screen.renderlist[sortperm(zvals)]
+    permute!(screen.renderlist, sortperm(zvals))
 
     # NOTE
     # The transparent color buffer is reused by SSAO and FXAA. Changing the

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -125,7 +125,8 @@ function render_frame(screen::Screen; resize_buffers=true)
         # TODO, use actual boundingbox
         return Makie.zvalue2d(plot)
     end
-    sort!(screen.renderlist; by=sortby)
+    zvals = sortby.(screen.renderlist)
+    screen.renderlist = screen.renderlist[sortperm(zvals)]
 
     # NOTE
     # The transparent color buffer is reused by SSAO and FXAA. Changing the


### PR DESCRIPTION
# Description

This appears to speed up rendering because when using a function for `by` in a sort, the function is usually called many more times than the number of elements in the vector. 

Storing the vals then sorting via that vector appears to speed up the sort and thus the render loop.

Here are some profiles (on the top of #1612 ), The sort is the lower busy region just to the right of the middle in the first one.
On the 2nd it's a lot smaller (it has the mouse hovering over it with the line info)

Before
![Screenshot from 2022-01-21 02-15-10](https://user-images.githubusercontent.com/1694067/150484601-2c55c224-6119-49a5-a7df-57a008f271d4.png)

This PR
![Screenshot from 2022-01-21 02-26-56](https://user-images.githubusercontent.com/1694067/150484653-60bd6fd7-21fa-403e-bee2-6028825817de.png)


Note that the way I profiled this was to launch the interactive window normally, then in the repl ran `@profile sleep(10)` then interacted with the plot. It captures the async tasks and avoids anything to do with plot startup.

Also with ProfileView you can ignore the other threads.


## Type of change

Delete options that do not apply:

- [x] Optimization ?

## Checklist

- [x] Tested locally