### PR TITLE
fix text layouting

### DIFF
--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -23,12 +23,20 @@ end
 function gl_bboxes(gl::GlyphCollection)
     scales = gl.scales.sv isa Vec2f ? (gl.scales.sv for _ in gl.extents) : gl.scales.sv
     map(gl.extents, gl.fonts, scales) do ext, font, scale
-        unscaled_hi_bb = height_insensitive_boundingbox(ext, font)
+        unscaled_hi_bb = height_insensitive_boundingbox_with_advance(ext, font)
         hi_bb = Rect2f(
             Makie.origin(unscaled_hi_bb) * scale,
             widths(unscaled_hi_bb) * scale
         )
     end
+end
+
+function height_insensitive_boundingbox_with_advance(ext, font)
+    l = 0f0
+    r = FreeTypeAbstraction.hadvance(ext)
+    b = FreeTypeAbstraction.descender(font)
+    t = FreeTypeAbstraction.ascender(font)
+    return Rect2f((l, b), (r - l, t - b))
 end
 
 function boundingbox(glyphcollection::GlyphCollection, position::Point3f, rotation::Quaternion)

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -99,18 +99,18 @@ function glyph_collection(str::AbstractString, font_per_char, fontscale_px, hali
     # calculate the x positions of each character in each line
     xs = map(lineinfos) do line
         cumsum([
-            isempty(line) ? 0.0 : -(line[1].hi_bb.origin[1]);
+            0f0;
             [l.hadvance for l in line[1:end-1]]
         ])
     end
 
-    # calculate linewidths as the last origin plus inkwidth for each line
+    # calculate linewidths as the last origin plus hadvance for each line
     linewidths = map(lineinfos, xs) do line, xx
         nchars = length(line)
         # if the last and not the only character is \n, take the previous one
         # to compute the width
         i = (nchars > 1 && line[end].char == '\n') ? nchars - 1 : nchars
-        xx[i] + widths(line[i].hi_bb)[1]
+        xx[i] + line[i].hadvance
     end
 
     # the maximum width is needed for justification

--- a/test/text.jl
+++ b/test/text.jl
@@ -34,7 +34,7 @@
     # This is just repeating code from Makie
     unit_extents = [FreeTypeAbstraction.get_extent(font, char) for char in chars]
     origins = cumsum(20f0 * Float32[
-        -unit_extents[1].horizontal_bearing[1],
+        0,
         unit_extents[1].advance[1],
         unit_extents[2].advance[1],
         unit_extents[3].advance[1]


### PR DESCRIPTION
This came up when trying to build tables out of `Label`s. The alignment looked bad, which seems to be because of incorrect assumptions about glyph boundingboxes. So far, the width of a line was computed using the "ink-width" of the glyphs, but this leads to a ragged appearance when right-aligning. Also, the left origin of a line was incorrectly adjusted for bearing, which is not necessary at all, as the bearing is chosen to make the glyph look well-adjusted when left aligned.

Some test code:

```julia
f = Figure(fontsize = 30, font = "Helvetica")

words = ["Apple", "Pear", "Cherry", "Coconut", "Pineapple", "Grapes"]

for (i, word) in enumerate(words)
    Label(f[i, 1], word, halign = :left)
    Label(f[i, 2], string(i), halign = :right)
end

rowgap!(f.layout, 10)

f
```

| Before | After |
|--|--|
| <img width="160" alt="grafik" src="https://user-images.githubusercontent.com/22495855/151986227-1ffd3ecc-1f94-4d56-af75-d548b642371d.png"> | <img width="161" alt="grafik" src="https://user-images.githubusercontent.com/22495855/151986194-defe8f4e-b7fc-43ff-9ad9-19f2d23a507c.png"> |
