### PR TITLE
benchmark should be allowed to fail

### DIFF
--- a/.github/workflows/compilation-benchmark.yaml
+++ b/.github/workflows/compilation-benchmark.yaml
@@ -28,6 +28,7 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - name: Benchmark
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.BENCHMARK_KEY }}
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
...since if all other tests run through, it must be something flaky in the benchmark (time out, gh-api down etc).