### PR TITLE
fix #1969, interpolate cmap correctly

### DIFF
--- a/GLMakie/assets/shader/heatmap.frag
+++ b/GLMakie/assets/shader/heatmap.frag
@@ -31,7 +31,7 @@ vec4 get_color_from_cmap(float value, sampler1D color_map, vec2 colorrange) {
     // between the colors, we need to scale it, so that the ends are at 1 - (stepsize/2) and 0+(stepsize/2).
     float stepsize = 1.0 / float(textureSize(color_map, 0));
     i01 = (1.0 - stepsize) * i01 + 0.5 * stepsize;
-    return texture(colormap, i01);
+    return texture(color_map, i01);
 }
 
 vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_map){
@@ -40,7 +40,7 @@ vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_ma
         return nan_color;
     } else if (i < color_norm.x) {
         return lowclip;
-    } else if (i > color_norm.y) {
+} else if (i > color_norm.y) {
         return highclip;
     }
     return get_color_from_cmap(i, color_map, color_norm);

--- a/GLMakie/assets/shader/heatmap.frag
+++ b/GLMakie/assets/shader/heatmap.frag
@@ -23,25 +23,15 @@ vec4 getindex(sampler1D image, vec2 uv){return texture(image, uv.y);}
 
 void write2framebuffer(vec4 color, uvec2 id);
 
