### PR TITLE
`volumeslices`: expose heatmaps

### DIFF
--- a/docs/examples/plotting_functions/volumeslices.md
+++ b/docs/examples/plotting_functions/volumeslices.md
@@ -22,7 +22,8 @@ lsgrid = labelslidergrid!(
   ["yz plane - x axis", "xz plane - y axis", "xy plane - z axis"],
   [1:length(x), 1:length(y), 1:length(z)]
 )
-fig[2, 1] = lsgrid.layout
+fig[2, 1] = lo = lsgrid.layout
+nc = ncols(lo)
 
 vol = [cos(X)*sin(Y)*sin(Z) for X ∈ x, Y ∈ y, Z ∈ z]
 plt = volumeslices!(ax, x, y, z, vol)
@@ -37,6 +38,14 @@ on(sl_xy.value) do v; plt[:update_xy][](v) end
 set_close_to!(sl_yz, .5length(x))
 set_close_to!(sl_xz, .5length(y))
 set_close_to!(sl_xy, .5length(z))
+
+# add toggles to show/hide heatmaps
+hmaps = [plt[Symbol(:heatmap_, s)][] for s ∈ (:yz, :xz, :xy)]
+toggles = [Toggle(lo[i, nc + 1], active = true) for i ∈ 1:length(hmaps)]
+
+map(zip(hmaps, toggles)) do (h, t)
+  connect!(h.visible, t.active)
+end
 
 # cam3d!(ax.scene, projectiontype=Makie.Orthographic)
 

--- a/src/basic_recipes/volumeslices.jl
+++ b/src/basic_recipes/volumeslices.jl
@@ -38,16 +38,17 @@ function plot!(plot::VolumeSlices)
 
     axes = :x, :y, :z
     for (ax, p, r, (X, Y)) ∈ zip(axes, (:yz, :xz, :xy), (x, y, z), ((y, z), (x, z), (x, y)))
-        hmap = heatmap!(plot, attr, X, Y, zeros(length(X[]), length(Y[])))
-        plot[Symbol(:update_, p)] = i -> begin
+        plot[Symbol(:heatmap_, p)] = hmap = heatmap!(
+            plot, attr, X, Y, zeros(length(X[]), length(Y[]))
+        )
+        plot[Symbol(:update_, p)] = update = i -> begin
             transform!(hmap, (p, r[][i]))
             indices = ntuple(Val(3)) do j
                 axes[j] == ax ? i : (:)
             end
             hmap[3][] = view(volume[], indices...)
         end
-        # Trigger once to place heatmaps correctly
-        plot[Symbol(:update_, p)][](1)
+        update(1) # trigger once to place heatmaps correctly
     end
 
     linesegments!(plot, bbox, color = bbox_color, visible = bbox_visible, inspectable = false)


### PR DESCRIPTION
- Expose `heatmap_yz`, `heatmap_xz`, `heatmap_xy` in `volumeslices` recipe (used e.g. when adding `Toggle`s, see updated example from `docs/examples/plotting_functions/volumeslices.md`).

- Enhance corresponding example in docs (added `Toggle`s to hide/show heatmaps):

![pr-volslice](https://user-images.githubusercontent.com/13423344/157293350-0b7559fb-47b2-47ab-98ff-bea50000f7c8.png)

