### PR TITLE
also consider newline chars for line wrapping

### DIFF
--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -114,7 +114,8 @@ function glyph_collection(
             push!(xs[end], x)
             x += charinfos[i].hadvance
             
-            if 0 < word_wrap_width < x && (ci.char == ' ' || i == length(charinfos)) && 
+            if 0 < word_wrap_width < x &&
+                    ((ci.char == ' ' || ci.char == '\n') || i == length(charinfos)) &&
                     last_space_local_idx != 0
 
                 newline_offset = xs[end][last_space_local_idx + 1]
@@ -133,6 +134,14 @@ function glyph_collection(
                 
                 if i == length(charinfos)
                     push!(lineinfos, view(charinfos, last_line_start:i))
+                end
+
+                if ci.char == '\n'
+                    push!(xs, Float32[])
+                    push!(lineinfos, view(charinfos, last_line_start:i))
+                    last_space_local_idx = 0
+                    last_line_start = i+1
+                    x = 0f0
                 end
 
             elseif ci.char == '\n' || i == length(charinfos)


### PR DESCRIPTION
# Description

In the course of adapting the text line wrapping feature I noticed that newline chars are not considered when looking for line wrap positions. Consequently, visual box width overflows can appear.

Unfortunately, I could not come up with a MWE that shows this with Makie only features.
Instead, I have two gifs here https://github.com/fatteneder/MakieSlides.jl/pull/12 that illustrate the issue.

## Type of change

- [x] Bug fix

## Checklist

- [ ] Also ignore whitespace and newline chars at which we wrap when determining the full width.
```
                      currently line width includes this trailing whitespace/newline, but it shouldn't
                            ↓                          
word{space}word{space}word{space}
```
@ffreyer Could this be related to this TODO here: https://github.com/JuliaPlots/Makie.jl/blob/07f0763bcb8e990274aec5335deaa247bcf60229/src/layouting/layouting.jl#L127