-// It seems texture(color_map, i0) doesn't actually correctly interpolate between the values.
-// TODO, further investigate texture, since it's likely not broken, but rather not used correctly.
-// Meanwhile, we interpolate manually from the colormap
 vec4 get_color_from_cmap(float value, sampler1D color_map, vec2 colorrange) {
     float cmin = colorrange.x;
     float cmax = colorrange.y;
     float i01 = clamp((value - cmin) / (cmax - cmin), 0.0, 1.0);
-    int len = textureSize(color_map, 0);
-
-    float i1len = i01 * (len - 1);
-    int down = int(floor(i1len));
-    int up = int(ceil(i1len));
-    if (down == up) {
-        return texelFetch(color_map, up, 0);
-    }
-    float interp_val = i1len - down;
-    vec4 downc = texelFetch(color_map, down, 0);
-    vec4 upc = texelFetch(color_map, up, 0);
-    return mix(downc, upc, interp_val);
+    // 1/0 corresponds to the corner of the colormap, so to properly interpolate
+    // between the colors, we need to scale it, so that the ends are at 1 - (stepsize/2) and 0+(stepsize/2).
+    float stepsize = 1.0 / float(textureSize(color_map, 0));
+    i01 = (1.0 - stepsize) * i01 + 0.5 * stepsize;
+    return texture(colormap, i01);
 }
 
 vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_map){

--- a/GLMakie/assets/shader/heatmap.frag
+++ b/GLMakie/assets/shader/heatmap.frag
@@ -17,9 +17,6 @@ uniform vec4 nan_color;
 
 vec4 getindex(sampler2D image, vec2 uv){return texture(image, vec2(uv.x, 1-uv.y));}
 vec4 getindex(sampler1D image, vec2 uv){return texture(image, uv.y);}
-float range_01(float val, float from, float to){
-    return (val - from) / (to - from);
-}
 
 #define ALIASING_CONST 0.70710678118654757
 #define M_PI 3.1415926535897932384626433832795

--- a/GLMakie/assets/shader/mesh.frag
+++ b/GLMakie/assets/shader/mesh.frag
@@ -42,6 +42,27 @@ uniform vec4 highclip;
 uniform vec4 lowclip;
 uniform vec4 nan_color;
 
+// It seems texture(color_map, i0) doesn't actually correctly interpolate between the values.
+// TODO, further investigate texture, since it's likely not broken, but rather not used correctly.
+// Meanwhile, we interpolate manually from the colormap
+vec4 get_color_from_cmap(float value, sampler1D color_map, vec2 colorrange) {
+    float cmin = colorrange.x;
+    float cmax = colorrange.y;
+    float i01 = clamp((value - cmin) / (cmax - cmin), 0.0, 1.0);
+    int len = textureSize(color_map, 0);
+
+    float i1len = i01 * (len - 1);
+    int down = int(floor(i1len));
+    int up = int(ceil(i1len));
+    if (down == up) {
+        return texelFetch(color_map, up, 0);
+    }
+    float interp_val = i1len - down;
+    vec4 downc = texelFetch(color_map, down, 0);
+    vec4 upc = texelFetch(color_map, up, 0);
+    return mix(downc, upc, interp_val);
+}
+
 vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){
     float i = texture(intensity, uv).x;
     if (isnan(i)) {
@@ -51,7 +72,7 @@ vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_ma
     } else if (i > color_norm.y) {
         return highclip;
     }
-    return color_lookup(i, color_map, color_norm);
+    return get_color_from_cmap(i, color_map, color_norm);
 }
 
 vec4 matcap_color(sampler2D matcap){

--- a/GLMakie/assets/shader/mesh.frag
+++ b/GLMakie/assets/shader/mesh.frag
@@ -33,11 +33,6 @@ vec4 get_color(sampler2D color, vec2 uv, Nothing color_norm, Nothing color_map, 
     return texture(color, uv);
 }
 
-float _normalize(float val, float from, float to){return (val-from) / (to - from);}
-vec4 color_lookup(float intensity, sampler1D color_ramp, vec2 norm){
-    return texture(color_ramp, _normalize(intensity, norm.x, norm.y));
-}
-
 uniform vec4 highclip;
 uniform vec4 lowclip;
 uniform vec4 nan_color;

--- a/GLMakie/assets/shader/mesh.frag
+++ b/GLMakie/assets/shader/mesh.frag
@@ -45,7 +45,7 @@ vec4 get_color_from_cmap(float value, sampler1D color_map, vec2 colorrange) {
     // between the colors, we need to scale it, so that the ends are at 1 - (stepsize/2) and 0+(stepsize/2).
     float stepsize = 1.0 / float(textureSize(color_map, 0));
     i01 = (1.0 - stepsize) * i01 + 0.5 * stepsize;
-    return texture(colormap, i01);
+    return texture(color_map, i01);
 }
 
 vec4 get_color(sampler2D intensity, vec2 uv, vec2 color_norm, sampler1D color_map, Nothing matcap){

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -443,11 +443,6 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Image)
         end
         gl_attributes[:color] = x[3]
         gl_attributes[:shading] = false
-        if gl_attributes[:color_map][] isa Vector
-            cmap = pop!(gl_attributes, :color_map)
-            gl_attributes[:color_map] = Texture(cmap; mipmap=true, minfilter=:linear)
-        end
-
         connect_camera!(gl_attributes, scene.camera)
         return mesh_inner(mesh, transform_func_obs(x), gl_attributes)
     end

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -443,6 +443,11 @@ function draw_atomic(screen::GLScreen, scene::Scene, x::Image)
         end
         gl_attributes[:color] = x[3]
         gl_attributes[:shading] = false
+        if gl_attributes[:color_map][] isa Vector
+            cmap = pop!(gl_attributes, :color_map)
+            gl_attributes[:color_map] = Texture(cmap; mipmap=true, minfilter=:linear)
+        end
+
         connect_camera!(gl_attributes, scene.camera)
         return mesh_inner(mesh, transform_func_obs(x), gl_attributes)
     end

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -442,3 +442,27 @@ end
 @reference_test "2D surface with explicit color" begin
     surface(1:10, 1:10, ones(10, 10); color = [RGBf(x*y/100, 0, 0) for x in 1:10, y in 1:10], shading = false)
 end
+
+@reference_test "heatmap and image colormap interpolation" begin
+    f = Figure(resolution=(500, 500))
+    crange = LinRange(0, 255, 10)
+    len = length(crange)
+    img = zeros(Float32, len, len + 2)
+    img[:, 1] .= 255f0
+    for (i, v) in enumerate(crange)
+        ib = i + 1
+        img[2:end-1, ib] .= v
+        img[1, ib] = 255-v
+        img[end, ib] = 255-v
+    end
+
+    kw(p, interpolate) = (axis=(title="$(p)(interpolate=$(interpolate))", aspect=DataAspect()), interpolate=interpolate, colormap=[:white, :black])
+
+    for (i, p) in enumerate([heatmap, image])
+        for (j, interpolate) in enumerate([true, false])
+            ax, pl = p(f[i,j], img; kw(p, interpolate)...)
+            hidedecorations!(ax)
+        end
+    end
+    f
+end


### PR DESCRIPTION
This is really weird, I don't see any reason why `texture(cmap, val01)` should do incorrect interpolations when only having few colors in the colormap (e.g. like with the default one for `image` which is `[:black, :white]`).
Would be nice to figure out the exact bug here, but meanwhile this should fix it.
I also deleted the GLVisualize remnant of having a `stroke_width` for the heatmap.. This isn't used nor tested and only implemented in GLMakie. I feel like we should either support it fully, or just don't offer it.
If this makes it a breaking change, I may also just bring it back 🤷 
Fixes #1969