### PR TITLE
Add subtitles to Axis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## master
+
+- Added subtitle capability to `Axis` [#1859](https://github.com/JuliaPlots/Makie.jl/pull/1859).
+
 ## v0.17.2
 
 - Changed the default font from `Dejavu Sans` to `TeX Gyre Heros Makie` which is the same as `TeX Gyre Heros` with slightly decreased descenders and ascenders. Decreasing those metrics reduced unnecessary whitespace and alignment issues. Four fonts in total were added, the styles Regular, Bold, Italic and Bold Italic. Also changed `Axis`, `Axis3` and `Legend` attributes `titlefont` to `TeX Gyre Heros Makie Bold` in order to separate it better from axis labels in multifacet arrangements [#1897](https://github.com/JuliaPlots/Makie.jl/pull/1897).
@@ -8,7 +12,7 @@
 
 - Added word wrapping. In `Label`, `word_wrap = true` causes it to use the suggested width and wrap text to fit. In `text`, `word_wrap_width > 0` can be used to set a pixel unit line width. Any word (anything between two spaces without a newline) that goes beyond this width gets a newline inserted before it [#1819](https://github.com/JuliaPlots/Makie.jl/pull/1819).
 - Improved `Axis3`'s interactive performance [#1835](https://github.com/JuliaPlots/Makie.jl/pull/1835). 
-- Fixed errors in GLMakie's `scatter` implementation when markers are given as images. [#1917](https://github.com/JuliaPlots/Makie.jl/pull/1917)
+- Fixed errors in GLMakie's `scatter` implementation when markers are given as images. [#1917](https://github.com/JuliaPlots/Makie.jl/pull/1917).
 - Removed some method ambiguities introduced in v0.17 [#1922](https://github.com/JuliaPlots/Makie.jl/pull/1922).
 - Add an empty default label, `""`, to each slider that doesn't have a label in `SliderGrid` [#1888](https://github.com/JuliaPlots/Makie.jl/pull/1888).
 

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -43,3 +43,44 @@ end
     mesh!(fig.scene, lbl5.layoutobservables.computedbbox, color = (:red, 0.5))
     fig
 end
+
+@reference_test "Axis titles and subtitles" begin
+    f = Figure()
+
+    Axis(
+        f[1, 1],
+        title = "First Title",
+        subtitle = "This is a longer subtitle"
+    )
+    Axis(
+        f[1, 2],
+        title = "Second Title",
+        subtitle = "This is a longer subtitle",
+        titlealign = :left,
+        subtitlecolor = :gray50,
+        titlegap = 10,
+        titlesize = 20,
+        subtitlesize = 15,
+    )
+    Axis(
+        f[2, 1],
+        title = "Third Title",
+        titlecolor = :gray50,
+        titlefont = "TeX Gyre Heros Bold Italic Makie",
+        titlealign = :right,
+        titlesize = 25,
+    )
+    Axis(
+        f[2, 2],
+        title = "Fourth Title\nWith Line Break",
+        subtitle = "This is an even longer subtitle,\nthat also has a line break.",
+        titlealign = :left,
+        subtitlegap = 2,
+        titlegap = 5,
+        subtitlefont = "TeX Gyre Heros Italic Makie",
+        subtitlelineheight = 0.9,
+        titlelineheight = 0.9,
+    )
+
+    f
+end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -1,21 +1,21 @@
 @reference_test "Figure and Subplots" begin
-    fig, _ = scatter(randn(100, 2), color = :red)
-    scatter(fig[1, 2], randn(100, 2), color = :blue)
-    scatter(fig[2, 1:2], randn(100, 2), color = :green)
-    scatter(fig[1:2, 3][1:2, 1], randn(100, 2), color = :black)
-    scatter(fig[1:2, 3][3, 1], randn(100, 2), color = :gray)
+    fig, _ = scatter(RNG.randn(100, 2), color = :red)
+    scatter(fig[1, 2], RNG.randn(100, 2), color = :blue)
+    scatter(fig[2, 1:2], RNG.randn(100, 2), color = :green)
+    scatter(fig[1:2, 3][1:2, 1], RNG.randn(100, 2), color = :black)
+    scatter(fig[1:2, 3][3, 1], RNG.randn(100, 2), color = :gray)
     fig
 end
 
 @reference_test "Figure with Blocks" begin
     fig = Figure(resolution = (900, 900))
-    ax, sc = scatter(fig[1, 1][1, 1], randn(100, 2), axis = (;title = "Random Dots", xlabel = "Time"))
-    sc2 = scatter!(ax, randn(100, 2) .+ 2, color = :red)
+    ax, sc = scatter(fig[1, 1][1, 1], RNG.randn(100, 2), axis = (;title = "Random Dots", xlabel = "Time"))
+    sc2 = scatter!(ax, RNG.randn(100, 2) .+ 2, color = :red)
     ll = fig[1, 1][1, 2] = Legend(fig, [sc, sc2], ["Scatter", "Other"])
     lines(fig[2, 1:2][1, 3][1, 1], 0..3, sin ∘ exp, axis = (;title = "Exponential Sine"))
-    heatmap(fig[2, 1:2][1, 1], randn(30, 30))
-    heatmap(fig[2, 1:2][1, 2], randn(30, 30), colormap = :grays)
-    lines!(fig[2, 1:2][1, 2], cumsum(rand(30)), color = :red, linewidth = 10)
+    heatmap(fig[2, 1:2][1, 1], RNG.randn(30, 30))
+    heatmap(fig[2, 1:2][1, 2], RNG.randn(30, 30), colormap = :grays)
+    lines!(fig[2, 1:2][1, 2], cumsum(RNG.rand(30)), color = :red, linewidth = 10)
     surface(fig[1, 2], collect(1.0:40), collect(1.0:40), (x, y) -> 10 * cos(x) * sin(y))
     fig[2, 1:2][2, :] = Colorbar(fig, vertical = false,
         height = 20, ticklabelalign = (:center, :top), flipaxis = false)

--- a/ReferenceTests/src/tests/refimages.jl
+++ b/ReferenceTests/src/tests/refimages.jl
@@ -27,3 +27,6 @@ end
 @testset "short_tests.jl" begin
     include("short_tests.jl")
 end
+@testset "figures_and_makielayout.jl" begin
+    include("figures_and_makielayout.jl")
+end

--- a/docs/examples/blocks/axis.md
+++ b/docs/examples/blocks/axis.md
@@ -160,6 +160,8 @@ You can change titles and subtitles with the `title` and `subtitle` attributes.
 You can set `subtitlefont`, `subtitlefontsize` and `subtitlecolor` separately.
 The alignment of the subtitle follows that of the title.
 
+The gap between title and subtitle is set with `subtitlegap` and the gap between `Axis` and title or subtitle with `titlegap`.
+
 \begin{examplefigure}{svg = true}
 ```julia
 using CairoMakie
@@ -179,24 +181,33 @@ Axis(
     subtitle = "This is a longer subtitle",
     titlealign = :left,
     subtitlecolor = :gray50,
-    titlegap = 0,
+    titlegap = 10,
     titlesize = 20,
+    subtitlesize = 15,
 )
 Axis(
     f[2, 1],
     title = "Third Title",
+    titlecolor = :gray50,
+    titlefont = "TeX Gyre Heros Bold Italic Makie",
+    titlealign = :right,
+    titlesize = 25,
 )
 Axis(
     f[2, 2],
-    title = "Fourth Title",
+    title = "Fourth Title\nWith Line Break",
     subtitle = "This is an even longer subtitle,\nthat also has a line break.",
     titlealign = :left,
-    subtitlegap = 5,
-    subtitlefont = "TeX Gyre Heros Italic Makie"
+    subtitlegap = 2,
+    titlegap = 5,
+    subtitlefont = "TeX Gyre Heros Italic Makie",
+    subtitlelineheight = 0.9,
+    titlelineheight = 0.9,
 )
 
 f
 ```
+\end{examplefigure}
 
 ## Modifying ticks
 

--- a/docs/examples/blocks/axis.md
+++ b/docs/examples/blocks/axis.md
@@ -153,6 +153,51 @@ lines(f[1, 2], 0..10, sin, axis = (limits = (0, 10, -1, 1),))
 f
 ```
 \end{examplefigure}
+
+## Titles and subtitles
+
+You can change titles and subtitles with the `title` and `subtitle` attributes.
+You can set `subtitlefont`, `subtitlefontsize` and `subtitlecolor` separately.
+The alignment of the subtitle follows that of the title.
+
+\begin{examplefigure}{svg = true}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+
+f = Figure()
+
+Axis(
+    f[1, 1],
+    title = "First Title",
+    subtitle = "This is a longer subtitle"
+)
+Axis(
+    f[1, 2],
+    title = "Second Title",
+    subtitle = "This is a longer subtitle",
+    titlealign = :left,
+    subtitlecolor = :gray50,
+    titlegap = 0,
+    titlesize = 20,
+)
+Axis(
+    f[2, 1],
+    title = "Third Title",
+)
+Axis(
+    f[2, 2],
+    title = "Fourth Title",
+    subtitle = "This is an even longer subtitle,\nthat also has a line break.",
+    titlealign = :left,
+    subtitlegap = 5,
+    subtitlefont = "TeX Gyre Heros Italic Makie"
+)
+
+f
+```
+
 ## Modifying ticks
 
 To control ticks, you can set the axis attributes `xticks/yticks` and `xtickformat/ytickformat`.

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -285,7 +285,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         yminorgridnode[] = interleave_vectors(tickpos, opposite_tickpos)
     end
 
-    subtitlepos = lift(scene.px_area, ax.subtitlegap, ax.titlealign, ax.xaxisposition, xaxis.protrusion) do a,
+    subtitlepos = lift(scene.px_area, ax.titlegap, ax.titlealign, ax.xaxisposition, xaxis.protrusion) do a,
         titlegap, align, xaxisposition, xaxisprotrusion
 
         x = if align == :center
@@ -315,11 +315,12 @@ function initialize_block!(ax::Axis; palette = nothing)
         align = titlealignnode,
         font = ax.subtitlefont,
         color = ax.subtitlecolor,
+        lineheight = ax.subtitlelineheight,
         markerspace = :data,
         inspectable = false)
 
-    titlepos = lift(scene.px_area, ax.titlegap, ax.titlealign, ax.xaxisposition, xaxis.protrusion) do a,
-            titlegap, align, xaxisposition, xaxisprotrusion
+    titlepos = lift(scene.px_area, ax.titlegap, ax.subtitlegap, ax.titlealign, ax.xaxisposition, xaxis.protrusion, ax.subtitlelineheight) do a,
+            titlegap, subtitlegap, align, xaxisposition, xaxisprotrusion, _
 
         x = if align == :center
             a.origin[1] + a.widths[1] / 2
@@ -332,7 +333,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         end
 
         subtitlespace = if ax.subtitlevisible[] && !iswhitespace(ax.subtitle[])
-            boundingbox(subtitlet).widths[2] + ax.subtitlegap[]
+            boundingbox(subtitlet).widths[2] + subtitlegap
         else
             0f0
         end
@@ -351,6 +352,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         align = titlealignnode,
         font = ax.titlefont,
         color = ax.titlecolor,
+        lineheight = ax.titlelineheight,
         markerspace = :data,
         inspectable = false)
     decorations[:title] = titlet
@@ -358,7 +360,7 @@ function initialize_block!(ax::Axis; palette = nothing)
     function compute_protrusions(title, titlesize, titlegap, titlevisible, spinewidth,
                 topspinevisible, bottomspinevisible, leftspinevisible, rightspinevisible,
                 xaxisprotrusion, yaxisprotrusion, xaxisposition, yaxisposition,
-                subtitle, subtitlevisible, subtitlesize, subtitlegap)
+                subtitle, subtitlevisible, subtitlesize, subtitlegap, titlelineheight, subtitlelineheight)
 
         left, right, bottom, top = 0f0, 0f0, 0f0, 0f0
 
@@ -395,7 +397,8 @@ function initialize_block!(ax::Axis; palette = nothing)
     onany(ax.title, ax.titlesize, ax.titlegap, ax.titlevisible, ax.spinewidth,
             ax.topspinevisible, ax.bottomspinevisible, ax.leftspinevisible, ax.rightspinevisible,
             xaxis.protrusion, yaxis.protrusion, ax.xaxisposition, ax.yaxisposition,
-            ax.subtitle, ax.subtitlevisible, ax.subtitlesize, ax.subtitlegap) do args...
+            ax.subtitle, ax.subtitlevisible, ax.subtitlesize, ax.subtitlegap,
+            ax.titlelineheight, ax.subtitlelineheight) do args...
         ax.layoutobservables.protrusions[] = compute_protrusions(args...)
     end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -209,6 +209,8 @@ end
         titlealign::Symbol = :center
         "The color of the title"
         titlecolor::RGBAf = @inherit(:textcolor, :black)
