### PR TITLE
interpolate between values instead of interpolating between colors

### DIFF
--- a/GLMakie/assets/shader/mesh.vert
+++ b/GLMakie/assets/shader/mesh.vert
@@ -37,10 +37,14 @@ vec4 to_color(vec4 c, Nothing color_map, Nothing color_norm){
     return c;
 }
 
-vec4 color_lookup(float intensity, sampler1D color_ramp, vec2 norm);
+// JEEZ I Hate OpenGL...No real NaN or Inf support
+const float Inf = 1.0 / 0.0;
 
 vec4 to_color(float c, sampler1D color_map, vec2 color_norm){
-    return color_lookup(c, color_map, color_norm);
+    // Since we can't really switch the color output type, we store single
+    // colors in the red channel,
+    // and use Inf as a sentinel in the other values to signal that we just have one valid value.
+    return vec4(c, Inf, Inf, Inf);
 }
 
 vec4 to_color(vec4 c, sampler1D color_map, vec2 color_norm){


### PR DESCRIPTION
We've been interpolating between colors in the mesh shader...
TODO: We also still interpolate between colors in cairo at least for mesh.
Bug report: https://discourse.julialang.org/t/how-to-create-a-patch-shape-with-a-color-gradient-in-a-simple-2d-plot/62607/7?u=sdanisch

Before:
```julia

using GLMakie
vertices = Point2[
    (0.0, -1.0)
    (1.0, 0.0)
    (0.6, 1.0)
]
faces = [1, 2, 3]
colors = [1, 2, 3]
f, ax, p = mesh(vertices, faces, color = colors, shading = false, colormap = Reverse(:viridis))
Colorbar(f[1, 2], p)
f
```
<img width="623" alt="image" src="https://user-images.githubusercontent.com/1010467/175970954-15e70045-754e-41d4-b4cf-c5255ab29a92.png">

With this PR:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/1010467/175971084-3e91d7dd-d7cc-4224-99df-35e2c7d8ad93.png">
