### PR TITLE
benchmark against PR base branch

### DIFF
--- a/.github/workflows/compilation-benchmark.yaml
+++ b/.github/workflows/compilation-benchmark.yaml
@@ -34,4 +34,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BENCHMARK_KEY }}
           PR_NUMBER: ${{ github.event.number }}
         run: >
-          DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=./metrics/ttfp/ ./metrics/ttfp/run-benchmark.jl ${{ matrix.package }}
+          DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=./metrics/ttfp/ ./metrics/ttfp/run-benchmark.jl ${{ matrix.package }} 7 ${{ github.event.pull_request.base.ref }}

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -101,9 +101,7 @@ function analyze(pr, master)
     else
         "*noisy*🤷‍♀️"
     end
-    if abs(percent) < 5
-        result = "*under 5%*" * (percent < 0 ? "✓" : "x")
-    end
+    
     return @sprintf("%s%.2f%s, %s %s (%.2fd, %.2fp, %.2fstd)", percent > 0 ? "+" : "-", abs(percent), "%", mean_diff_str, result, d, p, std_p)
 end
 

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -23,7 +23,7 @@ COMMENT_TEMPLATE = """
 ## Compile Times benchmark
 
 Note, that these numbers may fluctuate on the CI servers, so take them with a grain of salt.
-All benchmark results are based on the mean time and negative percent mean faster than master.
+All benchmark results are based on the mean time and negative percent mean faster than the base branch.
 Note, that GLMakie + WGLMakie run on an emulated GPU, so the runtime benchmark is much slower.
 Results are from running:
 
@@ -40,13 +40,13 @@ display_time = @benchmark Makie.colorbuffer(display(fig))
 |               | using     | create   | display  | create   | display  |
 |--------------:|:----------|:---------|:---------|:---------|:---------|
 | GLMakie       | --        | --       | --       | --       | --       |
-| master        | --        | --       | --       | --       | --       |
+| $base_branch  | --        | --       | --       | --       | --       |
 | evaluation    | --        | --       | --       | --       | --       |
 | CairoMakie    | --        | --       | --       | --       | --       |
-| master        | --        | --       | --       | --       | --       |
+| $base_branch  | --        | --       | --       | --       | --       |
 | evaluation    | --        | --       | --       | --       | --       |
 | WGLMakie      | --        | --       | --       | --       | --       |
-| master        | --        | --       | --       | --       | --       |
+| $base_branch  | --        | --       | --       | --       | --       |
 | evaluation    | --        | --       | --       | --       | --       |
 """
 
@@ -94,8 +94,8 @@ function analyze(pr, master)
 
     result = if p < 0.05
         if abs(d) > 0.2
-            s = abs(percent) < 5 ? ["✓", "X"] : ["✅", "❌"]
-            d < 0 ? "**faster**$(s[1])" : "**worse**$(s[2])"
+            indicator = abs(percent) < 5 ? ["faster ✓", "slower X"] : ["**faster**✅", "**slower**❌"]
+            indicator[d < 0 ? 1 : 2]
         else
             "*invariant*"
         end

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -94,14 +94,19 @@ function analyze(pr, master)
 
     result = if p < 0.05
         if abs(d) > 0.2
-            d < 0 ? "faster✅" : "worse❌"
+            s = abs(percent) < 5 ? ["✓", "X"] : ["✅", "❌"]
+            d < 0 ? "**faster**$(s[1])" : "**worse**$(s[2])"
         else
             "*invariant*"
         end
     else
-        "*noisy*🤷‍♀️"
+        if abs(percent) < 5
+            "*invariant*"
+        else
+            "*noisy*🤷‍♀️"
+        end
     end
-    
+
     return @sprintf("%s%.2f%s, %s %s (%.2fd, %.2fp, %.2fstd)", percent > 0 ? "+" : "-", abs(percent), "%", mean_diff_str, result, d, p, std_p)
 end
 

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -102,7 +102,7 @@ function analyze(pr, master)
         "*noisy*🤷‍♀️"
     end
     if abs(percent) < 5
-        result = "*under 5%*" * (percent < 0 "✓" : "x")
+        result = "*under 5%*" * (percent < 0 ? "✓" : "x")
     end
     return @sprintf("%s%.2f%s, %s %s (%.2fd, %.2fp, %.2fstd)", percent > 0 ? "+" : "-", abs(percent), "%", mean_diff_str, result, d, p, std_p)
 end


### PR DESCRIPTION
... Otherwise all the benchmarks for PRs based against `breaking-release` are hard to interpret.
Also makes it more visible if results are under 5% and not highlighted because of that.
