### PR TITLE
Explain how to add `DRI_PRIME=1` permanently

### DIFF
--- a/docs/documentation/backends/glmakie.md
+++ b/docs/documentation/backends/glmakie.md
@@ -26,7 +26,7 @@ set_window_config!(;
 
 Normally the dedicated GPU is used for rendering.
 If instead an integrated GPU is used, one can tell Julia to use the dedicated GPU while launching julia as `$ sudo DRI_PRIME=1 julia` in the bash terminal.
-
+To have it permanently used, add the line `export DRI_PRIME=1` in  your `.bashrc` or `.zshrc` file.
 
 ## Troubleshooting OpenGL
 


### PR DESCRIPTION
# Description

I am not sure how helpful this addition is, but to solve the GPU selection permanently this could be useful to some people

## Type of change

Docs improvement

## Checklist

- [x] Added or changed relevant sections in the documentation

