### PR TITLE
Fix rotation with Irrational and Uniful's degree

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -965,8 +965,8 @@ function to_rotation(s::VecTypes{N}) where N
     end
 end
 
-to_rotation(s::Tuple{VecTypes, AbstractFloat}) = qrotation(to_ndim(Vec3f, s[1], 0.0), s[2])
-to_rotation(angle::AbstractFloat) = qrotation(Vec3f(0, 0, 1), Float32(angle))
+to_rotation(s::Tuple{VecTypes, Number}) = qrotation(to_ndim(Vec3f, s[1], 0.0), s[2])
+to_rotation(angle::Number) = qrotation(Vec3f(0, 0, 1), angle)
 to_rotation(r::AbstractVector) = to_rotation.(r)
 to_rotation(r::AbstractVector{<: Quaternionf}) = r
 

--- a/test/quaternions.jl
+++ b/test/quaternions.jl
@@ -1,3 +1,10 @@
+struct Degree{T} <: Number
+    θ::T
+end
+Base.:/(θ::Degree, x::Number) = Degree(θ.θ / x)
+Base.sin(θ::Degree) = sin(θ.θ * π/180)
+Base.cos(θ::Degree) = cos(θ.θ * π/180)
+
 @testset "Quaternions" begin
 
     qx = qrotation(Vec(1, 0, 0), pi / 4)
@@ -40,4 +47,13 @@
     #         @test angle(q) ≈ θ
     #     end
     # end
+
+    # Test `to_rotation` with other subtypes of `Number` than `AbstractFloat`
+    # such as `Base.Irrational` and Unitful's `90u"°"`
+    v = Vec(0.0, 0.0, 1.0)
+    # `π` is not an `AbstractFloat` but it is a `Number`
+    @test to_rotation(π) == to_rotation(1.0π)
+    @test to_rotation((v, π)) == to_rotation((v, 1.0π))
+    @test to_rotation(Degree(90)) == to_rotation(π/2)
+    @test to_rotation((v, Degree(90))) == to_rotation((v, π/2))
 end


### PR DESCRIPTION
`rotate!` doesn't work with irrational angle like `π` because it's not an `AbstractFloat` so the user has to use `1.0π` for instance as a workaround.
Moreover, Unitful's degree implement `sin` and `cos` but they are subtypes of `Number` and not `AbstractFloat` so by using `Number` we allow both the use of Unitful's degree and irrational.