### PR TITLE
Update DataInspector to work with text changes

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -181,30 +181,6 @@ function ncoords(poly::Polygon)
     N
 end
 
-
-### Text bounding box
-########################################
-
-function Bbox_from_glyphcollection(text, gc)
-    bbox = Rect2f(0, 0, 0, 0)
-    bboxes = Rect2f[]
-    broadcast_foreach(gc.extents, gc.scales) do extent, scale
-        b = height_insensitive_boundingbox_with_advance(extent) * scale
-        push!(bboxes, b)
-    end
-    for (c, o, bb) in zip(text, gc.origins, bboxes)
-        c == '\n' && continue
-        bbox2 = Rect2f(o[Vec(1,2)] .+ origin(bb), widths(bb))
-        if bbox == Rect2f(0, 0, 0, 0)
-            bbox = bbox2
-        else
-            bbox = union(bbox, bbox2)
-        end
-    end
-    bbox
-end
-
-
 ## Shifted projection
 ########################################
 
@@ -255,7 +231,6 @@ end
         enabled = true,
         range = 10,
 
-        _root_px_projection = Mat4f(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1),
         _model = Mat4f(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1),
         _visible = true,
         _tooltip_align = (:center, :top),
@@ -273,31 +248,24 @@ function plot!(plot::_Inspector)
         indicator_linestyle, indicator_linewidth, indicator_color,
         tooltip_offset, depth,
         _display_text, _text_position, _bbox2D, _px_bbox_visible,
-        _tooltip_align, _root_px_projection, _visible
+        _tooltip_align, _visible
     )
 
     # tooltip text
     _aligned_text_position = Observable(Point2f(0))
-    id = Mat4f(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)
-    text_plot = text!(plot, _display_text,
-        position = _aligned_text_position, visible = _visible, align = text_align,
+    text_plot = text!(plot, _aligned_text_position, text = _display_text,
+        visible = _visible, align = text_align,
         color = textcolor, font = font, textsize = textsize,
-        inspectable = false,
-        # with https://github.com/JuliaPlots/Makie.jl/tree/master/GLMakie/pull/183 this should
-        # allow the tooltip to work in any scene.
-        space = :data,
-        projection = _root_px_projection, view = id, projectionview = _root_px_projection
+        inspectable = false, space = :pixel
     )
 
     # compute text boundingbox and adjust _aligned_text_position
-    bbox = map(text_plot.plots[1][1], text_plot.position, text_padding) do gc, pos, pad
-        rect = Bbox_from_glyphcollection(_display_text[], gc)
+    bbox = map(_display_text, _aligned_text_position, text_padding) do _, _, pad
+        rect = Rect2f(boundingbox(text_plot))
         l, r, b, t = pad
-        Rect2f(
-            origin(rect) .+ Vec2f(pos[1] - l, pos[2] - b),
-            widths(rect) .+ Vec2f(l + r, b + t)
-        )
+        Rect2f(origin(rect) .- Vec2f(l, b), widths(rect) .+ Vec2f(l + r, b + t))
     end
+
     onany(_text_position, _tooltip_align, tooltip_offset, bbox) do pos, align, offset, bbox
         halign, valign = align
         ox, oy = offset
@@ -327,14 +295,13 @@ function plot!(plot::_Inspector)
     background = mesh!(
         plot, bbox, color = background_color, shading = false, #fxaa = false,
         # TODO with fxaa here the text above becomes seethrough on a heatmap
-        visible = _visible, inspectable = false,
-        projection = _root_px_projection, view = id, projectionview = _root_px_projection
+        visible = _visible, inspectable = false, space = :pixel
     )
     outline = wireframe!(
         plot, bbox,
         color = outline_color, visible = _visible, inspectable = false,
         linestyle = outline_linestyle, linewidth = outline_linewidth,
-        projection = _root_px_projection, view = id, projectionview = _root_px_projection
+        space = :pixel
     )
 
     # pixel-space marker for selected element (not always used)
@@ -342,8 +309,7 @@ function plot!(plot::_Inspector)
         plot, _bbox2D,
         color = indicator_color, linewidth = indicator_linewidth,
         linestyle = indicator_linestyle, visible = _px_bbox_visible,
-        inspectable = false,
-        projection = _root_px_projection, view = id, projectionview = _root_px_projection
+        inspectable = false, space = :pixel
     )
 
     # To make sure inspector plots end up in front
@@ -439,11 +405,7 @@ function DataInspector(scene::Scene; priority = 100, kwargs...)
     parent = root(scene)
     @assert origin(pixelarea(parent)[]) == Vec2f(0)
 
-    plot = _inspector!(
-        parent, 1,
-        _root_px_projection = camera(parent).pixel_space;
-        kwargs...
-    )
+    plot = _inspector!(parent, 1, kwargs...)
     inspector = DataInspector(parent, plot)
 
     e = events(parent)

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -739,7 +739,7 @@ function show_imagelike(inspector, plot, name, edge_based)
         a._display_text[] = color2text(name, mpos[1], mpos[2], z)
     else
         a._bbox2D[] = _pixelated_image_bbox(plot[1][], plot[2][], plot[3][], i, j, edge_based)
