### PR TITLE
fix `add_cycle_attributes!` for nested attributes

### DIFF
--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -622,7 +622,7 @@ function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palett
     # because if there were any, these are looked up directly
     # in the cycler without advancing the counter etc.
     manually_cycled_attributes = filter(keys(allattrs)) do key
-        allattrs[key][] isa Cycled
+        to_value(allattrs[key]) isa Cycled
     end
 
     # if there are any manually cycled attributes, we don't do the normal


### PR DESCRIPTION
Custom recipes with nested attributes won't work otherwise, because
`getindex(::Attributes)` fails.

Fixes https://github.com/JuliaPlots/GraphMakie.jl/issues/50

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
