### PR TITLE
Allow antialias configuration in CairoBackend

### DIFF
--- a/CairoMakie/src/CairoMakie.jl
+++ b/CairoMakie/src/CairoMakie.jl
@@ -51,15 +51,17 @@ const _last_inline = Ref(true)
 const _last_type = Ref("png")
 const _last_px_per_unit = Ref(1.0)
 const _last_pt_per_unit = Ref(0.75)
+const _last_antialias = Ref(Cairo.ANTIALIAS_BEST)
 
-function activate!(; inline = _last_inline[], type = _last_type[], px_per_unit=_last_px_per_unit[], pt_per_unit=_last_pt_per_unit[])
-    backend = CairoBackend(display_path(type); px_per_unit=px_per_unit, pt_per_unit=pt_per_unit)
+function activate!(; inline = _last_inline[], type = _last_type[], px_per_unit=_last_px_per_unit[], pt_per_unit=_last_pt_per_unit[], antialias = _last_antialias[])
+    backend = CairoBackend(display_path(type); px_per_unit=px_per_unit, pt_per_unit=pt_per_unit, antialias = antialias)
     Makie.current_backend[] = backend
     Makie.use_display[] = !inline
     _last_inline[] = inline
     _last_type[] = type
     _last_px_per_unit[] = px_per_unit
     _last_pt_per_unit[] = pt_per_unit
+    _last_antialias[] = antialias
     return
 end
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - **Breaking** Bumped `GridLayoutBase` version to `v0.7`, which introduced offset layouts. Now, indexing into row 0 doesn't create a new row 1, but a new row 0, so that all previous content positions stay the same. This makes building complex layouts order-independent [#1704](https://github.com/JuliaPlots/Makie.jl/pull/1704).
 - `Layoutable` was renamed to `Block` and the infrastructure changed such that attributes are fixed fields and each block has its own `Scene` for better encapsulation.
 - Added `SliderGrid` block which replaces the deprecated `labelslider!` and `labelslidergrid!` functions.
+- The default anti-aliasing method can now be set in `CairoMakie.activate!` using the `antialias` keyword.  Available options are `CairoMakie.Cairo.ANTIALIAS_*`.
 - Changed some code which consistently caused a segfault in `streamplot_impl` on Mac M1.
 - Set the [Cairo miter limit](https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-set-miter-limit) to mimic GLMakie behaviour [#1844]
 - Fixed a method ambiguity in `rotatedrect`.


### PR DESCRIPTION
# Description

Allows the backend to set the antialias method in CairoMakie.  Just a small feature which I thought I'd add since it's pretty easy to do.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)