### PR TITLE
dont use Attributes type for theme

### DIFF
--- a/CairoMakie/src/infrastructure.jl
+++ b/CairoMakie/src/infrastructure.jl
@@ -213,7 +213,7 @@ function draw_background(screen::CairoScreen, scene::Scene)
     cr = screen.context
     Cairo.save(cr)
     if scene.clear[]
-        bg = to_color(theme(scene, :backgroundcolor)[])
+        bg = scene.backgroundcolor[]
         Cairo.set_source_rgba(cr, red(bg), green(bg), blue(bg), alpha(bg));
         r = pixelarea(scene)[]
         Cairo.rectangle(cr, origin(r)..., widths(r)...) # background

--- a/CairoMakie/src/precompiles.jl
+++ b/CairoMakie/src/precompiles.jl
@@ -1,0 +1,10 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Makie.backend_display, (CairoBackend, Scene))
+    activate!()
+    f, ax1, pl = scatter(1:4)
+    f, ax2, pl = lines(1:4)
+    Makie.colorbuffer(ax1.scene)
+    Makie.colorbuffer(ax2.scene)
+    return
+end

--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -1,5 +1,5 @@
 
-const Theme = Attributes
+const Theme = Dict{Symbol, Any}
 
 Base.broadcastable(x::AbstractScene) = Ref(x)
 Base.broadcastable(x::AbstractPlot) = Ref(x)

--- a/src/interaction/observables.jl
+++ b/src/interaction/observables.jl
@@ -1,47 +1,5 @@
-# I don't want to use map anymore, it's so ambigious, especially to newcomers.
-# TODO should this become it's own function?
-"""
-    lift(f, o1::Observables.AbstractObservable, rest...) -> w
+const lift = map
 
-Create a new `w::Observable` by applying `f` to the _values_ of all observables 
-in `o1` and `rest...`. The initial value of `w` is determined by the first function
-evaluation. The observable `w` is updated by calling `f` each time any of the
-observables `o1, rest...` are updated.
-
-## Examples
-```julia
-julia> x = Observable(2)
-Observable{Int64} with 0 listeners. Value:
-2
-
-julia> y = lift(a -> a^2, x)
-Observable{Int64} with 0 listeners. Value:
-4
-
-julia> z = lift((a,b) -> a+b, x, y)
-Observable{Int64} with 0 listeners. Value:
-6
-```
-"""
-function lift(f, o1::Observables.AbstractObservable, rest...; kw...)
-    if !isempty(kw)
-        error("lift(f, obs...; init=f.(obs...), typ=typeof(init)) is deprecated. Use lift(typ, f, obs...), or map!(f, Observable(), obs...) for different init.")
-    end
-    init = f(to_value(o1), to_value.(rest)...)
-    typ = typeof(init)
-    result = Observable{typ}(init)
-    map!(f, result, o1, rest...)
-    return result
-end
-
-function lift(
-        f, ::Type{T}, o1::Observables.AbstractObservable, rest...
-    ) where {T}
-    init = f(to_value(o1), to_value.(rest)...)
-    result = Observable{T}(init)
-    map!(f, result, o1, rest...)
-    return result
-end
 
 Base.close(obs::Observable) = empty!(obs.listeners)
 

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -1,6 +1,6 @@
 function lift_parent_attribute(scene, attr::Symbol, default_value)
     if haskey(scene.theme, attr)
-        lift(identity, scene.theme[attr])
+        lift(identity, convert(Observable, scene.theme[attr]))
     else
         lift_parent_attribute(scene.parent, attr, default_value)
     end

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -268,8 +268,8 @@ macro documented_attributes(exp)
             for (name, exp, _) in vars_and_exps)...)
 
     # make an Attributes instance with of variable_name = variable_expression
