### PR TITLE
Better errors for invalid usage of `axis` and `figure` keywords

### DIFF
--- a/src/figureplotting.jl
+++ b/src/figureplotting.jl
@@ -61,8 +61,6 @@ end
 # without scenelike, use current axis of current figure
 
 function plot!(P::PlotFunc, args...; kw_attributes...)
-    _disallow_keyword(:axis, kw_attributes)
-    _disallow_keyword(:figure, kw_attributes)
     ax = current_axis(current_figure())
     isnothing(ax) && error("There is no current axis to plot into.")
     plot!(P, ax, args...; kw_attributes...)
@@ -70,7 +68,6 @@ end
 
 function plot(P::PlotFunc, gp::GridPosition, args...; axis = NamedTuple(), kwargs...)
 
-    _disallow_keyword(:figure, kwargs)
     _validate_nt_like_keyword(axis, "axis")
 
     f = get_top_parent(gp)
@@ -109,12 +106,10 @@ function plot(P::PlotFunc, gp::GridPosition, args...; axis = NamedTuple(), kwarg
 end
 
 function plot!(P::PlotFunc, gp::GridPosition, args...; kwargs...)
-    _disallow_keyword(:axis, kwargs)
-    _disallow_keyword(:figure, kwargs)
 
     c = contents(gp, exact = true)
-    if !(length(c) == 1 && c[1] isa Union{Axis, LScene})
-        error("There needs to be a single axis at $(gp.span), $(gp.side) to plot into.\nUse a non-mutating plotting command to create an axis implicitly.")
+    if !(length(c) == 1 && can_be_current_axis(c[1]))
+        error("There needs to be a single axis-like object at $(gp.span), $(gp.side) to plot into.\nUse a non-mutating plotting command to create an axis implicitly.")
     end
     ax = first(c)
     plot!(P, ax, args...; kwargs...)
@@ -122,7 +117,6 @@ end
 
 function plot(P::PlotFunc, gsp::GridSubposition, args...; axis = NamedTuple(), kwargs...)
 
-    _disallow_keyword(:figure, kwargs)
     _validate_nt_like_keyword(axis, "axis")
     
     layout = GridLayoutBase.get_layout_at!(gsp.parent, createmissing = true)
@@ -163,15 +157,13 @@ function plot(P::PlotFunc, gsp::GridSubposition, args...; axis = NamedTuple(), k
 end
 
 function plot!(P::PlotFunc, gsp::GridSubposition, args...; kwargs...)
-    _disallow_keyword(:axis, kwargs)
-    _disallow_keyword(:figure, kwargs)
 
     layout = GridLayoutBase.get_layout_at!(gsp.parent, createmissing = false)
 
     gp = layout[gsp.rows, gsp.cols, gsp.side]
 
     c = contents(gp, exact = true)
-    if !(length(c) == 1 && c[1] isa Union{Axis, LScene})
+    if !(length(c) == 1 && can_be_current_axis(c[1]))
         error("There is not just one axis at $(gp).")
     end
     ax = first(c)

--- a/src/figureplotting.jl
+++ b/src/figureplotting.jl
@@ -22,6 +22,12 @@ function _validate_nt_like_keyword(@nospecialize(kw), name)
     end
 end
 
+function _disallow_keyword(kw, @nospecialize(attributes))
+    if haskey(attributes, kw)
+        throw(ArgumentError("You cannot pass `$kw` as a keyword argument to this plotting function. Note that `axis` can only be passed to non-mutating plotting functions (not ending with a `!`) that implicitly create an axis, and `figure` only to those that implicitly create a `Figure`."))
+    end
+end
+
 function plot(P::PlotFunc, args...; axis = NamedTuple(), figure = NamedTuple(), kw_attributes...)
     
     _validate_nt_like_keyword(axis, "axis")
@@ -55,6 +61,8 @@ end
 # without scenelike, use current axis of current figure
 
 function plot!(P::PlotFunc, args...; kw_attributes...)
+    _disallow_keyword(:axis, kw_attributes)
+    _disallow_keyword(:figure, kw_attributes)
     ax = current_axis(current_figure())
     isnothing(ax) && error("There is no current axis to plot into.")
     plot!(P, ax, args...; kw_attributes...)
@@ -62,8 +70,9 @@ end
 
 function plot(P::PlotFunc, gp::GridPosition, args...; axis = NamedTuple(), kwargs...)
 
+    _disallow_keyword(:figure, kwargs)
     _validate_nt_like_keyword(axis, "axis")
-    
+
     f = get_top_parent(gp)
 
     c = contents(gp, exact = true)
@@ -100,6 +109,8 @@ function plot(P::PlotFunc, gp::GridPosition, args...; axis = NamedTuple(), kwarg
 end
 
 function plot!(P::PlotFunc, gp::GridPosition, args...; kwargs...)
+    _disallow_keyword(:axis, kwargs)
+    _disallow_keyword(:figure, kwargs)
 
     c = contents(gp, exact = true)
     if !(length(c) == 1 && c[1] isa Union{Axis, LScene})
@@ -111,6 +122,7 @@ end
 
 function plot(P::PlotFunc, gsp::GridSubposition, args...; axis = NamedTuple(), kwargs...)
 
+    _disallow_keyword(:figure, kwargs)
     _validate_nt_like_keyword(axis, "axis")
     
     layout = GridLayoutBase.get_layout_at!(gsp.parent, createmissing = true)
@@ -151,6 +163,8 @@ function plot(P::PlotFunc, gsp::GridSubposition, args...; axis = NamedTuple(), k
 end
 
 function plot!(P::PlotFunc, gsp::GridSubposition, args...; kwargs...)
+    _disallow_keyword(:axis, kwargs)
+    _disallow_keyword(:figure, kwargs)
 
     layout = GridLayoutBase.get_layout_at!(gsp.parent, createmissing = false)
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -726,6 +726,9 @@ function Makie.plot!(
 
     allattrs = merge(attributes, Attributes(kw_attributes))
 
+    _disallow_keyword(:axis, allattrs)
+    _disallow_keyword(:figure, allattrs)
+
     cycle = get_cycle_for_plottype(allattrs, P)
     add_cycle_attributes!(allattrs, P, cycle, la.cycler, la.palette)
 

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -274,6 +274,9 @@ function Makie.plot!(
 
     allattrs = merge(attributes, Attributes(kw_attributes))
 
+    _disallow_keyword(:axis, allattrs)
+    _disallow_keyword(:figure, allattrs)
+
     cycle = get_cycle_for_plottype(allattrs, P)
     add_cycle_attributes!(allattrs, P, cycle, ax.cycler, ax.palette)
 

--- a/src/makielayout/blocks/scene.jl
+++ b/src/makielayout/blocks/scene.jl
@@ -11,6 +11,8 @@ end
 
 function Makie.plot!(P::Makie.PlotFunc, ls::LScene, args...; kw_attributes...)
     attributes = Makie.Attributes(kw_attributes)
+    _disallow_keyword(:axis, attributes)
+    _disallow_keyword(:figure, attributes)
     Makie.plot!(ls, P, attributes, args...)
 end
 

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -186,18 +186,24 @@ end
     @test leg.valign[] == 0.8
 end
 
+# issue 2005
 @testset "invalid plotting function keyword arguments" begin
-    f = Figure()
-    kw = (; backgroundcolor = :red)
-    @test_throws ArgumentError lines(f[1, 1], 1:10, figure = kw)
-    @test_nowarn               lines(f[1, 1], 1:10, axis = kw)
-    @test_throws ArgumentError lines(f[1, 1][1, 1], 1:10, figure = kw)
-    @test_nowarn               lines(f[1, 1][1, 1], 1:10, axis = kw)
-    ax = Axis(f[1, 2])
-    @test_throws ArgumentError lines!(1:10, axis = kw)
-    @test_throws ArgumentError lines!(1:10, figure = kw)
-    @test_nowarn               lines!(1:10)
-    @test_throws ArgumentError lines!(f[1, 2], 1:10, figure = kw)
-    @test_throws ArgumentError lines!(f[1, 2], 1:10, axis = kw)
-    @test_nowarn               lines!(f[1, 2], 1:10)
+    for T in [Axis, Axis3, LScene]
+        f = Figure()
+        kw = (; backgroundcolor = :red)
+        @test_throws ArgumentError lines(f[1, 1], 1:10, figure = kw)
+        @test_nowarn               lines(f[1, 2], 1:10, axis = kw)
+        @test_throws ArgumentError lines(f[1, 3][1, 1], 1:10, figure = kw)
+        @test_nowarn               lines(f[1, 4][1, 2], 1:10, axis = kw)
+        ax = T(f[1, 5])
+        @test_throws ArgumentError lines!(ax, 1:10, axis = kw)
+        @test_throws ArgumentError lines!(ax, 1:10, axis = kw)
+        @test_throws ArgumentError lines!(1:10, axis = kw)
+        @test_throws ArgumentError lines!(1:10, figure = kw)
+        @test_nowarn               lines!(1:10)
+        @test_throws ArgumentError lines!(f[1, 5], 1:10, figure = kw)
+        @test_throws ArgumentError lines!(f[1, 5], 1:10, axis = kw)
+        @test_nowarn               lines!(f[1, 5], 1:10)
+    end
 end
+

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -185,3 +185,19 @@ end
     @test leg.halign[] == 0.4
     @test leg.valign[] == 0.8
 end
+
+@testset "invalid plotting function keyword arguments" begin
+    f = Figure()
+    kw = (; backgroundcolor = :red)
+    @test_throws ArgumentError lines(f[1, 1], 1:10, figure = kw)
+    @test_nowarn               lines(f[1, 1], 1:10, axis = kw)
+    @test_throws ArgumentError lines(f[1, 1][1, 1], 1:10, figure = kw)
+    @test_nowarn               lines(f[1, 1][1, 1], 1:10, axis = kw)
+    ax = Axis(f[1, 2])
+    @test_throws ArgumentError lines!(1:10, axis = kw)
+    @test_throws ArgumentError lines!(1:10, figure = kw)
+    @test_nowarn               lines!(1:10)
+    @test_throws ArgumentError lines!(f[1, 2], 1:10, figure = kw)
+    @test_throws ArgumentError lines!(f[1, 2], 1:10, axis = kw)
+    @test_nowarn               lines!(f[1, 2], 1:10)
+end


### PR DESCRIPTION
# Description

Fixes #2005

A more informative error is thrown when `axis` or `figure` keywords end up in the 
plotting functions of Axis, Axis3 and LScene. This will usually have happened 
because a mutating plotting function was used accidentally.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.
