### PR TITLE
New website examples for pie() and spy()

### DIFF
--- a/docs/examples/plotting_functions/pie.md
+++ b/docs/examples/plotting_functions/pie.md
@@ -16,13 +16,12 @@
 - `radius = 1` sets the radius for the pie plot.
 - `inner_radius = 0` sets the inner radius of the plot. Choose as a value between 0 and `radius` to create a donut chart.
 - `offset = 0` rotates the pie plot counterclockwise as given in radians.
-- `transparency = false` adjusts how the plot deals with transparency.
-In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `transparency = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
 - `inspectable = true` sets whether this plot should be seen by `DataInspector`.
 
 ### Other
 
-Set the axis property `autolimitaspect = 1` to ensure that a circle and not an ellipsoid is plotted. 
+Set the axis properties `autolimitaspect = 1` or `aspect = DataAspect()` to ensure that the pie chart looks like a circle and not an ellipsoid.
 
 ## Examples
 
@@ -35,17 +34,16 @@ Makie.inline!(true) # hide
 data   = [36, 12, 68, 5, 42, 27]
 colors = [:yellow, :orange, :red, :blue, :purple, :green]
 
-f, ax, plt = pie(data, 
+f, ax, plt = pie(data,
                  color = colors,
-                 radius = 4, 
+                 radius = 4,
                  inner_radius = 2,
                  strokecolor = :white,
-                 strokewidth = 5, 
-                 figure = (resolution= (800, 600), ), 
+                 strokewidth = 5,
                  axis = (autolimitaspect = 1, ) 
-    )
+                )
 
-f 
+f
 ```
 \end{examplefigure}
 
@@ -60,10 +58,9 @@ f, ax, plt = pie([π/2, 2π/3, π/4],
                 normalize=false,
                 offset = π/2,
                 color = [:orange, :purple, :green],
-                figure = (resolution= (800, 600), ),
                 axis = (autolimitaspect = 1,)
                 )
 
-f                
+f
 ```
 \end{examplefigure}

--- a/docs/examples/plotting_functions/pie.md
+++ b/docs/examples/plotting_functions/pie.md
@@ -1,0 +1,69 @@
+# pie
+
+{{doc pie}}
+
+
+
+## Attributes
+
+### Generic
+
+- `normalize = true` sets whether the data will be normalized to the range [0, 2π]. 
+- `color` sets the color of the pie segments. It can be given as a single named color or a vector of the same length as the input data
+- `strokecolor = :black` sets the color of the outline around the segments.
+- `strokewidth = 1` sets the width of the outline around the segments.
+- `vertex_per_deg = 1` defines the number of vertices per degree that are used to create the pie plot with polys. Increase if smoother circles are needed.
+- `radius = 1` sets the radius for the pie plot.
+- `inner_radius = 0` sets the innner radius if the plot. Choose as a value between 0 and `radius` to create a donut chart.
+- `offset = 0` rotates the pie plot counterclockwise as given in radians.
+- `transparency = false` adjusts how the plot deals with transparency.
+In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `inspectable = true` sets whether this plot should be seen by `DataInspector`.
+
+### Other
+
+Set the axis property `autolimitaspect = 1` to ensure that a circle and not an elipsoid is plottet. 
+
+## Examples
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+data   = [36, 12, 68, 5, 42, 27]
+colors = [:yellow, :orange, :red, :blue, :purple, :green]
+
+f, ax, plt = pie(data, 
+                 color = colors,
+                 radius = 4, 
+                 inner_radius = 2,
+                 strokecolor = :white,
+                 strokewidth = 5, 
+                 figure = (resolution= (800, 600), ), 
+                 axis = (autolimitaspect = 1, ) 
+    )
+
+f 
+```
+\end{examplefigure}
+
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+f, ax, plt = pie([π/2, 2π/3, π/4],
+                normalize=false,
+                offset = π/2,
+                color = [:orange, :purple, :green],
+                figure = (resolution= (800, 600), ),
+                axis = (autolimitaspect = 1,)
+                )
+
+f                
+```
+\end{examplefigure}

--- a/docs/examples/plotting_functions/pie.md
+++ b/docs/examples/plotting_functions/pie.md
@@ -14,7 +14,7 @@
 - `strokewidth = 1` sets the width of the outline around the segments.
 - `vertex_per_deg = 1` defines the number of vertices per degree that are used to create the pie plot with polys. Increase if smoother circles are needed.
 - `radius = 1` sets the radius for the pie plot.
-- `inner_radius = 0` sets the innner radius if the plot. Choose as a value between 0 and `radius` to create a donut chart.
+- `inner_radius = 0` sets the inner radius of the plot. Choose as a value between 0 and `radius` to create a donut chart.
 - `offset = 0` rotates the pie plot counterclockwise as given in radians.
 - `transparency = false` adjusts how the plot deals with transparency.
 In GLMakie `transparency = true` results in using Order Independent Transparency.
@@ -22,7 +22,7 @@ In GLMakie `transparency = true` results in using Order Independent Transparency
 
 ### Other
 
-Set the axis property `autolimitaspect = 1` to ensure that a circle and not an elipsoid is plottet. 
+Set the axis property `autolimitaspect = 1` to ensure that a circle and not an ellipsoid is plotted. 
 
 ## Examples
 

--- a/docs/examples/plotting_functions/spy.md
+++ b/docs/examples/plotting_functions/spy.md
@@ -7,7 +7,7 @@
 
 \begin{examplefigure}{}
 ```julia
-using CairoMakie
+using CairoMakie, SparseArrays
 CairoMakie.activate!() # hide
 Makie.inline!(true) # hide
 

--- a/docs/examples/plotting_functions/spy.md
+++ b/docs/examples/plotting_functions/spy.md
@@ -1,4 +1,4 @@
-# Spy
+# spy
 
 {{doc spy}}
 

--- a/docs/examples/plotting_functions/spy.md
+++ b/docs/examples/plotting_functions/spy.md
@@ -1,4 +1,4 @@
-# pie
+# Spy
 
 {{doc spy}}
 

--- a/docs/examples/plotting_functions/spy.md
+++ b/docs/examples/plotting_functions/spy.md
@@ -1,0 +1,26 @@
+# pie
+
+{{doc spy}}
+
+
+## Examples
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+N = 100 # dimension of the sparse matrix
+p = 0.1 # independent probability that an entry is zero
+
+A = sprand(N, N, p)
+
+f, ax, plt = spy(A, markersize = 4, marker = :circle, framecolor = :lightgrey)
+
+hidedecorations!(ax) # remove axis labeling
+ax.title = "Visualization of a random sparse matrix"
+
+f
+```
+\end{examplefigure}


### PR DESCRIPTION
# Description

I noticed that there are three plotting functions that do not have examples on the website (see #1639). 
Therefore I created two new sites, for the `pie()` and `spy()` function, an example for `timeseries()` is still missing. 

For the pie example I also added some more information about the attributes as it is done for example for the [arrow function](https://makie.juliaplots.org/stable/examples/plotting_functions/arrows/#example_12707894566346229771) because they were not that clear for me in the beginning. 

Would it make sense to add  this description in the [pie docstring](https://github.com/JuliaPlots/Makie.jl/blob/78820311c9b45347f0937caf8b31a25bbc27dd73/src/basic_recipes/pie.jl)? 

I tested the examples with CairoMakie in VS Code as well as with GLMakie in the REPL. 

Please give me feedback if I did everything as its intended as this is my first time contributing :) 

## Type of change

Delete options that do not apply:
- [x] Improvement of the Documentation

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
