### PR TITLE
Better colormap handling in CairoMakie

### DIFF
--- a/CairoMakie/src/CairoMakie.jl
+++ b/CairoMakie/src/CairoMakie.jl
@@ -11,7 +11,7 @@ using Makie: convert_attribute, @extractvalue, LineSegments, to_ndim, NativeFont
 using Makie: @info, @get_attribute, Combined
 using Makie: to_value, to_colormap, extrema_nan
 using Makie: inline!
-using Makie: Observables
+using Makie.Observables
 using Makie: spaces, is_data_space, is_pixel_space, is_relative_space, is_clip_space
 
 const OneOrVec{T} = Union{

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -109,7 +109,7 @@ to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, c))
 
 function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
 
-    colormap = get(primitive, :colormap, nothing) |> to_value |> to_colormap
+    colormap = haskey(primitive, :colormap) ? to_colormap(plot.colormap[]) : nothing
     colorrange = get(primitive, :colorrange, nothing) |> to_value
 
     if colorrange === Makie.automatic

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -109,7 +109,7 @@ to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, c))
 
 function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
 
-    colormap = haskey(primitive, :colormap) ? to_colormap(plot.colormap[]) : nothing
+    colormap = haskey(primitive, :colormap) ? to_colormap(primitive.colormap[]) : nothing
     colorrange = get(primitive, :colorrange, nothing) |> to_value
 
     if colorrange === Makie.automatic


### PR DESCRIPTION
Define a method `to_colormap(::Nothing) = nothing`, which is required for CairoMakie to plot polygons as meshes 

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

