### PR TITLE
Retrieve top parent correctly

### DIFF
--- a/src/makielayout/layoutables.jl
+++ b/src/makielayout/layoutables.jl
@@ -52,7 +52,7 @@ end
 can_be_current_axis(x) = false
 
 get_top_parent(gp::GridPosition) = GridLayoutBase.top_parent(gp.layout)
-get_top_parent(gp::GridSubposition) = GridLayoutBase.top_parent(gp.parent)
+get_top_parent(gp::GridSubposition) = get_top_parent(gp.parent)
 
 function _layoutable(T::Type{<:Layoutable},
         gp::Union{GridPosition, GridSubposition}, args...; kwargs...)


### PR DESCRIPTION
Fixes this issue:

```julia
f = Figure()
subpos = f[1, 1]
ax = Axis(subpos[1, 1])
Label(subpos[1, 2], "hello", tellheight = false)
f
```
|Before|After|
|--|--|
| <img width="560" alt="grafik" src="https://user-images.githubusercontent.com/22495855/153723355-5dff0889-439e-41a3-9be7-e32000e414a3.png"> | <img width="567" alt="grafik" src="https://user-images.githubusercontent.com/22495855/153723366-f6272d66-aadf-4579-aa4f-ab3ed928b34f.png"> |
