### PR TITLE
CairoMakie: less specialization, better inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ CairoMakie/src/display.*
 
 WGLMakie/test/recorded/
 GLMakie/test/reference_test_output/
+CairoMakie/test/reference_test_output/
 RPRMakie/test/recorded/
 CairoMakie/test/recorded/
 CairoMakie/src/display.svg

--- a/CairoMakie/src/infrastructure.jl
+++ b/CairoMakie/src/infrastructure.jl
@@ -163,14 +163,15 @@ function cairo_draw(screen::CairoScreen, scene::Scene)
         to_value(get(p, :visible, true)) || continue
         # only prepare for scene when it changes
         # this should reduce the number of unnecessary clipping masks etc.
-        if p.parent != last_scene
+        pparent = p.parent::Scene
+        if pparent != last_scene
             Cairo.restore(screen.context)
             Cairo.save(screen.context)
-            prepare_for_scene(screen, p.parent)
-            last_scene = p.parent
+            prepare_for_scene(screen, pparent)
+            last_scene = pparent
         end
         Cairo.save(screen.context)
-        draw_plot(p.parent, screen, p)
+        draw_plot(pparent, screen, p)
         Cairo.restore(screen.context)
     end
 

--- a/CairoMakie/src/precompiles.jl
+++ b/CairoMakie/src/precompiles.jl
@@ -111,5 +111,8 @@ function _precompile_()
     )
 
     CairoMakie.draw_mesh3D(scene, screen, attributes, mesh2)
+    mktempdir() do path
+        save(joinpath(path, "test.png"), scatter(1:4))
+    end
     return
 end

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -2,7 +2,7 @@
 #                             Lines, LineSegments                              #
 ################################################################################
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Lines, LineSegments})
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Union{Lines, LineSegments}))
     fields = @get_attribute(primitive, (color, linewidth, linestyle))
     linestyle = Makie.convert_attribute(linestyle, Makie.key"linestyle"())
     ctx = screen.context
@@ -173,7 +173,7 @@ end
 #                                   Scatter                                    #
 ################################################################################
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Scatter)
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Scatter))
     fields = @get_attribute(primitive, (color, markersize, strokecolor, strokewidth, marker, marker_offset, rotations))
     @get_attribute(primitive, (transform_marker,))
 
@@ -315,7 +315,7 @@ function p3_to_p2(p::Point3{T}) where T
     end
 end
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Text{<:Tuple{<:G}}) where G <: Union{AbstractArray{<:Makie.GlyphCollection}, Makie.GlyphCollection}
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Text{<:Tuple{<:Union{AbstractArray{<:Makie.GlyphCollection}, Makie.GlyphCollection}}}))
     ctx = screen.context
     @get_attribute(primitive, (rotation, model, space, markerspace, offset))
     position = primitive.position[]
@@ -483,7 +483,7 @@ function interpolation_flag(is_vector, interp, wpx, hpx, w, h)
 end
 
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Union{Heatmap, Image})
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Union{Heatmap, Image}))
     ctx = screen.context
     image = primitive[3][]
     xs, ys = primitive[1][], primitive[2][]
@@ -817,7 +817,7 @@ end
 ################################################################################
 
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Makie.Surface)
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Makie.Surface))
     # Pretend the surface plot is a mesh plot and plot that instead
     mesh = surface2mesh(primitive[1][], primitive[2][], primitive[3][])
     old = primitive[:color]
@@ -872,7 +872,7 @@ end
 ################################################################################
 
 
-function draw_atomic(scene::Scene, screen::CairoScreen, primitive::Makie.MeshScatter)
+function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Makie.MeshScatter))
     @get_attribute(primitive, (color, model, marker, markersize, rotations))
 
     if color isa AbstractArray{<: Number}

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -296,7 +296,7 @@ function plot!(scene::Union{Combined, SceneLike}, P::PlotFunc, attributes::Attri
         Observable(())
     else
         # Remove used attributes from `attributes` and collect them in a `Tuple` to pass them more easily
-        lift((args...)-> Pair.(convert_keys, args), pop!.(attributes, convert_keys)...)
+        lift((args...)-> Pair.(convert_keys, args), pop!.(attributes, convert_keys)...)::Observable{Tuple}
     end
     # call convert_arguments for a first time to get things started
     converted = convert_arguments(PreType, argvalues...; kw_signal[]...)
@@ -309,13 +309,13 @@ function plot!(scene::Union{Combined, SceneLike}, P::PlotFunc, attributes::Attri
     onany(kw_signal, lift(tuple, input_nodes...)) do kwargs, args
         # do the argument conversion inside a lift
         result = convert_arguments(FinalType, args...; kwargs...)
-        finaltype, argsconverted = apply_convert!(FinalType, attributes, result)
+        finaltype, argsconverted_ = apply_convert!(FinalType, attributes, result) # avoid a Core.Box (https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured)
         if finaltype != FinalType
             error("Plot type changed from $FinalType to $finaltype after conversion.
                 Changing the plot type based on values in convert_arguments is not allowed"
             )
         end
-        converted_node[] = argsconverted
+        converted_node[] = argsconverted_
     end
     plot!(scene, FinalType, attributes, input_nodes, converted_node)
 end


### PR DESCRIPTION
On my machine, this drops the time for
`save("/tmp/test.png", scatter(1:4))`
from 25.6s to 24.4s.  The time for CairoMakie's whole test suite drops
from 4m50s to 4m34s.
