### PR TITLE
Fix glyphlayout not being an Observable for LaTeXStrings

### DIFF
--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -112,7 +112,7 @@ function plot!(plot::Text{<:Tuple{<:Union{LaTeXString, AbstractVector{<:LaTeXStr
             end
             tex_elements, glyphcollections, offsets
         else
-            tex_elements, glyphcollection, offset = texelems_and_glyph_collection(latexstring, ts,
+            tex_elements, glyphcollections, offsets = texelems_and_glyph_collection(latexstring, ts,
                 al[1], al[2], rot, color, scolor, swidth)
         end
     end


### PR DESCRIPTION
# Description

I noticed that using latex strings as axis labels in `Axis3` results in wrong, static rotations so I did some digging. It turns out that glyphcollection decides it no longer is an Observable after `notify(plot.position)` (it is before) but instead is the glyphcollection in the first `lift`. Removing the name collision fixes this.

Fixes #1417 as well.

## Type of change

Bug fix (non-breaking change which fixes an issue)
