### PR TITLE
Hide decorations for scatter markers docs

### DIFF
--- a/docs/examples/plotting_functions/scatter.md
+++ b/docs/examples/plotting_functions/scatter.md
@@ -121,6 +121,7 @@ ax = Axis(f[1, 1], yreversed = true,
     xautolimitmargin = (0.15, 0.15),
     yautolimitmargin = (0.15, 0.15)
 )
+hidedecorations!(ax)
 
 for (i, (marker, label)) in enumerate(markers_labels)
     p = Point2f(fldmod1(i, 6)...)


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/20724914/162623642-1f67c2a7-d6cc-43d5-969d-4400f4cd6038.png)

## After

![image](https://user-images.githubusercontent.com/20724914/162623639-c14782c5-088c-4ba2-bb43-317741ae6d48.png)
