### PR TITLE
Fix gluniform ambiguity

### DIFF
--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.5.2"
+version = "0.5.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/GLMakie/src/GLAbstraction/GLUniforms.jl
+++ b/GLMakie/src/GLAbstraction/GLUniforms.jl
@@ -75,6 +75,7 @@ function gluniform(loc::Integer, x::Observable{T}) where T
 end
 
 gluniform(location::Integer, x::Union{GLubyte, GLushort, GLuint}) = glUniform1ui(GLint(location), x)
+gluniform(location::Integer, x::GLuint) = glUniform1ui(GLint(location), x)
 gluniform(location::Integer, x::Union{GLbyte, GLshort, GLint, Bool}) = glUniform1i(GLint(location),  x)
 gluniform(location::Integer, x::GLfloat) = glUniform1f(GLint(location),  x)
 gluniform(location::Integer, x::GLdouble) = glUniform1d(GLint(location),  x)

--- a/GLMakie/src/GLAbstraction/GLUniforms.jl
+++ b/GLMakie/src/GLAbstraction/GLUniforms.jl
@@ -75,7 +75,7 @@ function gluniform(loc::Integer, x::Observable{T}) where T
 end
 
 gluniform(location::Integer, x::Union{GLubyte, GLushort, GLuint}) = glUniform1ui(GLint(location), x)
-gluniform(location::Integer, x::GLuint) = glUniform1ui(GLint(location), x)
+gluniform(location::Integer, x::UInt8) = glUniform1ui(GLint(location), x)
 gluniform(location::Integer, x::Union{GLbyte, GLshort, GLint, Bool}) = glUniform1i(GLint(location),  x)
 gluniform(location::Integer, x::GLfloat) = glUniform1f(GLint(location),  x)
 gluniform(location::Integer, x::GLdouble) = glUniform1d(GLint(location),  x)


### PR DESCRIPTION
# Description

Fixes #1616.

Adds another method to `gluniform` to address an ambiguity. I have tested this in my original use case, and it fixed the problem without introducing regressions.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
