### PR TITLE
fix show AbstractPattern

### DIFF
--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -9,9 +9,14 @@ function, which must return a `Matrix{<: AbstractRGB}`.
 abstract type AbstractPattern{T} <: AbstractArray{T, 2} end
 
 function Base.show(io::IO, ::MIME"text/plain", p::AbstractPattern)
+    
     println(io, typeof(p))
-    show(io, mime, image(p))
+    print(io, p)
 end
+
+Base.show(io::IO, p::AbstractPattern) = print(io, image(to_image(p)))
+
+
 struct ImagePattern{T<:Colorant} <: AbstractPattern{T}
     img::Matrix{T}
 end


### PR DESCRIPTION
# Description

Fixed the error in the show function for AbstractPatterns 

Based on @ffreyer's suggestion on issue #1566, I fixed the show function for AbstractPatterns. I tested this with both a LinePattern and an ImagePattern. The show function converts the pattern to an image and prints it as a Scene object.

- [x] Bug fix (non-breaking change which fixes an issue)