+        "The axis title line height multiplier."
+        titlelineheight::Float64 = 1
         "The axis subtitle string."
         subtitle = ""
         "The font family of the subtitle."
@@ -216,11 +218,13 @@ end
         "The subtitle's font size."
         subtitlesize::Float64 = @inherit(:fontsize, 16f0)
         "The gap between subtitle and title."
-        subtitlegap::Float64 = 4f0
+        subtitlegap::Float64 = 2
         "Controls if the subtitle is visible."
         subtitlevisible::Bool = true
         "The color of the subtitle"
         subtitlecolor::RGBAf = @inherit(:textcolor, :black)
+        "The axis subtitle line height multiplier."
+        subtitlelineheight::Float64 = 1
         "The font family of the xlabel."
         xlabelfont::Makie.FreeTypeAbstraction.FTFont = @inherit(:font, "TeX Gyre Heros Makie")
         "The font family of the ylabel."

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -218,7 +218,7 @@ end
         "The subtitle's font size."
         subtitlesize::Float64 = @inherit(:fontsize, 16f0)
         "The gap between subtitle and title."
-        subtitlegap::Float64 = 2
+        subtitlegap::Float64 = 0
         "Controls if the subtitle is visible."
         subtitlevisible::Bool = true
         "The color of the subtitle"

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -209,6 +209,18 @@ end
         titlealign::Symbol = :center
         "The color of the title"
         titlecolor::RGBAf = @inherit(:textcolor, :black)
