### PR TITLE
Improved Rainclouds API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - **Breaking** Added `space` as a generic attribute to switch between data, pixel, relative and clip space for positions. `space` in text has been renamed to `markerspace` because of this. `Pixel` and `SceneSpace` are no longer valid inputs for `space` or `markerspace`.
 - **Breaking** Deprecated `mouse_selection(scene)` for `pick(scene)`.
 - **Breaking** Bumped `GridLayoutBase` version to `v0.7`, which introduced offset layouts. Now, indexing into row 0 doesn't create a new row 1, but a new row 0, so that all previous content positions stay the same. This makes building complex layouts order-independent [#1704](https://github.com/JuliaPlots/Makie.jl/pull/1704).
+- Added `raindclouds` and `raindclouds` [#1725](https://github.com/JuliaPlots/Makie.jl/pull/1725)
 
 ##  v0.16.4
 
@@ -49,7 +50,6 @@ All other changes are collected [in this PR](https://github.com/JuliaPlots/Makie
 - Use [MathTexEngine v0.2](https://github.com/Kolaru/MathTeXEngine.jl/releases/tag/v0.2.0).
 - Depend on new GeometryBasics, which changes all the Vec/Point/Quaternion/RGB/RGBA - f0 aliases to just f. For example, `Vec2f0` is changed to `Vec2f`. Old aliases are still exported, but deprecated and will be removed in the next breaking release. For more details and an upgrade script, visit [GeometryBasics#97](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/97).
 - Added `hspan!` and `vspan!` functions [#1264](https://github.com/JuliaPlots/Makie.jl/pull/1264).
-- Added `raindclouds` and `raindclouds` [#1725](https://github.com/JuliaPlots/Makie.jl/pull/1725)
 
 ## v0.15.1
 - Switched documentation framework to Franklin.jl.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - **Breaking** Added `space` as a generic attribute to switch between data, pixel, relative and clip space for positions. `space` in text has been renamed to `markerspace` because of this. `Pixel` and `SceneSpace` are no longer valid inputs for `space` or `markerspace`.
 - **Breaking** Deprecated `mouse_selection(scene)` for `pick(scene)`.
 - **Breaking** Bumped `GridLayoutBase` version to `v0.7`, which introduced offset layouts. Now, indexing into row 0 doesn't create a new row 1, but a new row 0, so that all previous content positions stay the same. This makes building complex layouts order-independent [#1704](https://github.com/JuliaPlots/Makie.jl/pull/1704).
-- Added `raindclouds` and `raindclouds` [#1725](https://github.com/JuliaPlots/Makie.jl/pull/1725)
+- Added `raindclouds` and `raindclouds!` [#1725](https://github.com/JuliaPlots/Makie.jl/pull/1725)
 
 ##  v0.16.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ All other changes are collected [in this PR](https://github.com/JuliaPlots/Makie
 - Use [MathTexEngine v0.2](https://github.com/Kolaru/MathTeXEngine.jl/releases/tag/v0.2.0).
 - Depend on new GeometryBasics, which changes all the Vec/Point/Quaternion/RGB/RGBA - f0 aliases to just f. For example, `Vec2f0` is changed to `Vec2f`. Old aliases are still exported, but deprecated and will be removed in the next breaking release. For more details and an upgrade script, visit [GeometryBasics#97](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/97).
 - Added `hspan!` and `vspan!` functions [#1264](https://github.com/JuliaPlots/Makie.jl/pull/1264).
+- Added `raindclouds` and `raindclouds` [#1725](https://github.com/JuliaPlots/Makie.jl/pull/1725)
 
 ## v0.15.1
 - Switched documentation framework to Franklin.jl.

--- a/docs/examples/plotting_functions/rainclouds.md
+++ b/docs/examples/plotting_functions/rainclouds.md
@@ -49,13 +49,13 @@ end
 
 function mockup_categories_and_data_array(num_categories; N = 500)
     category_labels = String[]
-    data_array = Vector{Float64}[]
+    data_array = Float64[]
 
     for _ in 1:num_categories
         category_label, data_points = mockup_distribution(N)
 
-        push!(category_labels, category_label)
-        push!(data_array, data_points)
+        append!(category_labels, fill(category_label, N))
+        append!(data_array, data_points)
     end
     return category_labels, data_array
 end
@@ -101,8 +101,7 @@ fig = rainclouds(more_category_labels, more_data_array;
 
 \begin{examplefigure}{}
 ```julia
-more_category_labels = repeat(category_labels, 3)
-more_data_array = repeat(data_array, 3)
+category_labels, data_array = mockup_categories_and_data_array(6)
 fig = rainclouds(more_category_labels, more_data_array;
     xlabel = "Categories of Distributions",
     ylabel = "Samples", title = "My Title",
@@ -112,8 +111,7 @@ fig = rainclouds(more_category_labels, more_data_array;
 
 \begin{examplefigure}{}
 ```julia
-more_category_labels = repeat(category_labels, 3)
-more_data_array = repeat(data_array, 3)
+category_labels, data_array = mockup_categories_and_data_array(6)
 rainclouds(more_category_labels, more_data_array;
     xlabel = "Categories of Distributions",
     ylabel = "Samples", title = "My Title",

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -111,9 +111,13 @@ function plot!(
         allattrs::Attributes, category_labels, data_array)
 
     plot = plot!(ax.scene, P, allattrs, category_labels, data_array)
-    category_labels, data_array = group_args(category_labels, data_array)
+    category_labels, data_array = group_labels(category_labels, data_array)
 
-    ax.xticks = (plot.x_positions_of_categories[], string.(category_labels))
+    if eltype(category_labels) <: AbstractString
+        ax.xticks = (plot.x_positions_of_categories[], string.(category_labels))
+    else
+        ax.xticks = plot.x_positions_of_categories[]
+    end
     if haskey(allattrs, :title)
         ax.title = allattrs.title[]
     end
@@ -127,7 +131,7 @@ function plot!(
     return plot
 end
 
-function group_args(category_labels, data_array)
+function group_labels(category_labels, data_array)
     if !(eltype(data_array) isa AbstractVector)
         grouped = Dict{eltype(category_labels), typeof(data_array)}()
         for (label, data) in zip(category_labels, data_array)
@@ -150,7 +154,7 @@ end
 function plot!(plot::RainClouds)
     category_labels = plot.category_labels[]
     data_array = plot.data_array[]
-    category_labels, data_array = group_args(category_labels, data_array)
+    category_labels, data_array = group_labels(category_labels, data_array)
 
     # Checking kwargs, and assigning defaults if they are not in kwargs
     # General Settings

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -113,7 +113,7 @@ function plot!(
     plot = plot!(ax.scene, P, allattrs, category_labels, data_array)
     category_labels, data_array = group_args(category_labels, data_array)
 
-    ax.xticks = (plot.x_positions_of_categories[], category_labels)
+    ax.xticks = (plot.x_positions_of_categories[], string.(category_labels))
     if haskey(allattrs, :title)
         ax.title = allattrs.title[]
     end
@@ -129,9 +129,9 @@ end
 
 function group_args(category_labels, data_array)
     if !(eltype(data_array) isa AbstractVector)
-        grouped = Dict{String, typeof(data_array)}()
+        grouped = Dict{eltype(category_labels), typeof(data_array)}()
         for (label, data) in zip(category_labels, data_array)
-            push!(get!(grouped, string(label), eltype(data_array)[]), data)
+            push!(get!(grouped, label, eltype(data_array)[]), data)
         end
 
         @info "Converting parameters"

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -135,6 +135,15 @@ end
 function plot!(plot::RainClouds)
     category_labels = plot.category_labels[]
     data_array = plot.data_array[]
+    if length(category_labels) == length(data_array) && !(data_array isa AbstractVector{<:AbstractVector})
+        grouped = Dict{String, typeof(data_array)}()
+        for (label, data) in zip(category_labels, data_array)
+            push!(get!(grouped, label, eltype(data_array)[]), data)
+        end
+
+        category_labels = collect(keys(grouped))
+        data_array = collect(values(grouped))
+    end
 
     # Checking kwargs, and assigning defaults if they are not in kwargs
     # General Settings

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -16,15 +16,14 @@ rand_localized(min, max) = rand_localized(RAINCLOUD_RNG[], min, max)
 rand_localized(RNG::Random.AbstractRNG, min, max) = rand(RNG) * (max - min) .+ min
 
 """
-    rainclouds!(ax, category_labels, combined_data_array; plot_boxplots=true, plot_clouds=true, kwargs...)
+    rainclouds!(ax, category_labels, data_array; plot_boxplots=true, plot_clouds=true, kwargs...)
 
-Plot a scatter, vilin, and boxplot for the `combined_data_array`. Each data array in `combined_data_array` will be labeled using a
-corresponding label from `category_labels`.
+Plot a violin (/histogram), boxplot and individual data points with appropriate spacing between each.
 
 # Arguments
 - `ax`: Axis used to place all these plots onto.
-- `category_labels`: Typically `Vector{String}` used for storing the labels of each category on the x axis of the plot.
-- `combined_data_array`: Typically `Vector{Vector{Float64}}` used for storing the data array in each element of the `combined_data_array`.
+- `category_labels`: Typically `Vector{String}` with a label for each element in `data_array`
+- `data_array`: Typically `Vector{Float64}` used for to represent the datapoints to plot.
 
 # Keywords
 - `plot_boxplots=true`: Boolean to show boxplots to summarize distribution of data.
@@ -156,6 +155,7 @@ end
 
 function ungroup_labels(category_labels, data_array)
     if eltype(data_array) isa AbstractVector
+        @warn "Using a nested array for raincloud is deprected. Read raincloud's documentation and update your usage accordingly."
         data_array_ = reduce(vcat, data_array)
         category_labels_ = similar(category_labels, length(data_array_))
         ix = 0

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -115,8 +115,6 @@ function plot!(
 
     if eltype(category_labels) <: AbstractString
         ax.xticks = (plot.x_positions_of_categories[], string.(category_labels))
-    else
-        ax.xticks = plot.x_positions_of_categories[]
     end
     if haskey(allattrs, :title)
         ax.title = allattrs.title[]


### PR DESCRIPTION
# Description

This improves three related things about the current PR for rainclouds to make it behave more like all of the other plot recipes:

1. It makes the API more consistent with that of boxplot and violin: now you pass in a list of labels (integers or strings), one for each data point, and a flat array of data points.

2. It presumes that the `color` argument labels all data points rather than each category separately.

3. It implements the `dodge` keyword argument.

In addition to being a little more predictable from a user perspective, it also means that rainclouds works when calling it from AlgebraOfGraphics. 

I updated some docs/NEWS.md which the original PR hadn't yet addressed.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
