### PR TITLE
Add single-plot rasterization capability to CairoMakie

### DIFF
--- a/CairoMakie/src/infrastructure.jl
+++ b/CairoMakie/src/infrastructure.jl
@@ -255,21 +255,9 @@ end
 #   instead of the whole Scene
 # - Recognize when a screen is an image surface, and set scale to render the plot
 #   at the scale of the device pixel
-function draw_plot_as_image(scene::Scene, screen::CairoScreen, primitive::Combined, scale = 1)
-    # you can provide `p.rasterize = scale::Int` or `p.rasterize = true`,
-    @assert scale isa Int || scale isa Bool
+function draw_plot_as_image(scene::Scene, screen::CairoScreen, primitive::Combined, scale::Number = 1)
+    # you can provide `p.rasterize = scale::Int` or `p.rasterize = true`, both of which are numbers
 
-    # If plt.rasterize = true, then we want to rasterize to the exact scale necessary.
-    # So we find the device scaling factor so that we can scale our own rendered
-    # image to that precise scale.
-    if scale == true
-        xscale = Ref(0e0)
-        yscale = Ref(0e0)
-        ccall((:cairo_surface_get_device_scale, Cairo.libcairo), Cvoid, (Ptr{Nothing}, Ptr{Cdouble}, Ptr{Cdouble}),
-            screen.surface.ptr, xscale, yscale)
-
-        scale = max(xscale[], yscale[])
-    end
     # Extract scene width in pixels
     w, h = Int.(scene.px_area[].widths)
     # Create a new Screen which renders directly to an image surface,
