### PR TITLE
support `Makie.AbstractPattern` as color in `CairoMakie` for non-mesh plots

### DIFF
--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -240,6 +240,9 @@ function per_face_colors(
                 end
             end
             return FaceIterator(cvec, faces)
+        elseif color isa Makie.AbstractPattern
+            # let next level extend and fill with CairoPattern
+            return color
         elseif color isa AbstractMatrix{<: Colorant} && uv !== nothing
             wsize = reverse(size(color))
             wh = wsize .- 1
@@ -257,4 +260,13 @@ end
 
 function mesh_pattern_set_corner_color(pattern, id, c::Colorant)
     Cairo.mesh_pattern_set_corner_color_rgba(pattern, id, rgbatuple(c)...)
+end
+
+# not piracy
+function Cairo.CairoPattern(color::Makie.AbstractPattern)
+    # the Cairo left and right are fliped
+    bitmappattern = reverse(ARGB32.(Makie.to_image(color)); dims=2)
+    cairoimage = Cairo.CairoImageSurface(bitmappattern)
+    cairopattern = Cairo.CairoPattern(cairoimage)
+    return cairopattern
 end

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -265,7 +265,7 @@ end
 # not piracy
 function Cairo.CairoPattern(color::Makie.AbstractPattern)
     # the Cairo left and right are fliped
-    bitmappattern = reverse(ARGB32.(Makie.to_image(color)); dims=2)
+    bitmappattern = reverse!(ARGB32.(Makie.to_image(color)); dims=2)
     cairoimage = Cairo.CairoImageSurface(bitmappattern)
     cairopattern = Cairo.CairoPattern(cairoimage)
     return cairopattern

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -264,7 +264,7 @@ end
 
 # not piracy
 function Cairo.CairoPattern(color::Makie.AbstractPattern)
-    # the Cairo left and right are fliped
+    # the Cairo y-coordinate are fliped
     bitmappattern = reverse!(ARGB32.(Makie.to_image(color)); dims=2)
     cairoimage = Cairo.CairoImageSurface(bitmappattern)
     cairopattern = Cairo.CairoPattern(cairoimage)

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -68,8 +68,7 @@ excludes = Set([
     "heatmap transparent colormap",
     "fast pixel marker",
     "Array of Images Scatter",
-    "Image Scatter different sizes",
-    "pattern barplot" # not implemented yet
+    "Image Scatter different sizes"
 ])
 
 functions = [:volume, :volume!, :uv_mesh]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # News
 
-## v0.17.9
+## master
 
 - `Makie.AbstractPattern` is now supported by `CairoMakie` in poly plot that doesn't involve mesh, such as `bar, poly` [#2106](https://github.com/JuliaPlots/Makie.jl/pull/2106/).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## v0.17.9
 
-- `Makie.AbstractPattern` is now supported by `CairoMakie` in poly plot that doesn't involve mesh, such as `bar, poly` [#2106].
+- `Makie.AbstractPattern` is now supported by `CairoMakie` in poly plot that doesn't involve mesh, such as `bar, poly` [#2106](https://github.com/JuliaPlots/Makie.jl/pull/2106/).
 
 ## v0.17.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- `Makie.AbstractPattern` is now supported by `CairoMakie` in poly plot that doesn't involve mesh, such as `bar, poly` [#2106](https://github.com/JuliaPlots/Makie.jl/pull/2106/).
+- Patterns (`Makie.AbstractPattern`) are now supported by `CairoMakie` in `poly` plots that don't involve `mesh`, such as `bar` and `poly` [#2106](https://github.com/JuliaPlots/Makie.jl/pull/2106/).
 - Fixed regression where `Block` alignments could not be specified as numbers anymore [#2108](https://github.com/JuliaPlots/Makie.jl/pull/2108).
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.17.9
+
+- `Makie.AbstractPattern` is now supported by `CairoMakie` in poly plot that doesn't involve mesh, such as `bar, poly` [#2106].
+
 ## v0.17.7
 
 - Improved `Menu` performance, now it should me much harder to reach the boundary of 255 scenes in GLMakie. `Menu` also takes a `default` keyword argument now and can be scrolled if there is too little space available.

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.17.8"
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ColorBrewer = "a2cac450-b92f-5266-8821-25eda20663c8"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.17.8"
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ColorBrewer = "a2cac450-b92f-5266-8821-25eda20663c8"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -89,12 +89,12 @@ const NativeFont = FreeTypeAbstraction.FTFont
 include("documentation/docstringextension.jl")
 include("utilities/quaternions.jl")
 include("types.jl")
-include("utilities/utilities.jl")
 include("utilities/texture_atlas.jl")
 include("interaction/observables.jl")
 include("interaction/liftmacro.jl")
 include("colorsampler.jl")
 include("patterns.jl")
+include("utilities/utilities.jl") # need Makie.AbstractPattern
 # Basic scene/plot/recipe interfaces + types
 include("scenes.jl")
 

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -9,11 +9,11 @@ function, which must return a `Matrix{<: AbstractRGB}`.
 abstract type AbstractPattern{T} <: AbstractArray{T, 2} end
 
 # for print_array because we defined it as <: AbstratArray
-function Base.show(io::IO, p::Makie.AbstractPattern)
+function Base.show(io::IO, p::AbstractPattern)
     print(io, typeof(p))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", p::Makie.AbstractPattern)
+function Base.show(io::IO, ::MIME"text/plain", p::AbstractPattern)
     print(io, typeof(p))
 end
 

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -8,7 +8,7 @@ function, which must return a `Matrix{<: AbstractRGB}`.
 """
 abstract type AbstractPattern{T} <: AbstractArray{T, 2} end
 
-# for print_array because we defined it as <: AbstratArray
+# for print_array because we defined it as <: Base.AbstractArray
 function Base.show(io::IO, p::AbstractPattern)
     print(io, typeof(p))
 end

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -8,9 +8,13 @@ function, which must return a `Matrix{<: AbstractRGB}`.
 """
 abstract type AbstractPattern{T} <: AbstractArray{T, 2} end
 
-function Base.show(io::IO, ::MIME"text/plain", p::AbstractPattern)
-    println(io, typeof(p))
-    show(io, mime, image(p))
+# for print_array because we defined it as <: AbstratArray
+function Base.show(io::IO, p::Makie.AbstractPattern)
+    print(io, typeof(p))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", p::Makie.AbstractPattern)
+    print(io, typeof(p))
 end
 
 struct ImagePattern <: AbstractPattern{RGBAf}

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -156,14 +156,14 @@ end
 attr_broadcast_length(x::NativeFont) = 1 # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_length(x::VecTypes) = 1 # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_length(x::AbstractArray) = length(x)
-attr_broadcast_length(x::Makie.AbstractPattern) = 1
+attr_broadcast_length(x::AbstractPattern) = 1
 attr_broadcast_length(x) = 1
 attr_broadcast_length(x::ScalarOrVector) = x.sv isa Vector ? length(x.sv) : 1
 
 attr_broadcast_getindex(x::NativeFont, i) = x # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_getindex(x::VecTypes, i) = x # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_getindex(x::AbstractArray, i) = x[i]
-attr_broadcast_getindex(x::Makie.AbstractPattern, i) = x
+attr_broadcast_getindex(x::AbstractPattern, i) = x
 attr_broadcast_getindex(x, i) = x
 attr_broadcast_getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -156,12 +156,14 @@ end
 attr_broadcast_length(x::NativeFont) = 1 # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_length(x::VecTypes) = 1 # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_length(x::AbstractArray) = length(x)
+attr_broadcast_length(x::Makie.AbstractPattern) = 1
 attr_broadcast_length(x) = 1
 attr_broadcast_length(x::ScalarOrVector) = x.sv isa Vector ? length(x.sv) : 1
 
 attr_broadcast_getindex(x::NativeFont, i) = x # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_getindex(x::VecTypes, i) = x # these are our rules, and for what we do, Vecs are usually scalars
 attr_broadcast_getindex(x::AbstractArray, i) = x[i]
+attr_broadcast_getindex(x::Makie.AbstractPattern, i) = x
 attr_broadcast_getindex(x, i) = x
 attr_broadcast_getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 


### PR DESCRIPTION
## Demo
```julia
julia> p = Pattern('/');

julia> save("/tmp/f.png", poly(Point2f[(0, 0), (2, 0), (3, 1), (1, 1)], color = p, strokecolor=:red, strokewidth=2))

```
```julia
using CairoMakie, Random
Random.seed!(3)
const Vec2f0 = CairoMakie.Vec2f0
# patterns
# `'/'`, `'\\'`, `'-'`, `'|'`, `'x'`, and `'+'`
directions = [Vec2f0(1), Vec2f0(1, -1), Vec2f0(1, 0), Vec2f0(0, 1),
    [Vec2f0(1), Vec2f0(1, -1)], [Vec2f0(1, 0), Vec2f0(0, 1)]]
colors = [:white, :red, (:green, 0.5), :white, (:navy, 0.85),:black]
patterns = [Makie.LinePattern(direction= hatch; width = 5, tilesize=(20,20),
    linecolor = colors[indx], background_colo
r = colors[end-indx+1])
    for (indx, hatch) in enumerate(directions)]
fig = Figure(resolution = (1200,800), fontsize = 32)

ax = Axis(fig[1,1])
for (idx, pattern) in enumerate(patterns)
    barplot!(ax, [idx], [idx*(2rand()+1)], color = pattern, strokewidth = 2)
end
ax.xticks = (1:6, ["/", "\\", "-", "|", "x", "+"])
save("/tmp/strippedPatterns.png", fig)
```

| first | second |
| -----  | ----- |
| ![image](https://user-images.githubusercontent.com/5306213/177017610-c6616f90-1d59-4b41-8d91-64ec1a3a21ca.png) | ![strippedPatterns](https://user-images.githubusercontent.com/5306213/177019805-93c07881-eac8-49c6-932c-9c5ce493fa5f.png) |


# Description

fix  #1385

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation [NO NEED]
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc. [ALREADY PRESENT]
