### PR TITLE
fix multi poly with rects

### DIFF
--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -466,3 +466,9 @@ end
     end
     f
 end
+
+
+@reference_test "multi rect with poly" begin
+    # use thick strokewidth, so it will make tests fail if something is missing
+    poly([Rect2f(0, 0, 1, 1)], color=:green, strokewidth=100, strokecolor=:black)
+end

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -90,7 +90,7 @@ function poly_convert(polygons::AbstractVector{<: AbstractVector{<: VecTypes}})
     end
 end
 
-to_line_segments(polygon) = convert_arguments(PointBased(), polygon)[1]
+to_line_segments(polygon) = convert_arguments(LineSegments, polygon)[1]
 # Need to explicitly overload for Mesh, since otherwise, Mesh will dispatch to AbstractVector
 to_line_segments(polygon::GeometryBasics.Mesh) = convert_arguments(PointBased(), polygon)[1]
 


### PR DESCRIPTION
`poly([Rect2f(0, 0, 1, 1)], color=:green, strokewidth=2, strokecolor=:black)` was missing a linesegment, since it was using the scatter conversion pipeline.