### PR TITLE
Mention merge and uniqe in docstring

### DIFF
--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -584,6 +584,12 @@ The position can be a Symbol where the first letter controls the horizontal
 alignment and can be l, r or c, and the second letter controls the vertical
 alignment and can be t, b or c. Or it can be a tuple where the first
 element is set as the Legend's halign and the second element as its valign.
+                        
+With the keywords merge and unique you can control how plot objects with the 
+same labels are treated. If merge is true, all plot objects with the same 
+label will be layered on top of each other into one legend entry. If unique 
+is true, all plot objects with the same plot type and label will be reduced 
+to one occurrence.
 """
 function axislegend(ax, args...; position = :rt, kwargs...)
     Legend(ax.parent, args...;


### PR DESCRIPTION
This PR copies a few lines from the documentation to the docstring for `axislegend`. This should reduce the need for googling, and make finding the relevant documentation faster.