### PR TITLE
Rainclouds: support `orientation = :horizontal`

### DIFF
--- a/docs/examples/plotting_functions/rainclouds.md
+++ b/docs/examples/plotting_functions/rainclouds.md
@@ -1,5 +1,8 @@
 # rainclouds
 
+"Raincloud" plots are a combination of a (half) violin plot, box plot and scatter plots, the
+three together can make an appealing visual, particularly for large N datasets.
+
 {{doc rainclouds}}
 
 \begin{examplefigure}{}
@@ -70,6 +73,17 @@ rainclouds(category_labels, data_array;
 ```
 \end{examplefigure}
 
+
+\begin{examplefigure}{}
+```julia
+rainclouds(category_labels, data_array;
+    xlabel = "Categories of Distributions",
+    ylabel = "Samples", title = "My Title",
+    orientation = :horizontal,
+    plot_boxplots = true, cloud_width=0.5, clouds=hist,
+    color = colors[indexin(category_labels, unique(category_labels))])
+```
+\end{examplefigure}
 
 \begin{examplefigure}{}
 ```julia


### PR DESCRIPTION
# Description

This is a small change to `rainclouds` that adds support for the `orientation` keyword.

It also fixes a bug in #1725 that prevented histograms from being properly displayed when dodge was set and color was homogenous.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added or changed relevant sections in the documentation
