### PR TITLE
use apply_transform directly on lims

### DIFF
--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -298,6 +298,14 @@ function apply_transform(f, r::Rect)
     ma_t = apply_transform(f, ma)
     Rect(Vec(mi_t), Vec(ma_t .- mi_t))
 end
+function apply_transform(f::PointTrans, r::Rect)
+    mi = minimum(r)
+    ma = maximum(r)
+    mi_t = apply_transform(f, Point(mi))
+    ma_t = apply_transform(f, Point(ma))
+    Rect(Vec(mi_t), Vec(ma_t .- mi_t))
+end
+
 # ambiguity fix
 apply_transform(f::typeof(identity), r::Rect) = r
 apply_transform(f::NTuple{2, typeof(identity)}, r::Rect) = r

--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -130,8 +130,10 @@ function layoutable(::Type{Axis}, fig_or_scene::Union{Figure, Scene}; bbox = not
         nearclip = -10_000f0
         farclip = 10_000f0
 
-        left, bottom = Makie.apply_transform(t, Point(minimum(lims)))
-        right, top = Makie.apply_transform(t, Point(maximum(lims)))
+        tlims = Makie.apply_transform(t, lims)
+
+        left, bottom = minimum(tlims)
+        right, top = maximum(tlims)
 
         leftright = xrev ? (right, left) : (left, right)
         bottomtop = yrev ? (top, bottom) : (bottom, top)


### PR DESCRIPTION
# Description

This helps fix https://github.com/JuliaPlots/GeoMakie.jl/issues/99

As explained by @visr in https://github.com/JuliaPlots/GeoMakie.jl/issues/99#issuecomment-1020510420, the problem is that the current bounding box is computed by just using `apply_transform` on the minimum and maximum points: this doesn't work for more complicated transformations.

Instead we now call `apply_transform` directly on the `Rect`, which can then be overloaded for custom transformations (e.g. see https://github.com/JuliaPlots/GeoMakie.jl/pull/101)

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
