### PR TITLE
Small raincloud fixes

### DIFF
--- a/docs/examples/plotting_functions/rainclouds.md
+++ b/docs/examples/plotting_functions/rainclouds.md
@@ -15,15 +15,16 @@ using Makie: rand_localized
 ####
 
 function mockup_distribution(N)
-    all_possible_labels = ["Single Mode", "Double Mode", "Single Mode", "Double Mode", "Random Exp", "Uniform"]
-    category_label = rand(all_possible_labels)
+    all_possible_labels = ["Single Mode", "Double Mode", "Single Mode", "Double Mode", 
+                           "Random Exp", "Uniform"]
+    category_type = rand(all_possible_labels)
 
-    if category_label == "Single Mode"
+    if category_type == "Single Mode"
         random_mean = rand_localized(0, 8)
         random_spread_coef = rand_localized(0.3, 1)
         data_points = random_spread_coef*randn(N) .+ random_mean
 
-    elseif category_label == "Double Mode"
+    elseif category_type == "Double Mode"
         random_mean = rand_localized(0, 8)
         random_spread_coef = rand_localized(0.3, 1)
         data_points = random_spread_coef*randn(Int(round(N/2.0))) .+ random_mean
@@ -32,10 +33,10 @@ function mockup_distribution(N)
         random_spread_coef = rand_localized(0.3, 1)
         data_points = vcat(data_points, random_spread_coef*randn(Int(round(N/2.0))) .+ random_mean)
 
-    elseif category_label == "Random Exp"
+    elseif category_type == "Random Exp"
         data_points = randexp(N)
 
-    elseif category_label == "Uniform"
+    elseif category_type == "Uniform"
         min = rand_localized(0, 4)
         max = min + rand_localized(0.5, 4)
         data_points = [rand_localized(min, max) for _ in 1:N]
@@ -44,15 +45,15 @@ function mockup_distribution(N)
         error("Unidentified category.")
     end
 
-    return category_label, data_points
+    return data_points
 end
 
 function mockup_categories_and_data_array(num_categories; N = 500)
     category_labels = String[]
     data_array = Float64[]
 
-    for _ in 1:num_categories
-        category_label, data_points = mockup_distribution(N)
+    for category_label in string.(('A':'Z')[1:min(num_categories, end)])
+        data_points = mockup_distribution(N)
 
         append!(category_labels, fill(category_label, N))
         append!(data_array, data_points)
@@ -62,9 +63,11 @@ end
 
 category_labels, data_array = mockup_categories_and_data_array(3)
 
+colors = Makie.wong_colors()
 fig = rainclouds(category_labels, data_array;
     xlabel = "Categories of Distributions", ylabel = "Samples", title = "My Title",
-    plot_boxplots = false, cloud_width=0.5, clouds=hist, hist_bins=50)
+    plot_boxplots = false, cloud_width=0.5, clouds=hist, hist_bins=50, 
+    color = colors[indexin(category_labels, unique(category_labels))])
 fig
 ```
 \end{examplefigure}
@@ -75,7 +78,9 @@ fig
 fig = rainclouds(category_labels, data_array;
     xlabel = "Categories of Distributions",
     ylabel = "Samples", title = "My Title",
-    plot_boxplots = true, cloud_width=0.5, clouds=hist)
+    plot_boxplots = true, cloud_width=0.5, clouds=hist,
+    color = colors[indexin(category_labels, unique(category_labels))])
+fig
 ```
 \end{examplefigure}
 