-        if inspector.selection != plot || !(inspector.temp_plots[1][1][] isa Rect2)
+        if inspector.selection != plot || isempty(inspector.temp_plots) || !(inspector.temp_plots[1][1][] isa Rect2)
             clear_temporary_plots!(inspector, plot)
             p = wireframe!(
                 scene, a._bbox2D, model = a._model, color = a.indicator_color,

--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -20,11 +20,11 @@ end
 
 function gl_bboxes(gl::GlyphCollection)
     scales = gl.scales.sv isa Vec2f ? (gl.scales.sv for _ in gl.extents) : gl.scales.sv
-    map(gl.extents, scales) do ext, scale
+    map(gl.glyphs, gl.extents, scales) do c, ext, scale
         hi_bb = height_insensitive_boundingbox_with_advance(ext)
         Rect2f(
             Makie.origin(hi_bb) * scale,
-            widths(hi_bb) * scale
+            (c != '\n') * widths(hi_bb) * scale
         )
     end
 end
@@ -48,9 +48,12 @@ end
 _inkboundingbox(ext::GlyphExtent) = ext.ink_bounding_box
 
 function boundingbox(glyphcollection::GlyphCollection, position::Point3f, rotation::Quaternion)
+    return boundingbox(glyphcollection, rotation) + position
+end
 
+function boundingbox(glyphcollection::GlyphCollection, rotation::Quaternion)
     if isempty(glyphcollection.glyphs)
-        return Rect3f(position, Vec3f(0, 0, 0))
+        return Rect3f(Point3f(0), Vec3f(0))
     end
 
     glyphorigins = glyphcollection.origins
@@ -58,7 +61,7 @@ function boundingbox(glyphcollection::GlyphCollection, position::Point3f, rotati
 
     bb = Rect3f()
     for (charo, glyphbb) in zip(glyphorigins, glyphbbs)
-        charbb = rotate_bbox(Rect3f(glyphbb), rotation) + charo + position
+        charbb = rotate_bbox(Rect3f(glyphbb), rotation) + charo
         if !isfinite_rect(bb)
             bb = charbb
         else
@@ -66,13 +69,12 @@ function boundingbox(glyphcollection::GlyphCollection, position::Point3f, rotati
         end
     end
     !isfinite_rect(bb) && error("Invalid text boundingbox")
-    bb
+    return bb
 end
 
 function boundingbox(layouts::AbstractArray{<:GlyphCollection}, positions, rotations)
-
     if isempty(layouts)
-        Rect3f((0, 0, 0), (0, 0, 0))
+        return Rect3f((0, 0, 0), (0, 0, 0))
     else
         bb = Rect3f()
         broadcast_foreach(layouts, positions, rotations) do layout, pos, rot
@@ -83,24 +85,43 @@ function boundingbox(layouts::AbstractArray{<:GlyphCollection}, positions, rotat
             end
         end
         !isfinite_rect(bb) && error("Invalid text boundingbox")
-        bb
+        return bb
     end
 end
 
 function boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
-    boundingbox(
-        x[1][],
-        to_ndim(Point3f, x.position[], 0),
-        to_rotation(x.rotation[]);
-    )
+    if x.space[] == :pixel
+        pos = to_ndim(Point3f, x.position[], 0)
+    else
+        cam = parent_scene(x).camera
+        transformed = apply_transform(x.transformation.transform_func[], x.position[])
+        pos = Makie.project(cam, x.space[], :pixel, transformed)
+    end
+    return boundingbox(x[1][], pos, to_rotation(x.rotation[]))
 end
 
 function boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
-    boundingbox(
-        x[1][],
-        to_ndim.(Point3f, x.position[], 0),
-        to_rotation(x.rotation[]);
-    )
+    if x.space[] == :pixel
+        pos = to_ndim.(Point3f, x.position[], 0)
+    else
+        cam = (parent_scene(x).camera,)
+        transformed = apply_transform(x.transformation.transform_func[], x.position[])
+        pos = Makie.project.(cam, x.space[], :pixel, transformed)
+    end
+    return boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+end
+
+function boundingbox(plot::Text)
+    bb = Rect3f()
+    for p in plot.plots
+        _bb = boundingbox(p)
+        if !isfinite_rect(bb)
+            bb = _bb
+        elseif isfinite_rect(_bb)
+            bb = union(bb, _bb)
+        end
+    end
+    return bb
 end
 
 _is_latex_string(x::AbstractVector{<:LaTeXString}) = true 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -167,6 +167,7 @@ attr_broadcast_getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 
 is_vector_attribute(x::AbstractArray) = true
 is_vector_attribute(x::NativeFont) = false
+is_vector_attribute(x::Quaternion) = false
 is_vector_attribute(x::VecTypes) = false
 is_vector_attribute(x) = false
 


### PR DESCRIPTION
# Description

Fixes https://discourse.julialang.org/t/problem-with-datainspector/82958

Also makes some changes/additions to `boundingbox(::Text)`:
- `gl_bboxes` now treats '\n' as 0 width and height
- added `boundingbox(::GlyphCollection, rotations)`
- transform text.position[] to pixelspace to avoid mixing different spaces
- added methods that work top level text plots (rather than just the final child version)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)