### PR TITLE
Adding a minimal working example of an animated heatmap

### DIFF
--- a/docs/documentation/animation.md
+++ b/docs/documentation/animation.md
@@ -158,3 +158,28 @@ for i = 1:nframes
 end
 nothing # hide
 ```
+
+Another example that updates the contents of a heatmap:
+```julia
+using GLMakie, Printf
+
+datarows = 400; datacols = 500
+buf = fill(0.0f0, datarows, datacols) 
+fig, ax, hm = heatmap(buf)
+@show typeof(hm[1])  # Axis x
+@show typeof(hm[2])  # Axis y
+@show typeof(hm[3])  # This would suggest we should be using hm[3] to modify the content
+
+display(fig)
+
+Printf.@printf "Finished creating first plot, start updating now"
+numFrames = 1000
+for frame=1:numFrames
+    buf .= rand.(Float32)
+    hm[3][] = buf   # This is the key step, also see print of types above 
+                    # Use [3] to index to data observable and [] to modify observable
+    yield()
+end
+
+```
+


### PR DESCRIPTION
# Description

Inspired by http://juliaplots.org/MakieReferenceImages/gallery//lots_of_heatmaps/index.html I wanted to see a MWE of an animated heatmap, however it turns out that syntax is obsolete. I managed to get it going again a while ago, but recent changes in Makie, seems to have changed the syntax again. Thus after figuring it out again, I thought it would help to add it to the documentation so others can see the example. I am not sure if this is the best place in the documentation though and am willing to listen to better suggestions.

## Type of change

Documentation

## Checklist

- [x ] Added or changed relevant sections in the documentation