@@ -84,38 +89,31 @@ fig = rainclouds(category_labels, data_array;
 ```julia
 fig = rainclouds(category_labels, data_array;
     xlabel = "Categories of Distributions", ylabel = "Samples", title = "My Title",
-    plot_boxplots = true, cloud_width=0.5, side = :right)
+    plot_boxplots = true, cloud_width=0.5, side = :right,
+    color = colors[indexin(category_labels, unique(category_labels))])
+fig
 ```
 \end{examplefigure}
 
 \begin{examplefigure}{}
 ```julia
-more_category_labels = repeat(category_labels, 2)
-more_data_array = repeat(data_array, 2)
+more_category_labels, more_data_array = mockup_categories_and_data_array(6)
 
 fig = rainclouds(more_category_labels, more_data_array;
     xlabel = "Categories of Distributions", ylabel = "Samples", title = "My Title",
-    plot_boxplots = true, cloud_width=0.5)
+    plot_boxplots = true, cloud_width=0.5,
+    color = colors[indexin(more_category_labels, unique(more_category_labels))])
 ```
 \end{examplefigure}
 
 \begin{examplefigure}{}
 ```julia
 category_labels, data_array = mockup_categories_and_data_array(6)
-fig = rainclouds(more_category_labels, more_data_array;
+fig = rainclouds(category_labels, data_array;
     xlabel = "Categories of Distributions",
     ylabel = "Samples", title = "My Title",
-    plot_boxplots = true, cloud_width=0.5)
-```
-\end{examplefigure}
-
-\begin{examplefigure}{}
-```julia
-category_labels, data_array = mockup_categories_and_data_array(6)
-rainclouds(more_category_labels, more_data_array;
-    xlabel = "Categories of Distributions",
-    ylabel = "Samples", title = "My Title",
-    plot_boxplots = true, cloud_width=0.5, dist_between_categories = 0.6)
+    plot_boxplots = true, cloud_width=0.5,
+    color = colors[indexin(category_labels, unique(category_labels))])
 ```
 \end{examplefigure}
 
@@ -126,27 +124,32 @@ With and Without Box Plot
 \begin{examplefigure}{}
 ```julia
 fig = Figure(resolution = (800*2, 600*5))
+colors = [Makie.wong_colors(); Makie.wong_colors()]
 
 category_labels, data_array = mockup_categories_and_data_array(3)
 rainclouds!(Axis(fig[1, 1]), category_labels, data_array;
     title = "Left Side, with Box Plot",
     side = :left,
-    plot_boxplots = true)
+    plot_boxplots = true,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 rainclouds!(Axis(fig[2, 1]), category_labels, data_array;
     title = "Left Side, without Box Plot",
     side = :left,
-    plot_boxplots = false)
+    plot_boxplots = false,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 rainclouds!(Axis(fig[1, 2]), category_labels, data_array;
     title = "Right Side, with Box Plot",
     side = :right,
-    plot_boxplots = true)
+    plot_boxplots = true,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 rainclouds!(Axis(fig[2, 2]), category_labels, data_array;
     title = "Right Side, without Box Plot",
     side = :right,
-    plot_boxplots = false)
+    plot_boxplots = false,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 # Plots wiht more categories
 # dist_between_categories (0.6, 1.0)
@@ -156,19 +159,23 @@ category_labels, data_array = mockup_categories_and_data_array(12)
 rainclouds!(Axis(fig[3, 1:2]), category_labels, data_array;
     title = "More categories. Default spacing.",
     plot_boxplots = true,
-    dist_between_categories = 1.0)
+    dist_between_categories = 1.0,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 rainclouds!(Axis(fig[4, 1:2]), category_labels, data_array;
     title = "More categories. Adjust space. (smaller cloud widths and smaller category distances)",
     plot_boxplots = true,
     cloud_width = 0.3,
-    dist_between_categories = 0.5)
+    dist_between_categories = 0.5,
+    color = colors[indexin(category_labels, unique(category_labels))])
+
 
 rainclouds!(Axis(fig[5, 1:2]), category_labels, data_array;
     title = "More categories. Adjust space. No clouds.",
     plot_boxplots = true,
     clouds = nothing,
-    dist_between_categories = 0.5)
+    dist_between_categories = 0.5,
+    color = colors[indexin(category_labels, unique(category_labels))])
 
 supertitle = Label(fig[0, :], "Cloud Plot Testing (Scatter, Violin, Boxplot)", textsize=30)
 fig

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -261,9 +261,10 @@ function plot!(plot::RainClouds)
             for (_, ixs) in group_labels(category_labels, data_array)
                 isempty(ixs) && continue
                 xoffset = final_x_positions[ixs[1]] - recenter_to_boxplot_nudge_value
-                hist!(plot, data_array; direction=:x, offset=xoffset,
-                        scale_to=-cloud_width*width_ratio, bins=hist_bins,
-                        color=getuniquevalue(plot.color, ixs))
+                hist!(plot, view(data_array, ixs); direction=:x, offset=xoffset,
+                        scale_to=-cloud_width*width_ratio, 
+                        bins=pick_hist_edges(data_array, hist_bins),
+                        color=getuniquevalue(plot.color[], ixs))
             end
         else
             error("cloud attribute accepts (violin, hist, nothing), but not: $(clouds)")

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -258,12 +258,12 @@ function plot!(plot::RainClouds)
                     show_median=show_median, side=side, width=width_ratio*cloud_width, plot.cycle,
                     plot.color, gap=0)
         elseif clouds === hist
+            edges = pick_hist_edges(data_array, hist_bins)
             for (_, ixs) in group_labels(category_labels, data_array)
                 isempty(ixs) && continue
                 xoffset = final_x_positions[ixs[1]] - recenter_to_boxplot_nudge_value
                 hist!(plot, view(data_array, ixs); direction=:x, offset=xoffset,
-                        scale_to=-cloud_width*width_ratio, 
-                        bins=pick_hist_edges(data_array, hist_bins),
+                        scale_to=-cloud_width*width_ratio, bins=edges,
                         color=getuniquevalue(plot.color[], ixs))
             end
         else

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -18,26 +18,31 @@ rand_localized(RNG::Random.AbstractRNG, min, max) = rand(RNG) * (max - min) .+ m
 """
     rainclouds!(ax, category_labels, data_array; plot_boxplots=true, plot_clouds=true, kwargs...)
 
-Plot a violin (/histogram), boxplot and individual data points with appropriate spacing between each.
+Plot a violin (/histogram), boxplot and individual data points with appropriate spacing
+between each.
 
 # Arguments
 - `ax`: Axis used to place all these plots onto.
-- `category_labels`: Typically `Vector{String}` with a label for each element in `data_array`
+- `category_labels`: Typically `Vector{String}` with a label for each element in
+  `data_array`
 - `data_array`: Typically `Vector{Float64}` used for to represent the datapoints to plot.
 
 # Keywords
 - `plot_boxplots=true`: Boolean to show boxplots to summarize distribution of data.
-- `clouds=violin`: [violin, hist, nothing] to show cloud plots either as violin or histogram plot, or no cloud plot.
-- `hist_bins=30`: if `clouds=hist`, this passes down the number of bins to the histogram call.
+- `clouds=violin`: [violin, hist, nothing] to show cloud plots either as violin or histogram
+  plot, or no cloud plot.
+- `hist_bins=30`: if `clouds=hist`, this passes down the number of bins to the histogram
+  call.
 - `gap=0.2`: Distance between elements of x-axis.
-- `side=:left`: Can take values of `:left` or `:right`. Determines which side the violin plot will be on.
-- `center_boxplot=true`: Determines whether or not to have the boxplot be centered in the category.
-- `dodge`: vector of `Integer`` (length of data) of grouping variable to create multiple side-by-side boxes at the same x position
+- `side=:left`: Can take values of `:left` or `:right`. Determines which side the violin
+  plot will be on.
+- `center_boxplot=true`: Determines whether or not to have the boxplot be centered in the
+  category.
+- `dodge`: vector of `Integer`` (length of data) of grouping variable to create multiple
+  side-by-side boxes at the same x position
 - `dodge_gap = 0.03`: spacing between dodged boxes
 - `n_dodge`: the number of categories to dodge (defaults to maximum(dodge))
-- `color`: the fill color of the plots (defaults to theme :patchcolor), you can directly
-define colors for all data here, or use the Axis palette property that cycles through integer
-values speciefied in color (see Makie themeing docs)
+- `color`: a single color, or a vector of colors, one for each point
 
 ## Violin Plot Specific Keywords
 - `cloud_width=1.0`: Determines size of violin plot. Corresponds to `width` keyword arg in
@@ -45,17 +50,21 @@ values speciefied in color (see Makie themeing docs)
 
 ## Box Plot Specific Keywords
 - `boxplot_width=0.1`: Width of the boxplot in category x-axis absolute terms.
-- `whiskerwidth=0.5`: The width of the Q1, Q3 whisker in the boxplot. Value as a portion of the `boxplot_width`.
+- `whiskerwidth=0.5`: The width of the Q1, Q3 whisker in the boxplot. Value as a portion of
+  the `boxplot_width`.
 - `strokewidth=1.0`: Determines the stroke width for the outline of the boxplot.
-- `show_median=true`: Determines whether or not to have a line should the median value in the boxplot.
-- `boxplot_nudge=0.075`: Determines the distance away the boxplot should be placed from the center line when `center_boxplot` is `false`.
-    This is the value used to recentering the boxplot.
+- `show_median=true`: Determines whether or not to have a line should the median value in
+  the boxplot.
+- `boxplot_nudge=0.075`: Determines the distance away the boxplot should be placed from the
+    center line when `center_boxplot` is `false`. This is the value used to recentering the
+    boxplot.
 - `show_boxplot_outliers`: show outliers in the boxplot as points (usually confusing when
 paired with the scatter plot so the default is to not show them)
 
 ## Scatter Plot Specific Keywords
 - `side_nudge`: Default value is 0.02 if `plot_boxplots` is true, otherwise `0.075` default.
-- `jitter_width=0.05`: Determines the width of the scatter-plot bar in category x-axis absolute terms.
+- `jitter_width=0.05`: Determines the width of the scatter-plot bar in category x-axis
+  absolute terms.
 - `markersize=2`: Size of marker used for the scatter plot.
 
 ## Axis General Keywords

--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -66,26 +66,27 @@ $(ATTRIBUTES)
     )
 end
 
+function pick_hist_edges(vals, bins)
+    if bins isa Int
+        mi, ma = float.(extrema(vals))
+        if mi == ma
+            return [mi - 0.5, ma + 0.5]
+        end
+        # hist is right-open, so to include the upper data point, make the last bin a tiny bit bigger
+        ma = nextfloat(ma)
+        return range(mi, ma, length = bins+1)
+    else
+        if !issorted(bins)
+            error("Histogram bins are not sorted: $bins")
+        end
+        return bins
+    end
+end
+
 function Makie.plot!(plot::Hist)
 
     values = plot.values
-
-    edges = lift(values, plot.bins) do vals, bins
-        if bins isa Int
-            mi, ma = float.(extrema(vals))
-            if mi == ma
-                return [mi - 0.5, ma + 0.5]
-            end
-            # hist is right-open, so to include the upper data point, make the last bin a tiny bit bigger
-            ma = nextfloat(ma)
-            return range(mi, ma, length = bins+1)
-        else
-            if !issorted(bins)
-                error("Histogram bins are not sorted: $bins")
-            end
-            return bins
-        end
-    end
+    edges = lift(pick_hist_edges, values, plot.bins) 
 
     points = lift(edges, plot.normalization, plot.scale_to, plot.weights) do edges, normalization, scale_to, wgts
         w = wgts === automatic ? () : (StatsBase.weights(wgts),)


### PR DESCRIPTION
# Description

This makes a few small improvements to #1725.

- Add colors to raincloud usage
- Fix bug in raincloud histogram to use same bins across categories
- Fix bug in raincloud histogram to only use data from within a category label

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
