### PR TITLE
Ensure that scatter respects low/high clip

### DIFF
--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -125,8 +125,8 @@ function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
         Float64.(numbers), # ints don't work in interpolated_getindex
         Ref(colorrange))
 
-    !isnothing(primitive.lowclip[])  && (raw_colors[numbers .< colorrange[1]] .= Makie.to_color(primitive.lowclip[]))
-    !isnothing(primitive.highclip[]) && (raw_colors[numbers .< colorrange[2]] .= Makie.to_color(primitive.highclip[]))
+    !isnothing(to_value(get(primitive, :lowclip,  nothing))) && (raw_colors[numbers .< colorrange[1]] .= Makie.to_color(primitive.lowclip[]))
+    !isnothing(to_value(get(primitive, :highclip, nothing))) && (raw_colors[numbers .< colorrange[2]] .= Makie.to_color(primitive.highclip[]))
 
 end
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -126,7 +126,7 @@ function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
         Ref(colorrange))
 
     !isnothing(to_value(get(primitive, :lowclip,  nothing))) && (raw_colors[numbers .< colorrange[1]] .= Makie.to_color(primitive.lowclip[]))
-    !isnothing(to_value(get(primitive, :highclip, nothing))) && (raw_colors[numbers .< colorrange[2]] .= Makie.to_color(primitive.highclip[]))
+    !isnothing(to_value(get(primitive, :highclip, nothing))) && (raw_colors[numbers .> colorrange[2]] .= Makie.to_color(primitive.highclip[]))
 
 end
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -120,10 +120,14 @@ function numbers_to_colors(numbers::AbstractArray{<:Number}, primitive)
         colorrange = extrema(numbers)
     end
 
-    Makie.interpolated_getindex.(
+    raw_colors = Makie.interpolated_getindex.(
         Ref(colormap),
         Float64.(numbers), # ints don't work in interpolated_getindex
         Ref(colorrange))
+
+    !isnothing(primitive.lowclip[])  && (raw_colors[numbers .< colorrange[1]] .= Makie.to_color(primitive.lowclip[]))
+    !isnothing(primitive.highclip[]) && (raw_colors[numbers .< colorrange[2]] .= Makie.to_color(primitive.highclip[]))
+
 end
 
 ########################################


### PR DESCRIPTION
# Description

Fixes #1980 

Adds checking code for highclip and lowclip to `numbers_to_colors`.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
