### PR TITLE
Colorbar example for heatmap

### DIFF
--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -128,7 +128,7 @@ ys = range(0, 2π, length=100)
 zs1 = [sin(x*y) for x in xs, y in ys]
 zs2 = [2sin(x*y) for x in xs, y in ys]
 
-my_limits = extrema(hcat(zs1, zs2))  # Get maximum and minimum for all z-values
+my_limits = (-2, 2)  # choose some good limits for sin / 2sin
 
 fig, ax1, hm1 = heatmap(xs, ys, zs1,  colorrange = my_limits)
 ax2, hm2 = heatmap(fig[1, end+1], xs, ys, zs2, colorrange = my_limits)

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -81,3 +81,62 @@ zs = [1, 2, 3, 4, 5, 6, 7, 8, NaN]
 heatmap(xs, ys, zs)
 ```
 \end{examplefigure}
+
+### Colorbar for single heatmap
+
+To get a scale for what the colors represent, add a colorbar. The colorbar is 
+placed within the figure in the first argument, and the scale and colormap can be 
+conveniently set by passing the relevant heatmap to it.
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+xs = range(0, 2π, 100)
+ys = range(0, 2π, 100)
+zs = [sin(x*y) for x in xs, y in ys]
+
+fig, ax, hm = heatmap(xs, ys, zs)
+Colorbar(fig[:, end+1], hm)
+
+fig
+```
+\end{examplefigure}
+
+### Colorbar for multiple heatmaps
+
+When there are several heatmaps in a single figure, it can be useful
+to have a single colorbar represent all of them. It is important to then 
+have syncronized scales and colormaps for the heatmaps and colorbar. This is done by
+setting the colorrange explicitly, so that it is independent of the data shown by 
+that particular heatmap.
+
+Since the heatmaps in the example below have the same colorrange and colormap, any of them 
+can be passed to `Colorbar` to give the colorbar the same attributes. Alternativly, 
+the colorbar attributes can be set explicitly.
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+xs = range(0, 2π, 100)
+ys = range(0, 2π, 100)
+zs1 = [sin(x*y) for x in xs, y in ys]
+zs2 = [2sin(x*y) for x in xs, y in ys]
+
+my_limits = extrema(hcat(zs1, zs2))  # Get maximum and minimum for all z-values
+
+fig, ax1, hm1 = heatmap(xs, ys, zs1,  colorrange = my_limits)
+ax2, hm2 = heatmap(fig[1, end+1], xs, ys, zs2, colorrange = my_limits)
+
+Colorbar(fig[:, end+1], hm1)
+Colorbar(fig[:, end+1], hm2)
+Colorbar(fig[:, end+1], colorrange = my_limits)
+
+fig
+```
+\end{examplefigure}

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -94,8 +94,8 @@ using CairoMakie
 CairoMakie.activate!() # hide
 Makie.inline!(true) # hide
 
-xs = range(0, 2π, 100)
-ys = range(0, 2π, 100)
+xs = range(0, 2π, length=100)
+ys = range(0, 2π, length=100)
 zs = [sin(x*y) for x in xs, y in ys]
 
 fig, ax, hm = heatmap(xs, ys, zs)
@@ -123,8 +123,8 @@ using CairoMakie
 CairoMakie.activate!() # hide
 Makie.inline!(true) # hide
 
-xs = range(0, 2π, 100)
-ys = range(0, 2π, 100)
+xs = range(0, 2π, length=100)
+ys = range(0, 2π, length=100)
 zs1 = [sin(x*y) for x in xs, y in ys]
 zs2 = [2sin(x*y) for x in xs, y in ys]
 

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -109,7 +109,7 @@ fig
 
 When there are several heatmaps in a single figure, it can be useful
 to have a single colorbar represent all of them. It is important to then 
-have syncronized scales and colormaps for the heatmaps and colorbar. This is done by
+have synchronized scales and colormaps for the heatmaps and colorbar. This is done by
 setting the colorrange explicitly, so that it is independent of the data shown by 
 that particular heatmap.
 

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -81,7 +81,3 @@ zs = [1, 2, 3, 4, 5, 6, 7, 8, NaN]
 heatmap(xs, ys, zs)
 ```
 \end{examplefigure}
-
-### Colors
-
-Using the previous example, we can see how to change the color of our plot. You can find additional colors [here](https://makie.juliaplots.org/stable/documentation/colors/index.html#colors).

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -128,14 +128,14 @@ ys = range(0, 2π, length=100)
 zs1 = [sin(x*y) for x in xs, y in ys]
 zs2 = [2sin(x*y) for x in xs, y in ys]
 
-my_limits = (-2, 2)  # choose some good limits for sin / 2sin
+joint_limits = (-2, 2)  # here we pick the limits manually for simplicity instead of computing them
 
-fig, ax1, hm1 = heatmap(xs, ys, zs1,  colorrange = my_limits)
-ax2, hm2 = heatmap(fig[1, end+1], xs, ys, zs2, colorrange = my_limits)
+fig, ax1, hm1 = heatmap(xs, ys, zs1,  colorrange = joint_limits)
+ax2, hm2 = heatmap(fig[1, end+1], xs, ys, zs2, colorrange = joint_limits)
 
 Colorbar(fig[:, end+1], hm1)                     # These three
 Colorbar(fig[:, end+1], hm2)                     # colorbars are
-Colorbar(fig[:, end+1], colorrange = my_limits)  # equivalent
+Colorbar(fig[:, end+1], colorrange = joint_limits)  # equivalent
 
 fig
 ```

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -133,9 +133,9 @@ my_limits = extrema(hcat(zs1, zs2))  # Get maximum and minimum for all z-values
 fig, ax1, hm1 = heatmap(xs, ys, zs1,  colorrange = my_limits)
 ax2, hm2 = heatmap(fig[1, end+1], xs, ys, zs2, colorrange = my_limits)
 
-Colorbar(fig[:, end+1], hm1)
-Colorbar(fig[:, end+1], hm2)
-Colorbar(fig[:, end+1], colorrange = my_limits)
+Colorbar(fig[:, end+1], hm1)                     # These three
+Colorbar(fig[:, end+1], hm2)                     # colorbars are
+Colorbar(fig[:, end+1], colorrange = my_limits)  # equivalent
 
 fig
 ```


### PR DESCRIPTION
# Description

This PR adds documentation to the page on [`heatmap`](https://makie.juliaplots.org/stable/examples/plotting_functions/heatmap/index.html), specifically how to make a colorbar.

It also removes the previous final section [Colors](https://makie.juliaplots.org/stable/examples/plotting_functions/heatmap/index.html#colors), as it 
1) Seems to have an outdated reference, and
2) had nothing else, effectively contributing nothing but noise.