@@ -290,7 +278,7 @@ function draw_plot_as_image(scene::Scene, screen::CairoScreen, primitive::Combin
     # this is needed to avoid blurry edges
     Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
     # Set filter doesn't work!?
-    Cairo.pattern_set_filter(p, Cairo.FILTER_BEST)
+    Cairo.pattern_set_filter(p, Cairo.FILTER_BILINEAR)
     Cairo.fill(screen.context)
     Cairo.restore(screen.context)
 

--- a/CairoMakie/src/infrastructure.jl
+++ b/CairoMakie/src/infrastructure.jl
@@ -171,7 +171,17 @@ function cairo_draw(screen::CairoScreen, scene::Scene)
             last_scene = pparent
         end
         Cairo.save(screen.context)
-        draw_plot(pparent, screen, p)
+
+        # This is a bit of a hack for now.  When a plot is too large to save with
+        # a reasonable file size on a vector backend, the user can choose to
+        # rasterize it when plotting to vector backends, by using the `rasterize`
+        # keyword argument.  This can be set to a Bool or an Int which describes
+        # the density of rasterization (in terms of a direct scaling factor.)
+        if to_value(get(p, :rasterize, false)) != false
+            draw_plot_as_image(pparent, screen, p, p[:rasterize][])
+        else # draw vector
+            draw_plot(pparent, screen, p)
+        end
         Cairo.restore(screen.context)
     end
 
@@ -237,6 +247,43 @@ function draw_plot(scene::Scene, screen::CairoScreen, primitive::Combined)
             end
         end
     end
+    return
+end
+
+# Possible improvements for this function:
+# - Obtain the bbox of the plot and draw an image which tightly fits that bbox
+#   instead of the whole Scene
+# - Recognize when a screen is an image surface, and set scale to render the plot
+#   at the scale of the device pixel
+function draw_plot_as_image(scene::Scene, screen::CairoScreen, primitive::Combined, scale = 1)
+    # you can provide `p.rasterize = scale::Int` or `p.rasterize = true`,
+    # if true then scale = 1.
+    scale == true && (scale = 1)
+    @assert scale isa Int || scale isa Bool
+    # Extract scene width in pixels
+    w, h = Int.(scene.px_area[].widths)
+    # Create a new Screen which renders directly to an image surface,
+    # specifically for the plot's parent scene.
+    scr = CairoScreen(scene; device_scaling_factor = scale)
+    # Draw the plot to the screen, in the normal way
+    draw_plot(scene, scr, primitive)
+
+    # Now, we draw the rasterized plot to the main screen.
+    # Since it has already been prepared by `prepare_for_scene`,
+    # we can draw directly to the Screen.
+    Cairo.rectangle(screen.context, 0, 0, w, h)
+    Cairo.save(screen.context)
+    Cairo.translate(screen.context, 0, 0)
+    # Cairo.scale(screen.context, w / scr.surface.width, h / scr.surface.height)
+    Cairo.set_source_surface(screen.context, scr.surface, 0, 0)
+    p = Cairo.get_source(scr.context)
+    # this is needed to avoid blurry edges
+    Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+    # Set filter doesn't work!?
+    Cairo.pattern_set_filter(p, Cairo.FILTER_BEST)
+    Cairo.fill(screen.context)
+    Cairo.restore(screen.context)
+
     return
 end
 

--- a/CairoMakie/test/rasterization_tests.jl
+++ b/CairoMakie/test/rasterization_tests.jl
@@ -1,0 +1,28 @@
+# guard against some future changes silently making simple vector graphics be
+# rasterized if they are using features unsupported by the SVG spec
+function svg_has_image(x)
+    mktempdir() do path
+        path = joinpath(path, "test.svg")
+        save(path, x)
+        # this is rough but an easy way to catch rasterization,
+        # if an image element is present in the svg
+        return !occursin("<image id=", read(path, String))
+    end
+end
+
+@testset "Internal rasterization" begin
+    fig = Figure()
+    ax = Axis(fig[1,1])
+    lp = lines!(ax, vcat(1:10, 10:-1:1))
+
+    @testset "Unrasterized SVG" begin
+        @test svg_has_image(fig)
+    end
+
+    @testset "Rasterized SVG" begin
+        lp.rasterize = true
+        @test !svg_has_image(fig)
+        lp.rasterize = 10
+        @test !svg_has_image(fig)
+    end
+end

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -16,6 +16,7 @@ Pkg.develop(PackageSpec(path = path))
 end
 
 include(joinpath(@__DIR__, "svg_tests.jl"))
+include(joinpath(@__DIR__, "rasterization_tests.jl"))
 
 using ReferenceTests
 using ReferenceTests: database_filtered

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - **Breaking** Bumped `GridLayoutBase` version to `v0.7`, which introduced offset layouts. Now, indexing into row 0 doesn't create a new row 1, but a new row 0, so that all previous content positions stay the same. This makes building complex layouts order-independent [#1704](https://github.com/JuliaPlots/Makie.jl/pull/1704).
 - `Layoutable` was renamed to `Block` and the infrastructure changed such that attributes are fixed fields and each block has its own `Scene` for better encapsulation.
 - Added `SliderGrid` block which replaces the deprecated `labelslider!` and `labelslidergrid!` functions.
+- CairoMakie can internally rasterize a `Plot` if `plt.rasterize = true` or `plt.rasterize = scale::Int`.
 - Changed some code which consistently caused a segfault in `streamplot_impl` on Mac M1.
 - Fixed a method ambiguity in `rotatedrect`.
 

--- a/docs/documentation/backends/cairomakie.md
+++ b/docs/documentation/backends/cairomakie.md
@@ -45,3 +45,13 @@ CairoMakie as a 2D engine has no concept of z-clipping, therefore its 3D capabil
 The z-values of 3D plots will have no effect and will be projected flat onto the canvas.
 Z-layering is approximated by sorting all plot objects by their z translation value before drawing, after that by parent scene and then insertion order.
 Therefore, if you want to draw something on top of something else, but it ends up below, try translating it forward via `translate!(obj, 0, 0, some_positive_z_value)`.
+
+#### Selective Rasterization
+
+By setting the `rasterize` attribute of a plot, you can tell CairoMakie that this plot needs to be rasterized when saving, even if saving to a vector backend.  This can be very useful for large meshes, surfaces or even heatmaps if on an irregular grid.
+
+Assuming that you have a `Plot` object `plt`, you can set `plt.rasterize = true` for simple rasterization, or you can set `plt.rasterize = scale::Int`, where `scale` represents the scaling factor for the image surface.
+
+For example, if your Scene's resolution is `(800, 600)`, by setting `scale=2`, the rasterized image will have a resolution of `(1600, 1200)`.
+
+You can deactivate this rasterization by setting `plt.rasterize = false`.


### PR DESCRIPTION
# Description

Allows the user to tell CairoMakie to rasterize individual Plots in a Scene, by setting `plt.rasterize = scale::Int || true`.  

CairoMakie will rasterize that specific plot to an image with `scale^2` pixels per Scene pixel (1 px per scene px if scale=1 or scale=true) and draw it to the main context.  The drawing order also preserves the z-order of the scene.

This has the potential to drastically decrease file sizes, which is extremely useful for publication plots and large meshes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
