### PR TITLE
Specify size of matrices in `rotatedrect`

### DIFF
--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -114,20 +114,20 @@ This is not perfect but works well enough. Check an A vs X to see the difference
 function rotatedrect(rect::Rect{2}, angle)
     ox, oy = rect.origin
     wx, wy = rect.widths
-    points = Mat(
+    points = Mat{2, 4}(
         ox, oy,
         ox, oy+wy,
         ox+wx, oy,
         ox+wx, oy+wy
     )
-    mrot = Mat(
+    mrot = Mat{2, 2}(
         cos(angle), -sin(angle),
         sin(angle), cos(angle)
     )
-    rotated = mrot * points'
+    rotated = mrot * points
 
-    rmins = minimum(rotated, dims = 2)
-    rmaxs = maximum(rotated, dims = 2)
+    rmins = minimum(rotated; dims=2)
+    rmaxs = maximum(rotated; dims=2)
 
     return Rect2(rmins..., (rmaxs .- rmins)...)
 end


### PR DESCRIPTION
# Description

Fixes an issue with MakieTeX layouting.

There was a method ambiguity when constructing `Mat(args...)`, which I fixed by explicitly providing sizes (`Mat{n, m}(...)`).  I guess this method wasn't used so the error was never caught.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
