### PR TITLE
Improve CairoMakie performance

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -773,7 +773,8 @@ function draw_mesh3D(
     end
 
     # Approximate zorder
-    zorder = sortperm(meshfaces, by = f -> average_z(ts, f))
+    average_zs = map(f -> average_z(ts, f), meshfaces)
+    zorder = sortperm(average_zs)
 
     # Face culling
     zorder = filter(i -> any(last.(ns[meshfaces[i]]) .> faceculling), zorder)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -594,11 +594,11 @@ function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
             # extend the polygon. (Which may change due to rotations in the
             # model matrix.) (i!=1) etc is used to avoid increasing the
             # outer extent of the heatmap.
-            center = 0.25 * (p1 + p2 + p3 + p4)
-            p1 += sign.(p1 - center) .* Point2f(0.5(i!=1),  0.5(j!=1))
-            p2 += sign.(p2 - center) .* Point2f(0.5(i!=ni), 0.5(j!=1))
-            p3 += sign.(p3 - center) .* Point2f(0.5(i!=ni), 0.5(j!=nj))
-            p4 += sign.(p4 - center) .* Point2f(0.5(i!=1),  0.5(j!=nj))
+            center = 0.25f0 * (p1 + p2 + p3 + p4)
+            p1 += sign.(p1 - center) .* Point2f(0.5f0 * (i!=1),  0.5f0 * (j!=1))
+            p2 += sign.(p2 - center) .* Point2f(0.5f0 * (i!=ni), 0.5f0 * (j!=1))
+            p3 += sign.(p3 - center) .* Point2f(0.5f0 * (i!=ni), 0.5f0 * (j!=nj))
+            p4 += sign.(p4 - center) .* Point2f(0.5f0 * (i!=1),  0.5f0 * (j!=nj))
         end
 
         Cairo.set_line_width(ctx, 0)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -211,8 +211,7 @@ function draw_atomic_scatter(scene, ctx, transfunc, colors, markersize, strokeco
         isnan(pos) && return
 
         Cairo.set_source_rgba(ctx, rgbatuple(col)...)
-        # m = convert_attribute(marker, key"marker"(), key"scatter"())
-        m = Circle(Point2f(0, 0), 0f0)
+        m = convert_attribute(marker, key"marker"(), key"scatter"())
         Cairo.save(ctx)
         if m isa Char
             draw_marker(ctx, m, best_font(m, font), pos, scale, strokecolor, strokewidth, offset, rotation)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -235,7 +235,7 @@ function draw_marker(ctx, marker::Char, font, pos, scale, strokecolor, strokewid
 
     cairoface = set_ft_font(ctx, font)
 
-    charextent = Makie.FreeTypeAbstraction.internal_get_extent(font, marker)
+    charextent = Makie.FreeTypeAbstraction.get_extent(font, marker)
     inkbb = Makie.FreeTypeAbstraction.inkboundingbox(charextent)
 
     # scale normalized bbox by font size

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -242,7 +242,7 @@ function draw_marker(ctx, marker::Char, font, pos, scale, strokecolor, strokewid
     inkbb_scaled = Rect2f(origin(inkbb) .* scale, widths(inkbb) .* scale)
 
     # flip y for the centering shift of the character because in Cairo y goes down
-    centering_offset = [1, -1] .* (-origin(inkbb_scaled) .- 0.5 .* widths(inkbb_scaled))
+    centering_offset = Vec2f(1, -1) .* (-origin(inkbb_scaled) .- 0.5f0 .* widths(inkbb_scaled))
     # this is the origin where we actually have to place the glyph so it can be centered
     charorigin = pos .+ Vec2f(marker_offset[1], -marker_offset[2])
     old_matrix = get_font_matrix(ctx)
@@ -250,14 +250,14 @@ function draw_marker(ctx, marker::Char, font, pos, scale, strokecolor, strokewid
 
     # First, we translate to the point where the
     # marker is supposed to go.
-    Cairo.translate(ctx, charorigin...)
+    Cairo.translate(ctx, charorigin[1], charorigin[2])
     # Then, we rotate the context by the
     # appropriate amount,
     Cairo.rotate(ctx, to_2d_rotation(rotation))
     # and apply a centering offset to account for
     # the fact that text is shown from the (relative)
     # bottom left corner.
-    Cairo.translate(ctx, centering_offset...)
+    Cairo.translate(ctx, centering_offset[1], centering_offset[2])
 
     Cairo.move_to(ctx, 0, 0)
     Cairo.text_path(ctx, string(marker))

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -800,7 +800,10 @@ function draw_pattern(ctx, zorder, shading, meshfaces, ts, per_face_col, ns, vs,
 
     for k in reverse(zorder)
         f = meshfaces[k]
-        t1, t2, t3 = ts[f]
+        # avoid SizedVector through Face indexing
+        t1 = ts[f[1]]
+        t2 = ts[f[2]]
+        t3 = ts[f[3]]
 
         facecolors = per_face_col[k]
         # light calculation

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -574,38 +574,41 @@ function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive:
         if ni + 1 != length(xs) || nj + 1 != length(ys)
             error("Error in conversion pipeline. xs and ys should have size ni+1, nj+1. Found: xs: $(length(xs)), ys: $(length(ys)), ni: $(ni), nj: $(nj)")
         end
+        _draw_rect_heatmap(ctx, xys, ni, nj, colors)
+    end
+end
 
-        @inbounds for i in 1:ni, j in 1:nj
-            p1 = xys[i, j]
-            p2 = xys[i+1, j]
-            p3 = xys[i+1, j+1]
-            p4 = xys[i, j+1]
+function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
+    @inbounds for i in 1:ni, j in 1:nj
+        p1 = xys[i, j]
+        p2 = xys[i+1, j]
+        p3 = xys[i+1, j+1]
+        p4 = xys[i, j+1]
 
-            # Rectangles and polygons that are directly adjacent usually show
-            # white lines between them due to anti aliasing. To avoid this we
-            # increase their size slightly.
+        # Rectangles and polygons that are directly adjacent usually show
+        # white lines between them due to anti aliasing. To avoid this we
+        # increase their size slightly.
 
-            if alpha(colors[i, j]) == 1
-                # sign.(p - center) gives the direction in which we need to
-                # extend the polygon. (Which may change due to rotations in the
-                # model matrix.) (i!=1) etc is used to avoid increasing the
-                # outer extent of the heatmap.
-                center = 0.25 * (p1 + p2 + p3 + p4)
-                p1 += sign.(p1 - center) .* Point2f(0.5(i!=1),  0.5(j!=1))
-                p2 += sign.(p2 - center) .* Point2f(0.5(i!=ni), 0.5(j!=1))
-                p3 += sign.(p3 - center) .* Point2f(0.5(i!=ni), 0.5(j!=nj))
-                p4 += sign.(p4 - center) .* Point2f(0.5(i!=1),  0.5(j!=nj))
-            end
-
-            Cairo.set_line_width(ctx, 0)
-            Cairo.move_to(ctx, p1[1], p1[2])
-            Cairo.line_to(ctx, p2[1], p2[2])
-            Cairo.line_to(ctx, p3[1], p3[2])
-            Cairo.line_to(ctx, p4[1], p4[2])
-            Cairo.close_path(ctx)
-            Cairo.set_source_rgba(ctx, rgbatuple(colors[i, j])...)
-            Cairo.fill(ctx)
+        if alpha(colors[i, j]) == 1
+            # sign.(p - center) gives the direction in which we need to
+            # extend the polygon. (Which may change due to rotations in the
+            # model matrix.) (i!=1) etc is used to avoid increasing the
+            # outer extent of the heatmap.
+            center = 0.25 * (p1 + p2 + p3 + p4)
+            p1 += sign.(p1 - center) .* Point2f(0.5(i!=1),  0.5(j!=1))
+            p2 += sign.(p2 - center) .* Point2f(0.5(i!=ni), 0.5(j!=1))
+            p3 += sign.(p3 - center) .* Point2f(0.5(i!=ni), 0.5(j!=nj))
+            p4 += sign.(p4 - center) .* Point2f(0.5(i!=1),  0.5(j!=nj))
         end
+
+        Cairo.set_line_width(ctx, 0)
+        Cairo.move_to(ctx, p1[1], p1[2])
+        Cairo.line_to(ctx, p2[1], p2[2])
+        Cairo.line_to(ctx, p3[1], p3[2])
+        Cairo.line_to(ctx, p4[1], p4[2])
+        Cairo.close_path(ctx)
+        Cairo.set_source_rgba(ctx, rgbatuple(colors[i, j])...)
+        Cairo.fill(ctx)
     end
 end
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -2,10 +2,10 @@
 #                             Projection utilities                             #
 ################################################################################
 
-function project_position(scene, space, point, model, yflip = true)
+function project_position(scene, transform_func::T, space, point, model, yflip::Bool = true) where T
 
     # use transform func
-    point = Makie.apply_transform(scene.transformation.transform_func[], point)
+    point = Makie.apply_transform(transform_func, point)
 
     res = scene.camera.resolution[]
     p4d = to_ndim(Vec4f, to_ndim(Vec3f, point, 0f0), 1f0)
@@ -20,6 +20,10 @@ function project_position(scene, space, point, model, yflip = true)
     end
     # multiply with scene resolution for final position
     return p_0_to_1 .* res
+end
+
+function project_position(scene, space, point, model, yflip::Bool = true)
+    project_position(scene, scene.transformation.transform_func[], space, point, model, yflip)
 end
 
 function project_scale(scene::Scene, space, s::Number, model = Mat4f(I))


### PR DESCRIPTION
- type stability improvements for scatter
- make draw_pattern type stable
- calculate z only once per face
- reduce allocations in draw_pattern
- avoid sizedvector for fewer allocations
- revert accidental scatter marker change
- use cached extent
- avoid SizedVector
- move marker conversion out of loop

# Description

With this test code:
```julia
begin
    f = Figure()
    scatter(f[1, 1], range(0, 50, 100000), sin, marker = :utriangle)
    lines(f[1, 2], range(0, 50, 100000), sin)
    surface(f[2, 1], range(0, 2pi, length = 200), range(0, 2pi, length = 200), cosi,
        axis = (type = Axis3,)
    )
    heatmap(f[2, 2], (1:300).^1.2, 1:300, randn(300, 300))
    @time display(f)
end
```

Master: 5.075926 seconds (55.47 M allocations: 1.585 GiB, 6.78% gc time)
This PR: 0.742038 seconds (2.58 M allocations: 114.594 MiB)
