### PR TITLE
Improvements from #1776

### DIFF
--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -68,7 +68,8 @@ excludes = Set([
     "heatmap transparent colormap",
     "fast pixel marker",
     "Array of Images Scatter",
-    "Image Scatter different sizes"
+    "Image Scatter different sizes",
+    "pattern barplot" # not implemented yet
 ])
 
 functions = [:volume, :volume!, :uv_mesh]

--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -257,3 +257,7 @@ function merge_attributes!(input::Attributes, theme::Attributes)
     end
     return input
 end
+
+function Base.propertynames(x::T) where T <: Union{Attributes, Transformable}
+    return (keys(x.attributes)...,)
+end

--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -191,3 +191,7 @@ end
 @reference_test "axsi3" begin
     meshscatter(RNG.rand(Point3f, 10), axis=(type=Axis3,))
 end
+
+@reference_test "pattern barplot" begin
+    barplot(1:5, color=Makie.LinePattern(linecolor=:red, background_color=:orange))
+end

--- a/WGLMakie/src/precompiles.jl
+++ b/WGLMakie/src/precompiles.jl
@@ -47,6 +47,5 @@ function _precompile_()
     Makie.get_texture_atlas()
     atlas = Makie.TextureAtlas()
     Makie.load_ascii_chars!(atlas)
-    println("done")
     return
 end

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -38,7 +38,8 @@ excludes = Set([
     "fast pixel marker",
     "Animated surface and wireframe",
     "Array of Images Scatter",
-    "Image Scatter different sizes"
+    "Image Scatter different sizes",
+    "pattern barplot" # not implemented yet
 ])
 
 @testset "refimages" begin

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -27,11 +27,7 @@ $(ATTRIBUTES)
         colorrange = automatic,
         strokewidth = theme(scene, :patchstrokewidth),
         shading = false,
-        # we turn this false for now, since otherwise shapes look transparent
-        # since we use meshes, which are drawn into a different framebuffer because of fxaa
-        # if we use fxaa=false, they're drawn into the same
-        # TODO, I still think this is a bug, since they should still use the same depth buffer!
-        fxaa = false,
+        fxaa = true,
         linestyle = nothing,
         overdraw = false,
         transparency = false,

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -325,7 +325,7 @@ function plot!(plot::_Inspector)
 
     # tooltip background and frame
     background = mesh!(
-        plot, bbox, color = background_color, shading = false, #fxaa = false,
+        plot, bbox, color = background_color, shading = false,
         # TODO with fxaa here the text above becomes seethrough on a heatmap
         visible = _visible, inspectable = false,
         projection = _root_px_projection, view = id, projectionview = _root_px_projection

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -453,9 +453,8 @@ function RectangleZoom(f::Function, ax::Axis; kw...)
     selection_vertices = lift(_selection_vertices, ax.finallimits, r.rectnode)
     # manually specify correct faces for a rectangle with a rectangle hole inside
     faces = [1 2 5; 5 2 6; 2 3 6; 6 3 7; 3 4 7; 7 4 8; 4 1 8; 8 1 5]
-    # fxaa false seems necessary for correct transparency
     mesh = mesh!(ax.scene, selection_vertices, faces, color = (:black, 0.2), shading = false,
-                 fxaa = false, inspectable = false, visible=r.active, transparency=true)
+                 inspectable = false, visible=r.active, transparency=true)
     # translate forward so selection mesh and frame are never behind data
     translate!(mesh, 0, 0, 100)
     return r

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -17,6 +17,8 @@ struct ImagePattern <: AbstractPattern{RGBAf}
     img::Matrix{RGBAf}
 end
 
+Base.size(pattern::ImagePattern) = size(pattern.img)
+
 """
     Pattern(image)
     Pattern(mask[; color1, color2])
@@ -43,6 +45,9 @@ struct LinePattern <: AbstractPattern{RGBAf}
     tilesize::NTuple{2, Int}
     colors::NTuple{2, RGBAf}
 end
+
+Base.size(pattern::LinePattern) = pattern.tilesize
+
 
 """
     LinePattern([; kwargs...])
@@ -103,8 +108,6 @@ function Pattern(style::Char = '/'; kwargs...)
         LinePattern(; kwargs...)
     end
 end
-
-to_color(p::LinePattern) = to_image(p)
 
 function to_image(p::LinePattern)
     tilesize = p.tilesize


### PR DESCRIPTION
Just noticed that I added some small improvements to #1776, which should make it to master quickly.
* concretely type fields in `Pattern`
* remove fxaa=false hack for transparency (should work now with OIT etc)
* add propertynames for plot like objects (can't believe we haven't done this in all these years)