### PR TITLE
don't use blendfunc to calculate 1-alpha, fix #1695

### DIFF
--- a/GLMakie/assets/shader/fragment_output.frag
+++ b/GLMakie/assets/shader/fragment_output.frag
@@ -25,10 +25,11 @@ void write2framebuffer(vec4 color, uvec2 id){
     {{buffer_writes}}
     // resolves to:
 
-    // // if transparency == true
-    // float weight = color.a * max(0.01, 3000 * pow((1 - gl_FragCoord.z), 3));
-    // fragment_color = weight * color;
-    // coverage = color.a;
+    // if transparency == true
+    // float weight = color.a * max(0.01, $scale * pow((1 - gl_FragCoord.z), 3));
+    // coverage = 1.0 - clamp(color.a, 0.0, 1.0);
+    // fragment_color.rgb = weight * color.rgb;
+    // fragment_color.a = weight;
 
     // // if transparency == false && enable_SSAO[] = true
     // fragment_color = color;

--- a/GLMakie/src/GLAbstraction/GLRenderObject.jl
+++ b/GLMakie/src/GLAbstraction/GLRenderObject.jl
@@ -59,8 +59,8 @@ function (sp::StandardPrerender)()
         glDisablei(1, GL_BLEND)
 
         # buffer 2 is color.a, should do product
-        # destination <- 0 * source + (1 - source) * destination
-        glBlendFunci(2, GL_ZERO, GL_ONE_MINUS_SRC_COLOR)
+        # destination <- 0 * source + (source) * destination
+        glBlendFunci(2, GL_ZERO, GL_SRC_COLOR)
 
     else
         glDepthMask(GL_TRUE)

--- a/GLMakie/src/GLVisualize/visualize_interface.jl
+++ b/GLMakie/src/GLVisualize/visualize_interface.jl
@@ -74,7 +74,7 @@ struct GLVisualizeShader <: AbstractLazyShader
         # TODO properly check what extensions are available
         @static if !Sys.isapple()
             view["GLSL_EXTENSIONS"] = "#extension GL_ARB_conservative_depth: enable"
-            view["SUPPORTED_EXTENSIONS"] = "#define DETPH_LAYOUT"
+            view["SUPPORTED_EXTENSIONS"] = "#define DEPTH_LAYOUT"
         end
         args = Dict{Symbol, Any}(kw_args)
         args[:view] = view
@@ -169,7 +169,7 @@ function output_buffer_writes(transparency = false)
         scale = transparency_weight_scale[]
         """
         float weight = color.a * max(0.01, $scale * pow((1 - gl_FragCoord.z), 3));
-        coverage = color.a;
+        coverage = 1.0 - clamp(color.a, 0.0, 1.0);
         fragment_color.rgb = weight * color.rgb;
         fragment_color.a = weight;
         """


### PR DESCRIPTION
Ok, this is really weird... Somehow AMDs drivers don't correctly apply the `GL_ONE_MINUS_SRC_COLOR` operation.
When we move it into the shader, things seem to work!
Fixes #1695