### PR TITLE
Fix buggy camera rotation with up = (x, y, 0)

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -459,7 +459,7 @@ function _rotate_cam!(scene, cam::Camera3D, angles::VecTypes, from_mouse=false)
     right = cross(viewdir, up)  # +x
 
     x_axis = right
-    y_axis = cam.attributes[:fixed_axis][] ? Vec3f(0, 0, sign(up[3])) : up
+    y_axis = cam.attributes[:fixed_axis][] ? Vec3f(0, 0, ifelse(up[3] < 0, -1, 1)) : up
     z_axis = -viewdir
 
     fix_x = ispressed(scene, cam.attributes[:fix_x_key][])


### PR DESCRIPTION
```julia
fig, ax, p = scatter(rand(Point3f, 10))
update_cam!(ax.scene, Point3f(0, 0, 4), Point3f(0), Point3f(0,1,0))
```

This generates a plot seen from +z with +y being the up direction. If you try to rotate this on master everything disappears as `y_axis = (0, 0, 0)` because of `sign(up[3]) = 0`. This pr fixes that.