-    exp_attrs = Expr(:call, :Attributes,
-        (Expr(:kw, name, exp)
+    exp_attrs = Expr(:call, :Theme,
+        (:($(QuoteNode(name)) => $exp)
             for (name, exp, _) in vars_and_exps)...)
 
     esc(quote
@@ -292,8 +292,8 @@ end
 
 
 function subtheme(scene, key::Symbol)
-    sub = haskey(theme(scene), key) ? theme(scene, key) : Attributes()
-    if !(sub isa Attributes)
+    sub = haskey(theme(scene), key) ? theme(scene, key) : Theme()
+    if !(sub isa Theme)
         error("Subtheme is not of type Attributes but is $sub")
     end
     sub

--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -11,7 +11,7 @@ function layoutable(::Type{<:Axis}, fig_or_scene::Union{Figure, Scene}; bbox = n
 
     default_attrs = default_attributes(Axis, topscene).attributes
     theme_attrs = subtheme(topscene, :Axis)
-    attrs = merge!(merge!(Attributes(kwargs), theme_attrs), default_attrs)
+    attrs = Attributes(merge!(merge!(Theme(kwargs), theme_attrs), default_attrs))
 
     @extract attrs (
         title, titlefont, titlesize, titlegap, titlevisible, titlealign, titlecolor,
@@ -610,7 +610,7 @@ function get_cycle_for_plottype(allattrs, P)::Cycle
     end
 end
 
-function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palette::Attributes)
+function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palette::Dict)
     # check if none of the cycled attributes of this plot
     # were passed manually, because we don't use the cycler
     # if any of the cycled attributes were specified manually
@@ -636,7 +636,7 @@ function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palett
             end
         end
 
-        palettes = [palette[sym][] for sym in palettesyms(cycle)]
+        palettes = [to_value(palette[sym]) for sym in palettesyms(cycle)]
 
         for sym in manually_cycled_attributes
             isym = findfirst(syms -> sym in syms, attrsyms(cycle))
@@ -658,7 +658,7 @@ function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palett
     elseif no_cycle_attribute_passed
         index = get_cycler_index!(cycler, P)
 
-        palettes = [palette[sym][] for sym in palettesyms(cycle)]
+        palettes = [to_value(palette[sym]) for sym in palettesyms(cycle)]
 
         for (isym, syms) in enumerate(attrsyms(cycle))
             for sym in syms
@@ -684,7 +684,7 @@ function Makie.plot!(
     allattrs = merge(attributes, Attributes(kw_attributes))
 
     cycle = get_cycle_for_plottype(allattrs, P)
-    add_cycle_attributes!(allattrs, P, cycle, la.cycler, la.palette)
+    add_cycle_attributes!(allattrs, P, cycle, la.cycler, la.palette[])
 
     plot = Makie.plot!(la.scene, P, allattrs, args...)
 

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -42,8 +42,8 @@ function LineAxis(parent::Scene; kwargs...)
         linestyle = nothing, visible = minorticksvisible, inspectable = false
     )
     decorations[:minorticklines] = minorticklines
-
-    realticklabelalign = lift(Any, ticklabelalign, pos_extents_horizontal, flipped, ticklabelrotation) do al, (pos, ex, hor), fl, rot
+    realticklabelalign = Observable{Any}()
+    map!(realticklabelalign, ticklabelalign, pos_extents_horizontal, flipped, ticklabelrotation) do al, (pos, ex, hor), fl, rot
         if al !== automatic
             return al
         end
@@ -82,8 +82,8 @@ function LineAxis(parent::Scene; kwargs...)
 
     ticklabelannosnode = Observable(Tuple{AbstractString, Point2f}[])
     ticklabels = nothing
-
-    ticklabel_ideal_space = lift(Float32, ticklabelannosnode, ticklabelalign, ticklabelrotation, ticklabelfont, ticklabelsvisible) do args...
+    ticklabel_ideal_space = Observable{Float32}()
+    map!(ticklabel_ideal_space, ticklabelannosnode, ticklabelalign, ticklabelrotation, ticklabelfont, ticklabelsvisible) do args...
         maxwidth = if pos_extents_horizontal[][3]
                 # height
                 ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : height(Rect2f(boundingbox(ticklabels)))) : 0f0
@@ -111,8 +111,6 @@ function LineAxis(parent::Scene; kwargs...)
             actual_ticklabelspace[] = s
         end
     end
-
-
 
     tickspace = lift(ticksvisible, ticksize, tickalign) do ticksvisible,
             ticksize, tickalign

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -31,9 +31,9 @@ end
 
 function SSAO(; radius=nothing, bias=nothing, blur=nothing)
     defaults = theme(nothing, :SSAO)
-    _radius = isnothing(radius) ? defaults.radius[] : radius
-    _bias = isnothing(bias) ? defaults.bias[] : bias
-    _blur = isnothing(blur) ? defaults.blur[] : blur
+    _radius = isnothing(radius) ? defaults[:radius] : radius
+    _bias = isnothing(bias) ? defaults[:bias] : bias
+    _blur = isnothing(blur) ? defaults[:blur] : blur
     return SSAO(_radius, _bias, _blur)
 end
 
@@ -98,7 +98,7 @@ mutable struct Scene <: AbstractScene
     "The plots contained in the Scene."
     plots::Vector{AbstractPlot}
 
-    theme::Attributes
+    theme::Theme
 
     "Children of the Scene inherit its transformation."
     children::Vector{Scene}
@@ -152,7 +152,7 @@ function Scene(;
         camera_controls::AbstractCamera = EmptyCamera(),
         transformation::Transformation = Transformation(transform_func),
         plots::Vector{AbstractPlot} = AbstractPlot[],
-        theme::Attributes = Attributes(),
+        theme = Theme(),
         children::Vector{Scene} = Scene[],
         current_screens::Vector{AbstractScreen} = AbstractScreen[],
         parent = nothing,
@@ -163,13 +163,11 @@ function Scene(;
     )
     m_theme = current_default_theme(; theme..., theme_kw...)
 
-    bg = map(to_color, m_theme.backgroundcolor)
+    bg = map(to_color, Observable(m_theme[:backgroundcolor]))
 
     wasnothing = isnothing(px_area)
     if wasnothing
-        px_area = lift(m_theme.resolution) do res
-            Recti(0, 0, res)
-        end
+        px_area = Observable(Recti(0, 0, m_theme[:resolution]))
     end
 
     cam = camera isa Camera ? camera : Camera(px_area)
@@ -199,7 +197,7 @@ function Scene(;
             position = if lightposition == :eyeposition
                 scene.camera.eyeposition
             else
-                m_theme.lightposition
+                m_theme[:lightposition]
             end
             push!(scene.lights, PointLight(position, RGBf(1, 1, 1)))
         end

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -45,59 +45,59 @@ function wong_colors(alpha = 1.0)
     @. RGBAf(red(colors), green(colors), blue(colors), alpha)
 end
 
-const default_palettes = Attributes(
-    color = wong_colors(1),
-    patchcolor = Makie.wong_colors(0.8),
-    marker = [:circle, :utriangle, :cross, :rect, :diamond, :dtriangle, :pentagon, :xcross],
-    linestyle = [nothing, :dash, :dot, :dashdot, :dashdotdot],
-    side = [:left, :right]
+const default_palettes = Theme(
+    :color => wong_colors(1),
+    :patchcolor => Makie.wong_colors(0.8),
+    :marker => [:circle, :utriangle, :cross, :rect, :diamond, :dtriangle, :pentagon, :xcross],
+    :linestyle => [nothing, :dash, :dot, :dashdot, :dashdotdot],
+    :side => [:left, :right]
 )
 
-const minimal_default = Attributes(
-    palette = default_palettes,
-    font = "Dejavu Sans",
-    textcolor = :black,
-    padding = Vec3f(0.05),
-    figure_padding = 16,
-    rowgap = 24,
-    colgap = 24,
-    backgroundcolor = :white,
-    colormap = :viridis,
-    marker = Circle,
-    markersize = 9,
-    markercolor = :black,
-    markerstrokecolor = :black,
-    markerstrokewidth = 0,
-    linecolor = :black,
-    linewidth = 1.5,
-    linestyle = nothing,
-    patchcolor = RGBAf(0, 0, 0, 0.6),
-    patchstrokecolor = :black,
-    patchstrokewidth = 0,
-    resolution = (800, 600), # 4/3 aspect ratio
-    visible = true,
-    axis = Attributes(),
-    axis3d = Attributes(),
-    legend = Attributes(),
-    axis_type = automatic,
-    camera = automatic,
-    limits = automatic,
-    SSAO = Attributes(
+const minimal_default = Theme(
+    :palette => default_palettes,
+    :font => "Dejavu Sans",
+    :textcolor => :black,
+    :padding => Vec3f(0.05),
+    :figure_padding => 16,
+    :rowgap => 24,
+    :colgap => 24,
+    :backgroundcolor => :white,
+    :colormap => :viridis,
+    :marker => Circle,
+    :markersize => 9,
+    :markercolor => :black,
+    :markerstrokecolor => :black,
+    :markerstrokewidth => 0,
+    :linecolor => :black,
+    :linewidth => 1.5,
+    :linestyle => nothing,
+    :patchcolor => RGBAf(0, 0, 0, 0.6),
+    :patchstrokecolor => :black,
+    :patchstrokewidth => 0,
+    :resolution => (800, 600), # 4/3 aspect ratio
+    :visible => true,
+    :axis => Theme(),
+    :axis3d => Theme(),
+    :legend => Theme(),
+    :axis_type => automatic,
+    :camera => automatic,
+    :limits => automatic,
+    :SSAO => Theme(
         # enable = false,
-        bias = 0.025f0,       # z threshhold for occlusion
-        radius = 0.5f0,       # range of sample positions (in world space)
-        blur = Int32(2),      # A (2blur+1) by (2blur+1) range is used for blurring
+        :bias => 0.025f0,       # z threshhold for occlusion
+        :radius => 0.5f0,       # range of sample positions (in world space)
+        :blur => Int32(2),      # A (2blur+1) by (2blur+1) range is used for blurring
         # N_samples = 64,       # number of samples (requires shader reload)
     ),
-    ambient = RGBf(0.55, 0.55, 0.55),
-    lightposition = :eyeposition,
-    inspectable = true
+    :ambient => RGBf(0.55, 0.55, 0.55),
+    :lightposition => :eyeposition,
+    :inspectable => true
 )
 
 const _current_default_theme = deepcopy(minimal_default)
 
 function current_default_theme(; kw_args...)
-    return merge!(Attributes(kw_args), deepcopy(_current_default_theme))
+    return merge!(Theme(kw_args), deepcopy(_current_default_theme))
 end
 
 """
@@ -106,7 +106,7 @@ end
 Set the global default theme to `theme` and add / override any attributes given
 as keyword arguments.
 """
-function set_theme!(new_theme = Theme()::Attributes; kwargs...)
+function set_theme!(new_theme = Dict{Symbol, Any}(); kwargs...)
     empty!(_current_default_theme)
     new_theme = merge!(deepcopy(new_theme), deepcopy(minimal_default))
     new_theme = merge!(Theme(kwargs), new_theme)
@@ -166,8 +166,8 @@ function _update_key!(theme, key::Symbol, content)
     theme[key] = content
 end
 
-function _update_key!(theme, key::Symbol, content::Attributes)
-    if haskey(theme, key) && theme[key] isa Attributes
+function _update_key!(theme, key::Symbol, content::Theme)
+    if haskey(theme, key) && theme[key] isa Theme
         _update_attrs!(theme[key], content)
     else
         theme[key] = content

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -242,35 +242,6 @@ function to_vector(x::ClosedInterval, len, T)
     range(a, stop=b, length=len)
 end
 
-
-"""
-Returns (N1, N2) with `N1 x N2 == n`. N2 might become 1
-"""
-function close2square(n::Real)
-    # a cannot be greater than the square root of n
-    # b cannot be smaller than the square root of n
-    # we get the maximum allowed value of a
-    amax = floor(Int, sqrt(n));
-    if 0 == rem(n, amax)
-        # special case where n is a square number
-        return (amax, div(n, amax))
-    end
-    # Get its prime factors of n
-    primeFactors  = factor(n);
-    # Start with a factor 1 in the list of candidates for a
-    candidates = [1]
-    for (f, _) in primeFactors
-        # Add new candidates which are obtained by multiplying
-        # existing candidates with the new prime factor f
-        # Set union ensures that duplicate candidates are removed
-        candidates = union(candidates, f .* candidates)
-        # throw out candidates which are larger than amax
-        filter!(x -> x <= amax, candidates)
-    end
-    # Take the largest factor in the list d
-    (candidates[end], div(n, candidates[end]))
-end
-
 """
 A colorsampler maps numnber values from a certain range to values of a colormap
 ```
@@ -327,19 +298,4 @@ end
 function attribute_names(PlotType)
     # TODO, have all plot types store their attribute names
     return keys(default_theme(nothing, PlotType))
-end
-
-"""
-    attributes_from(PlotType, plot)
-
-Gets the attributes from plot, that are valid for PlotType
-"""
-function attributes_from(PlotType, plot)
-    result = Attributes()
-    for key in attribute_names(PlotType)
-        if haskey(plot, key)
-            result[key] = plot[key]
-        end
-    end
-    return result
 end


### PR DESCRIPTION
Using the Attributes types for Themes is overly complicated, since we don't actually want every theme attribute to be converted to Observable{Any}. I think the ability to update the observables in a theme to be reflected in created plots hasn't been used a single time, and is likely also buggy.
Getting rid of Attributes in theming will also help getting rid of the Attribute type in the long run.