### PR TITLE
Fix `Legend` draw order

### DIFF
--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -85,27 +85,16 @@ end
     f
 end
 
-@testset "Linked axes" begin
-    # this tests a bug in 0.17.4 where the first axis targetlimits
-    # don't change because the second axis has limits contained inside those
-    # of the first, so the axis linking didn't proliferate
-    f = Figure()
-    ax1 = Axis(f[1, 1], xautolimitmargin = (0, 0), yautolimitmargin = (0, 0))
-    ax2 = Axis(f[2, 1], xautolimitmargin = (0, 0), yautolimitmargin = (0, 0))
-    scatter!(ax1, 1:5, 2:6)
-    scatter!(ax2, 2:3, 3:4)
-    @test first.(extrema(ax1.finallimits[])) == (1, 5)
-    @test last.(extrema(ax1.finallimits[])) == (2, 6)
-    @test first.(extrema(ax2.finallimits[])) == (2, 3)
-    @test last.(extrema(ax2.finallimits[])) == (3, 4)
-    linkxaxes!(ax1, ax2)
-    @test first.(extrema(ax1.finallimits[])) == (1, 5)
-    @test last.(extrema(ax1.finallimits[])) == (2, 6)
-    @test first.(extrema(ax2.finallimits[])) == (1, 5)
-    @test last.(extrema(ax2.finallimits[])) == (3, 4)
-    linkyaxes!(ax1, ax2)
-    @test first.(extrema(ax1.finallimits[])) == (1, 5)
-    @test last.(extrema(ax1.finallimits[])) == (2, 6)
-    @test first.(extrema(ax2.finallimits[])) == (1, 5)
-    @test last.(extrema(ax2.finallimits[])) == (2, 6)
-end
+@reference_test "Legend draw order" begin
+    with_theme(Lines = (linewidth = 10,)) do
+        f = Figure()
+        ax = Axis(f[1, 1], backgroundcolor = :gray80)
+        for i in 1:3
+            lines!(ax,( 1:10) .* i, label = "$i")
+        end
+        # To verify that RGB values differ across entries
+        axislegend(ax, position = :lt, patchcolor = :red, patchsize = (100, 100), bgcolor = :gray50);
+        Legend(f[1, 2], ax, patchcolor = :gray80, patchsize = (100, 100), bgcolor = :gray50);
+        f
+    end
+end 

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -19,10 +19,11 @@ function initialize_block!(leg::Legend,
         enlarge($legend_area, -$(leg.margin)[1], -$(leg.margin)[2], -$(leg.margin)[3], -$(leg.margin)[4])
     end
 
-    poly!(scene,
+    bg = poly!(scene,
         legendrect,
         color = leg.bgcolor, strokewidth = leg.framewidth, visible = leg.framevisible,
         strokecolor = leg.framecolor, inspectable = false)
+    translate!(bg, 0, 0, -7) # bg behind patches but before content at 0 (legend is at +10)
 
     # the grid containing all content
     grid = GridLayout(bbox = legendrect, alignmode = Outside(leg.padding[]...))
@@ -207,6 +208,7 @@ function initialize_block!(leg::Legend,
                 rect = Box(scene; color=e.patchcolor, strokecolor=e.patchstrokecolor, strokewidth=e.patchstrokewidth,
                            width=lift(x -> x[1], e.patchsize), height=lift(x -> x[2], e.patchsize))
                 push!(erects, rect)
+                translate!(rect.blockscene, 0, 0, -5) # patches before background but behind legend elements (legend is at +10)
 
                 # plot the symbols belonging to this entry
                 symbolplots = AbstractPlot[]

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -185,3 +185,28 @@ end
     @test leg.halign[] == 0.4
     @test leg.valign[] == 0.8
 end
+
+@testset "Linked axes" begin
+    # this tests a bug in 0.17.4 where the first axis targetlimits
+    # don't change because the second axis has limits contained inside those
+    # of the first, so the axis linking didn't proliferate
+    f = Figure()
+    ax1 = Axis(f[1, 1], xautolimitmargin = (0, 0), yautolimitmargin = (0, 0))
+    ax2 = Axis(f[2, 1], xautolimitmargin = (0, 0), yautolimitmargin = (0, 0))
+    scatter!(ax1, 1:5, 2:6)
+    scatter!(ax2, 2:3, 3:4)
+    @test first.(extrema(ax1.finallimits[])) == (1, 5)
+    @test last.(extrema(ax1.finallimits[])) == (2, 6)
+    @test first.(extrema(ax2.finallimits[])) == (2, 3)
+    @test last.(extrema(ax2.finallimits[])) == (3, 4)
+    linkxaxes!(ax1, ax2)
+    @test first.(extrema(ax1.finallimits[])) == (1, 5)
+    @test last.(extrema(ax1.finallimits[])) == (2, 6)
+    @test first.(extrema(ax2.finallimits[])) == (1, 5)
+    @test last.(extrema(ax2.finallimits[])) == (3, 4)
+    linkyaxes!(ax1, ax2)
+    @test first.(extrema(ax1.finallimits[])) == (1, 5)
+    @test last.(extrema(ax1.finallimits[])) == (2, 6)
+    @test first.(extrema(ax2.finallimits[])) == (1, 5)
+    @test last.(extrema(ax2.finallimits[])) == (2, 6)
+end


### PR DESCRIPTION
# Description

Fixes #2082.

Now the draw order should be from front to back:
- legend elements
- patch backgrounds
- legend background
- other figure content

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
