### PR TITLE
CI: fix the use of concurrency groups in the docs build

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -13,8 +13,10 @@ on:
       - breaking-release
 
 concurrency:
-  group: docs-${{ github.ref }}
-  cancel-in-progress: true
+  # Skip intermediate builds: all builds except for builds on the `master` or `release-*` branches
+  # Cancel intermediate builds: only pull request builds
+  group: docs-${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
# Description

Fix the use of concurrency groups in the docs build

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)