+        "The axis subtitle string."
+        subtitle = ""
+        "The font family of the subtitle."
+        subtitlefont::Makie.FreeTypeAbstraction.FTFont = @inherit(:font, "DejaVu Sans")
+        "The subtitle's font size."
+        subtitlesize::Float64 = @inherit(:fontsize, 16f0)
+        "The gap between subtitle and title."
+        subtitlegap::Float64 = 4f0
+        "Controls if the subtitle is visible."
+        subtitlevisible::Bool = true
+        "The color of the subtitle"
+        subtitlecolor::RGBAf = @inherit(:textcolor, :black)
         "The font family of the xlabel."
         xlabelfont::Makie.FreeTypeAbstraction.FTFont = @inherit(:font, "TeX Gyre Heros Makie")
         "The font family of the ylabel."

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -212,7 +212,7 @@ end
         "The axis subtitle string."
         subtitle = ""
         "The font family of the subtitle."
-        subtitlefont::Makie.FreeTypeAbstraction.FTFont = @inherit(:font, "DejaVu Sans")
+        subtitlefont::Makie.FreeTypeAbstraction.FTFont = @inherit(:font, "TeX Gyre Heros Makie")
         "The subtitle's font size."
         subtitlesize::Float64 = @inherit(:fontsize, 16f0)
         "The gap between subtitle and title."


### PR DESCRIPTION
# Description

Adds subtitle functionality to `Axis` which only has titles so far.
Can be used for something like this:

```julia
f = Figure(fontsize = 18, font = "TeX Gyre Heros")
ax = Axis(f[1, 1],
        title = "Trigonometric functions",
        subtitle = "Sine, cosine and tangens are the most used functions.",
        subtitlevisible = true,
        titlefont = "TeX Gyre Heros Bold",
        # titlesize = 22,
        # titlegap = 0,
        subtitlefont = "TeX Gyre Heros",
        # subtitlesize = 40,
        titlealign = :left,
        # height = 200
    )
lines!(ax, 0..pi/4, sin, label = "sin")
lines!(ax, 0..pi/4, cos, label = "cos")
lines!(ax, 0..pi/4, tan, label = "tan")
Legend(f[1, 2], ax)
f
```
![grafik](https://user-images.githubusercontent.com/22495855/166115494-d4b49600-04b8-4717-afaa-3f55ead625c3.png)


## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
