### PR TITLE
default labels

### DIFF
--- a/src/makielayout/blocks/slidergrid.jl
+++ b/src/makielayout/blocks/slidergrid.jl
@@ -51,7 +51,7 @@ function initialize_block!(sg::SliderGrid, nts::NamedTuple...)
     extract_range_format(x) = (x, default_format)
 
     for (i, nt) in enumerate(nts)
-        label = nt.label
+        label = haskey(nt, :label) ? nt.label : ""
         range = nt.range
         format = haskey(nt, :format) ? nt.format : default_format
         remaining_pairs = filter(pair -> pair[1] ∉ (:label, :range, :format), pairs(nt))


### PR DESCRIPTION
# Description
Add an empty default label, `""`,  to each slider that doesn't have a label in `SliderGrid`. `range` is still required.

## Fixes 
This
```julia
SliderGrid(fig[1,1], (; range = 0:5))
```
which would otherwise error.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
