### PR TITLE
Fix segfault during streamplot

### DIFF
--- a/src/basic_recipes/streamplot.jl
+++ b/src/basic_recipes/streamplot.jl
@@ -104,7 +104,7 @@ function streamplot_impl(CallType, f, limits::Rect{N, T}, resolutionND, stepsize
         end)
         ind += 1
         if mask[c]
-            x0 = Point(ntuple(N) do i
+            x0 = Point{N}(ntuple(N) do i
                 first(r[i]) + (c[i] - 0.5) * step(r[i])
             end)
             point = apply_f(x0, CallType)
@@ -184,7 +184,7 @@ function plot!(p::StreamPlot)
         rotations = lift(scene.camera.projectionview, scene.px_area, data) do pv, pxa, data
             angles = map(data[1], data[2]) do pos, dir
                 pstart = project(scene, pos)
-                pstop = project(scene, pos .+ dir)
+                pstop = project(scene, pos + dir)
                 pdir = pstop - pstart
                 n = norm(pdir)
                 if n == 0


### PR DESCRIPTION
Somehow, when I used streamplot on my machine it segfaults without this.  These are my fixes for it.

* Specify the length of `Point` when creating `x0`
* Remove broadcasted addition of arrays in projection

# Description

Fixes # (issue)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
