### PR TITLE
adjust dispatch for Reverse types in colormap conversion

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1055,7 +1055,7 @@ function convert_attribute(cs::Union{Tuple, Pair}, ::key"colormap", n::Int=2)
     return to_colormap([to_color.(cs)...], n)
 end
 
-function convert_attribute(cs::Tuple{<: Union{Symbol, AbstractString}, Real}, ::key"colormap", n::Int=30)
+function convert_attribute(cs::Tuple{<: Union{Reverse, Symbol, AbstractString}, Real}, ::key"colormap", n::Int=30)
     return RGBAf.(to_colormap(cs[1]), cs[2]) # We need to rework this to conform to the backend interface.
 end
 


### PR DESCRIPTION
# Description

Fixes #921

I adjusted `convert_attributes` for `colormap` to dispatch correctly on `Reverse` and thus break infinite recursion.

```julia
julia> to_colormap((Reverse(:plasma),0.6))
20-element Array{RGBA{Float32},1} with eltype ColorTypes.RGBA{Float32}:
 RGBA{Float32}(0.940015f0,0.975158f0,0.131326f0,0.6f0)
 RGBA{Float32}(0.97137386f0,0.8850977f0,0.14549963f0,0.6f0)
 RGBA{Float32}(0.99030447f0,0.797861f0,0.14765826f0,0.6f0)
 RGBA{Float32}(0.99426585f0,0.71510655f0,0.17796826f0,0.6f0)
 RGBA{Float32}(0.9856307f0,0.6371107f0,0.22021753f0,0.6f0)
 RGBA{Float32}(0.96661127f0,0.56384045f0,0.26547536f0,0.6f0)
 RGBA{Float32}(0.9390904f0,0.49502358f0,0.3109749f0,0.6f0)
 RGBA{Float32}(0.9047465f0,0.43004578f0,0.3561522f0,0.6f0)
 RGBA{Float32}(0.8649171f0,0.367987f0,0.40137604f0,0.6f0)
 RGBA{Float32}(0.82038385f0,0.30774865f0,0.44756916f0,0.6f0)
 RGBA{Float32}(0.7711437f0,0.24830647f0,0.49558184f0,0.6f0)
 RGBA{Float32}(0.7164665f0,0.18893111f0,0.54498404f0,0.6f0)
 RGBA{Float32}(0.6553256f0,0.12949258f0,0.5924907f0,0.6f0)
 RGBA{Float32}(0.5871952f0,0.07084163f0,0.63154674f0,0.6f0)
 RGBA{Float32}(0.51280886f0,0.01912037f0,0.6550932f0,0.6f0)
 RGBA{Float32}(0.43383452f0,0.0010335263f0,0.65967953f0,0.6f0)
 RGBA{Float32}(0.35178396f0,0.004228316f0,0.6466959f0,0.6f0)
 RGBA{Float32}(0.26667354f0,0.012809474f0,0.6199615f0,0.6f0)
 RGBA{Float32}(0.17467968f0,0.019514842f0,0.5821736f0,0.6f0)
 RGBA{Float32}(0.050383f0,0.029803f0,0.527975f0,0.6f0)
```

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Tested locally