### PR TITLE
update Three for performance bug, add fps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Master
+
+- Fix WGLMakie performance bug and add option to set fps via `WGLMakie.activate!(fps=30)`
+
 ## v0.16
 
 #### Big Changes

--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -31,7 +31,7 @@ using Makie: inline!
 struct WebGL <: ShaderAbstractions.AbstractContext end
 struct WGLBackend <: Makie.AbstractBackend end
 
-const THREE = Dependency(:THREE, ["https://unpkg.com/three@0.130.0/build/three.js"])
+const THREE = Dependency(:THREE, ["https://unpkg.com/three@0.137.0/build/three.js"])
 const WGL = Dependency(:WGLMakie, [@path joinpath(@__DIR__, "wglmakie.js")])
 const WEBGL = Dependency(:WEBGL, [@path joinpath(@__DIR__, "WEBGL.js")])
 
@@ -44,7 +44,17 @@ include("meshes.jl")
 include("imagelike.jl")
 include("display.jl")
 
-function activate!()
+const CONFIG = (
+    fps = Ref(30),
+)
+
+"""
+    activate!(; fps=30)
+
+Set fps (frames per second) to a higher number for smoother animations, or to a lower to use less resources.
+"""
+function activate!(; fps=30)
+    CONFIG.fps[] = fps
     b = WGLBackend()
     Makie.register_backend!(b)
     Makie.current_backend[] = b

--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -31,7 +31,7 @@ using Makie: inline!
 struct WebGL <: ShaderAbstractions.AbstractContext end
 struct WGLBackend <: Makie.AbstractBackend end
 
-const THREE = Dependency(:THREE, ["https://unpkg.com/three@0.137.0/build/three.js"])
+const THREE = Dependency(:THREE, ["https://unpkg.com/three@0.136.0/build/three.js"])
 const WGL = Dependency(:WGLMakie, [@path joinpath(@__DIR__, "wglmakie.js")])
 const WEBGL = Dependency(:WEBGL, [@path joinpath(@__DIR__, "WEBGL.js")])
 

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -82,7 +82,7 @@ function three_display(session::Session, scene::Scene)
         if ( renderer ) {
             const three_scenes = scenes.map(x=> $(WGL).deserialize_scene(x, canvas))
             const cam = new $(THREE).PerspectiveCamera(45, 1, 0, 100)
-            $(WGL).start_renderloop(renderer, three_scenes, cam)
+            $(WGL).start_renderloop(renderer, three_scenes, cam, $(CONFIG.fps[]))
             JSServe.on_update($canvas_width, w_h => {
                 // `renderer.setSize` correctly updates `canvas` dimensions
                 const pixelRatio = renderer.getPixelRatio();

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -600,9 +600,8 @@ const WGLMakie = (function () {
 
     function start_renderloop(renderer, three_scenes, cam, fps) {
         const time_per_frame = (1 / fps) * 1000; // default is 30 fps
-
         // make sure we immediately render the first frame and dont wait 30ms
-        let last_time_stamp = performance.now() - time_per_frame
+        let last_time_stamp = performance.now()
         function renderloop(timestamp) {
             const canvas = renderer.domElement
             if (!document.body.contains(canvas)){
@@ -617,6 +616,8 @@ const WGLMakie = (function () {
             }
             window.requestAnimationFrame(renderloop);
         }
+        // render one time before starting loop, so that we don't wait 30ms before first render
+        render_scenes(renderer, three_scenes, cam);
         renderloop();
     }
 

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -598,8 +598,12 @@ const WGLMakie = (function () {
         scenes.forEach((scene) => render_scene(renderer, scene, cam));
     }
 
-    function start_renderloop(renderer, three_scenes, cam) {
-        function renderloop() {
+    function start_renderloop(renderer, three_scenes, cam, fps) {
+        const time_per_frame = (1 / fps) * 1000; // default is 30 fps
+
+        // make sure we immediately render the first frame and dont wait 30ms
+        let last_time_stamp = performance.now() - time_per_frame
+        function renderloop(timestamp) {
             const canvas = renderer.domElement
             if (!document.body.contains(canvas)){
                 console.log("EXITING WGL")
@@ -607,7 +611,10 @@ const WGLMakie = (function () {
                 renderer.dispose()
                 return
             }
-            render_scenes(renderer, three_scenes, cam);
+            if (timestamp - last_time_stamp > time_per_frame){
+                render_scenes(renderer, three_scenes, cam);
+                last_time_stamp = performance.now();
+            }
             window.requestAnimationFrame(renderloop);
         }
         renderloop();

--- a/docs/documentation/backends/wglmakie.md
+++ b/docs/documentation/backends/wglmakie.md
@@ -2,6 +2,21 @@
 
 [WGLMakie](https://github.com/JuliaPlots/Makie.jl/tree/master/WGLMakie) is the Web-based backend, and is still experimental (though relatively feature-complete). WGLMakie uses [JSServe](https://github.com/SimonDanisch/JSServe.jl) to generate the HTML and JS for the Makie plots.
 
+
+## Activation
+
+Activate the backend by calling `WGLMakie.activate!()` with the following options:
+```julia:docs
+# hideall
+using WGLMakie, Markdown
+println("~~~")
+println(Markdown.html(@doc WGLMakie.activate!))
+println("~~~")
+```
+\textoutput{docs}
+
+## Output
+
 You can use JSServe and WGLMakie in Pluto, IJulia, Webpages and Documenter to create interactive apps and dashboards, serve them on live webpages, or export them to static HTML.
 
 This tutorial will run through the different modes and what kind of limitations to expect.


### PR DESCRIPTION
The ThreeJS version we were on had a bug, that invalidated the WebGL program for every frame, leading to recompile the shader for every frame. Updating the version drops CPU times back to normal values.
This PR also throttles the framerate to 30fps, which can be configured by `activate!(; fps=30)`.
fixes #1663 