### PR TITLE
GLBuffer-related bug fixes

### DIFF
--- a/GLMakie/src/GLAbstraction/GLBuffer.jl
+++ b/GLMakie/src/GLAbstraction/GLBuffer.jl
@@ -151,7 +151,7 @@ function Base.iterate(buffer::GLBuffer{T}) where T
     length(buffer) < 1 && return nothing
     glBindBuffer(buffer.buffertype, buffer.id)
     ptr = Ptr{T}(glMapBuffer(buffer.buffertype, GL_READ_WRITE))
-    return (unsafe_load(ptr, i), (ptr, 1))
+    return (unsafe_load(ptr, 1), (ptr, 2))
 end
 
 function Base.iterate(buffer::GLBuffer{T}, state::Tuple{Ptr{T}, Int}) where T

--- a/GLMakie/src/GLAbstraction/GLBuffer.jl
+++ b/GLMakie/src/GLAbstraction/GLBuffer.jl
@@ -151,6 +151,10 @@ function Base.iterate(buffer::GLBuffer{T}) where T
     length(buffer) < 1 && return nothing
     glBindBuffer(buffer.buffertype, buffer.id)
     ptr = Ptr{T}(glMapBuffer(buffer.buffertype, GL_READ_WRITE))
+    if ptr == C_NULL
+        # XXX: ModernGL.jl should expose glErrorMessage/glCheckError
+        error("GLBuffer iterate: glMapBuffer failed (GL error: $(glGetError()))")
+    end
     return (unsafe_load(ptr, 1), (ptr, 2))
 end
 

--- a/GLMakie/src/GLAbstraction/GLBuffer.jl
+++ b/GLMakie/src/GLAbstraction/GLBuffer.jl
@@ -53,6 +53,10 @@ function GLBuffer(
     return b
 end
 
+# no-op conversions
+GLBuffer(buffer::GLBuffer) = buffer
+GLBuffer{T}(buffer::GLBuffer{T}) where {T} = buffer
+
 function GLBuffer(
         buffer::AbstractVector{T};
         kw_args...


### PR DESCRIPTION
A small set of fixes for issues I ran into when using GLBuffer inputs directly.
Note that I first fixed `iterate(::GLBuffer)` before replacing the implementation (so that we can always go back to the old implementation, but in a working state), which means it may be better to merge this instead of squashing the commits.