### PR TITLE
streamline convert_for_attribute

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -565,10 +565,7 @@ end
 
 observable_type(x::Type{Observable{T}}) where T = T
 
-convert_for_attribute(t::Type{T}, value::T) where T = value
-convert_for_attribute(t::Type{Float64}, x) = convert(Float64, x)
-convert_for_attribute(t::Type{Float64}, x::Float64) = x
-convert_for_attribute(t::Type{RGBAf}, x) = to_color(x)::RGBAf
-convert_for_attribute(t::Type{RGBAf}, x::RGBAf) = x
 convert_for_attribute(t::Any, x) = x
+convert_for_attribute(t::Type{Float64}, x) = convert(Float64, x)
+convert_for_attribute(t::Type{RGBAf}, x) = to_color(x)::RGBAf
 convert_for_attribute(t::Type{Makie.FreeTypeAbstraction.FTFont}, x) = to_font(x)


### PR DESCRIPTION
# Description

This PR allows us to upgrade Makie in AlgebraOfGraphics without [this piracy](https://github.com/JuliaPlots/AlgebraOfGraphics.jl/pull/386/commits/85ea65cbe21ebe09ff1a48ec70de10388d34e64c).

As the general fallbacks for `convert_for_attribute` do the correct thing, this removes a few method to avoid ambiguities. In particular, `convert_for_attribute(t::Type{Makie.FreeTypeAbstraction.FTFont}, x::Makie.FreeTypeAbstraction.FTFont)` now does the correct thing instead of a method error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

