### PR TITLE
Add `empty!(fig)` and cleanup `empty!(scene)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - **Breaking** Added `space` as a generic attribute to switch between data, pixel, relative and clip space for positions. `space` in text has been renamed to `markerspace` because of this. `Pixel` and `SceneSpace` are no longer valid inputs for `space` or `markerspace`.
 - **Breaking** Deprecated `mouse_selection(scene)` for `pick(scene)`.
 - **Breaking** Bumped `GridLayoutBase` version to `v0.7`, which introduced offset layouts. Now, indexing into row 0 doesn't create a new row 1, but a new row 0, so that all previous content positions stay the same. This makes building complex layouts order-independent [#1704](https://github.com/JuliaPlots/Makie.jl/pull/1704).
+- Added `empty!(fig)` and changed `empty!(scene)` to remove all child plots without detaching windows
 
 ##  v0.16.4
 

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -145,3 +145,12 @@ function resize_to_layout!(fig::Figure)
     resize!(fig.scene, widths(bbox)...)
     new_size
 end
+
+function Base.empty!(fig::Figure)
+    empty!(fig.scene)
+    foreach(GridLayoutBase.remove_from_gridlayout!, reverse(fig.layout.content))
+    trim!(fig.layout)
+    empty!(fig.content)
+    fig.current_axis[] = nothing
+    return
+end

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -350,13 +350,31 @@ function getindex(scene::Scene, ::Type{OldAxis})
 end
 
 function Base.empty!(scene::Scene)
-    empty!(scene.plots)
+    _empty_recursion(scene)
+
     disconnect!(scene.camera)
-    scene.camera_controls[] = EmptyCamera()
+    scene.camera_controls = EmptyCamera()
     empty!(scene.theme)
     merge!(scene.theme, _current_default_theme)
     empty!(scene.children)
-    empty!(scene.current_screens)
+
+    return nothing
+end
+
+function _empty_recursion(scene::Scene)
+    for child in reverse(scene.children)
+        _empty_recursion(child)
+    end
+
+    for plot in reverse(scene.plots)
+        for screen in scene.current_screens
+            delete!(screen, scene, plot)
+        end
+    end
+
+    empty!(scene.plots)
+
+    return
 end
 
 Base.push!(scene::Combined, subscene) = nothing # Combined plots add themselves uppon creation

--- a/test/figures.jl
+++ b/test/figures.jl
@@ -75,6 +75,27 @@ end
     @test current_axis() === nothing
 end
 
+@testset "Clearing figures" begin
+    fig = Figure()
+    Label(fig[1, 1], "test")
+    ax = Axis(fig[2, 1])
+    scatter!(ax, rand(10))
+
+    @test !isempty(fig.scene.children)
+    @test !isempty(ax.scene.plots)
+    @test !isempty(fig.layout.content)
+    @test !isempty(fig.content)
+    @test current_axis() === ax
+
+    empty!(fig)
+
+    @test isempty(fig.scene.children)
+    @test isempty(ax.scene.plots)
+    @test isempty(fig.layout.content)
+    @test isempty(fig.content)
+    @test current_axis() === nothing
+end
+
 @testset "Getting figure content" begin
     fig = Figure()
     ax = fig[1, 1] = Axis(fig)


### PR DESCRIPTION
# Description

This fixes an error in `empty!(scene)`, makes it delete all plots in all child scenes and stops it from disconnecting the screen. 

It also adds `empty!(fig)` clearing all attached scenes and the layout. (Following https://github.com/jkrumbiegel/GridLayoutBase.jl/pull/2 here, though `delete!` seems unnecessary to me?)

Related: #1595

## Type of change

Delete options that do not apply:

- New feature & bug fix

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
