### PR TITLE
Forward `transparency` kwarg in `contour`/`contour3d` recipe

### DIFF
--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -190,7 +190,8 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
         lines!(
             plot, lift(first, result);
             color = lift(last, result), linewidth = plot[:linewidth],
-            inspectable = plot[:inspectable]
+            inspectable = plot[:inspectable],
+            transparency = plot[:transparency]
         )
     end
     plot


### PR DESCRIPTION
The transparency kwarg previously wasn't having any effect for `contour3d` (and `contour` as well I imagine).
@SimonDanisch suggested this fix on Slack.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

