### PR TITLE
fix manual cycling of plot attributes

### DIFF
--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -633,8 +633,9 @@ function add_cycle_attributes!(allattrs, P, cycle::Cycle, cycler::Cycler, palett
     if !isempty(manually_cycled_attributes)
         # an attribute given as Cycled needs to be present in the cycler,
         # otherwise there's no cycle in which to look up a value
+        cycle_attrsyms = attrsyms(cycle)
         for k in manually_cycled_attributes
-            if k ∉ palettesyms(cycle)
+            if !any(k .∈ cycle_attrsyms)
                 error("Attribute `$k` was passed with an explicit `Cycled` value, but $k is not specified in the cycler for this plot type $P.")
             end
         end


### PR DESCRIPTION
# Description

Fix manually cycling of plot attributes

Fixes #1628

When trying to set which cycle value to use for a plot attribute, it doesn't work unless the plot attribute is mapped to the palette attribute with the same name. For example, the mwe below does not work,

```julia
using CairoMakie
set_theme!(;
    palette=(patchcolor=[:blue, :green],),
)
fig = Figure()
ax = Axis(fig[1, 1])
density!(rand(10); color=Cycled(2))
save("test.pdf", fig)
```
because `density!` has `cycle=[:color => :patchcolor]`.

it throws the error,
```julia
julia> density!(rand(10); color=Cycled(2))
ERROR: Attribute `color` was passed with an explicit `Cycled` value, but color is not specified in the cycler for this plot type Combined{Makie.density}.
Stacktrace:
 [1] add_cycle_attributes!(allattrs::Attributes, P::Type, cycle::Cycle, cycler::Makie.MakieLayout.Cycler, palette::Attributes)
   @ Makie.MakieLayout ~/.julia/packages/Makie/lgPZh/src/makielayout/layoutables/axis.jl:639
 [2] plot!(la::Axis, P::Type{Combined{Makie.density}}, attributes::Attributes, args::Vector{Float64}; kw_attributes::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Makie.MakieLayout ~/.julia/packages/Makie/lgPZh/src/makielayout/layoutables/axis.jl:691
 [3] plot!
   @ ~/.julia/packages/Makie/lgPZh/src/makielayout/layoutables/axis.jl:688 [inlined]
 [4] #plot!#340
   @ ~/.julia/packages/Makie/lgPZh/src/makielayout/layoutables/axis.jl:705 [inlined]
 [5] plot!(P::Type{Combined{Makie.density}}, args::Vector{Float64}; kw_attributes::Base.Pairs{Symbol, Cycled, Tuple{Symbol}, NamedTuple{(:color,), Tuple{Cycled}}})
   @ Makie ~/.julia/packages/Makie/lgPZh/src/figureplotting.jl:48
 [6] #density!#742
   @ ~/.julia/packages/MakieCore/A0hGm/src/recipes.jl:37 [inlined]
 [7] top-level scope
   @ REPL[5]:1
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
