### PR TITLE
Fix resize of scatter plot when projectionview doesn't update

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -216,7 +216,7 @@ function draw_atomic(screen::GLScreen, scene::Scene, @nospecialize(x::Union{Scat
             space = get(gl_attributes, :space, :data)
             mspace = get(gl_attributes, :markerspace, :pixel)
             cam = scene.camera
-            gl_attributes[:preprojection] = map(space, mspace, cam.projectionview) do space, mspace, pv
+            gl_attributes[:preprojection] = map(space, mspace, cam.projectionview, cam.resolution) do space, mspace, _, _
                 return Makie.clip_to_space(cam, mspace) * Makie.space_to_clip(cam, space)
             end
             if !(marker[] isa FastPixel)

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -180,7 +180,7 @@ function create_shader(scene::Scene, plot::Scatter)
     space = get(attributes, :space, :data)
     mspace = get(attributes, :markerspace, :pixel)
     cam = scene.camera
-    attributes[:preprojection] = map(space, mspace, cam.projectionview) do space, mspace, pv
+    attributes[:preprojection] = map(space, mspace, cam.projectionview, cam.resolution) do space, mspace, _, _
         Makie.clip_to_space(cam, mspace) * Makie.space_to_clip(cam, space)
     end
     attributes[:pos] = apply_transform(transform_func_obs(plot),  plot[1])


### PR DESCRIPTION
# Description

scatter plots with `markerspace = :pixel` need to react to changes in `camera.resolution` to be correct when the window size changes.

```julia
scene = Scene()
scatter!(scene, rand(Point2f, 1000))
```
This for example does not resize correctly on master, but does after this pr. (A scatter plot in an axis resizes correctly either way because `camera.projectionview` gets updated.)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
