### PR TITLE
don't allow submit defocus on invalid textbox input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- `Textbox` doesn't defocus anymore on trying to submit invalid input [#2041](https://github.com/JuliaPlots/Makie.jl/pull/2041).
+
 ## v0.17.5
 
 - Fixed a regression with `linkaxes!` [#2039](https://github.com/JuliaPlots/Makie.jl/pull/2039). 

--- a/src/makielayout/blocks/textbox.jl
+++ b/src/makielayout/blocks/textbox.jl
@@ -189,13 +189,6 @@ function initialize_block!(tbox::Textbox)
         return Consume(false)
     end
 
-
-    function submit()
-        if displayed_is_valid[]
-            tbox.stored_string[] = tbox.displayed_string[]
-        end
-    end
-
     function reset_to_stored()
         cursorindex[] = 0
         if isnothing(tbox.stored_string[])
@@ -225,9 +218,13 @@ function initialize_block!(tbox::Textbox)
                 elseif key == Keyboard.delete
                     removechar!(cursorindex[] + 1)
                 elseif key == Keyboard.enter
-                    submit()
-                    if tbox.defocus_on_submit[]
-                        defocus!(tbox)
+                    # don't do anything for invalid input which should stay red
+                    if displayed_is_valid[]
+                        # submit the written text
+                        tbox.stored_string[] = tbox.displayed_string[]
+                        if tbox.defocus_on_submit[]
+                            defocus!(tbox)
+                        end
                     end
                 elseif key == Keyboard.escape
                     if tbox.reset_on_defocus[]


### PR DESCRIPTION
# Description

Fixes [#2037](https://github.com/JuliaPlots/Makie.jl/issues/2037)

On submitting an invalid textbox, the text shouldn't defocus which looks like submitting it worked.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)