### PR TITLE
Fix timeseries

### DIFF
--- a/src/basic_recipes/timeseries.jl
+++ b/src/basic_recipes/timeseries.jl
@@ -40,8 +40,13 @@ function Makie.plot!(plot::TimeSeries)
     points = Observable(fill(Point2f(NaN), plot.history[]))
     buffer = copy(points[])
     lines!(plot, points)
-    start = time()
+    start = 0
+    started = false
     on(plot.signal) do x
+        if !started
+            start = time()
+            started = true
+        end
         points[][end] = signal2point(x, start)
         circshift!(buffer, points[], 1)
         buff_ref = buffer

--- a/src/basic_recipes/timeseries.jl
+++ b/src/basic_recipes/timeseries.jl
@@ -1,7 +1,10 @@
 """
-    timeseries(x::Observable{{Union{Number, Point2}}})
+    timeseries(x::Observable{{Union{Number, Point2}}}; kwargs...)
 
 Plots a sampled signal.
+
+The `history::Int=100` argument controls how many data points are tracked.
+
 Usage:
 ```julia
 signal = Observable(1.0)
@@ -40,13 +43,8 @@ function Makie.plot!(plot::TimeSeries)
     points = Observable(fill(Point2f(NaN), plot.history[]))
     buffer = copy(points[])
     lines!(plot, points)
-    start = 0
-    started = false
+    start = time()
     on(plot.signal) do x
-        if !started
-            start = time()
-            started = true
-        end
         points[][end] = signal2point(x, start)
         circshift!(buffer, points[], 1)
         buff_ref = buffer

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -147,3 +147,5 @@ function resize_to_layout!(fig::Figure)
     resize!(fig.scene, widths(bbox)...)
     new_size
 end
+
+Base.isopen(fap::FigureAxisPlot) = Base.isopen(fap.plot)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -475,7 +475,10 @@ function is2d(scene::SceneLike)
     return is2d(lims)
 end
 is2d(lims::Rect2) = true
-is2d(lims::Rect3) = widths(lims)[3] == 0.0
+function is2d(lims::Rect3)
+    w = widths(lims)[3]
+    w == 0.0 || (isinf(w) && w < 0)
+end
 
 #####
 ##### Figure type


### PR DESCRIPTION
# Description

Fixes #1669

The initial scene upon creation of a `TimeSeries` plot was assumed to be a 3D one, because the data stream is filled with `NaNs`. Fixed this by adjusting `is2d` to return `true` for 3D rectangles who's width in z direction is `-Inf`.
Also overloaded `isopen` for `FigureAxisPlot` so that MWE from `TimeSeries` docs works again.

Automatic x, y limits as shown in https://github.com/JuliaPlots/Makie.jl/issues/736 don't work anymore. But that might be a different issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)