### PR TITLE
pass generic attributes to tex lines

### DIFF
--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -176,7 +176,11 @@ function plot!(plot::Text{<:Tuple{<:Union{LaTeXString, AbstractVector{<:LaTeXStr
     notify(plot.position)
 
     text!(plot, glyphcollection; plot.attributes...)
-    linesegments!(plot, linepairs, linewidth = linewidths, color = plot.color)
+    linesegments!(
+        plot, linepairs, linewidth = linewidths, color = plot.color,
+        visible = plot.visible, inspectable = plot.inspectable, 
+        transparent = plot.transparency
+    )
 
     plot
 end


### PR DESCRIPTION
# Description

This adds a couple of generic attributes to the lines plot of a latex text plot. Without this `text(L"\frac{1}{2}", visible = false)` would leave behind a line.

## Type of change

- Bug fix (non-breaking change which fixes an issue)