### PR TITLE
Better code formatting for `@lift` docstring

### DIFF
--- a/src/interaction/liftmacro.jl
+++ b/src/interaction/liftmacro.jl
@@ -10,7 +10,7 @@ function find_observable_expressions(obj::Expr)
             observable_expressions = union(observable_expressions, find_observable_expressions(a))
         end
     end
-    observable_expressions
+    return observable_expressions
 end
 
 # empty dict if x is not an Expr
@@ -42,19 +42,25 @@ end
 replace_observable_expressions!(x, exprdict) = nothing
 
 """
-Replaces an expression with lift(argtuple -> expression, args...), where args
+Replaces an expression with `lift(argtuple -> expression, args...)`, where `args`
 are all expressions inside the main one that begin with \$.
 
 # Example:
 
+```julia
 x = Observable(rand(100))
 y = Observable(rand(100))
+```
 
 ## before
+```julia
 z = lift((x, y) -> x .+ y, x, y)
+```
 
 ## after
+```julia
 z = @lift(\$x .+ \$y)
+```
 
 You can also use parentheses around an expression if that expression evaluates to an observable.
 
@@ -96,5 +102,5 @@ macro lift(exp)
         esc.(observable_expressions_without_dollar)...
     )
 
-    lift_expression
+    return lift_expression
 end


### PR DESCRIPTION
# Description

Better code formatting for `@lift` docstring

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
