### PR TITLE
move remaining primitive's attribute docs to docstrings

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -17,6 +17,28 @@ calculated_attributes!(plot::T) where T = calculated_attributes!(T, plot)
 
 Plots an image on range `x, y` (defaults to dimensions).
 
+## Attributes
+
+### Specific to `Image`
+
+- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
+- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
+- `interpolate::Bool = true` sets whether colors should be interpolated.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing).
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` is set by the plot.
+- `colormap::Union{Symbol, Vector{<:Colorant}} = [:black, :white` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for the position of the image. See `Makie.spaces()` for possible inputs.
 """
 @recipe(Image, x, y, image) do scene
     Attributes(;
@@ -38,6 +60,28 @@ end
 
 Plots a heatmap as an image on `x, y` (defaults to interpretation as dimensions).
 
+## Attributes
+
+### Specific to `Heatmap`
+
+- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
+- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
+- `interpolate::Bool = false` sets whether colors should be interpolated.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` is set by the plot.
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for the position of the heatmap. See `Makie.spaces()` for possible inputs.
 """
 @recipe(Heatmap, x, y, values) do scene
     Attributes(;
@@ -67,6 +111,35 @@ Available algorithms are:
 * `:absorptionrgba` => AbsorptionRGBA
 * `:additive` => AdditiveRGBA
 * `:indexedabsorption` => IndexedAbsorptionRGBA
+
+## Attributes
+
+### Specific to `Volume`
+
+- `algorithm::Union{Symbol, RaymarchAlgorithm} = :mip` sets the volume algorithm that is used.
+- `isorange::Real = 0.05` sets the range of values picked up by the IsoValue algorithm.
+- `isovalue = 0.5` sets the target value for the IsoValue algorithm.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for box encompassing the volume plot. See `Makie.spaces()` for possible inputs.
+### Generic 3D
+
+- `shading = true` enables lighting.
+- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light.
+- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
+- `shininess::Real = 32.0` sets how sharp the reflection is.
+- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
 """
 @recipe(Volume, x, y, z, volume) do scene
     Attributes(;
@@ -93,6 +166,12 @@ Plots a surface, where `(x, y)`  define a grid whose heights are the entries in 
 
 ## Attributes
 
+### Specific to `Surface`
+
+- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
+- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
+- `invert_normals::Bool = false` inverts the normals generated for the surface. This can be useful to illuminate the other side of the surface.
+
 ### Generic
 
 - `visible::Bool = true` sets whether the plot will be rendered or not.
@@ -114,12 +193,6 @@ Plots a surface, where `(x, y)`  define a grid whose heights are the entries in 
 - `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
 - `shininess::Real = 32.0` sets how sharp the reflection is.
 - `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
-
-### Other
-
-- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
-- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
-- `invert_normals::Bool = false` inverts the normals generated for the surface. This can be useful to illuminate the other side of the surface.
 """
 @recipe(Surface, x, y, z) do scene
     Attributes(;
@@ -145,8 +218,30 @@ end
 
 Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `positions`.
 
-!!! tip
-    You can separate segments by inserting `NaN`s.
+`NaN` values are displayed as gaps in the line.
+
+## Attributes
+
+### Specific
+
+- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
+- `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
+- `linewidth::Real = 1.5` sets the width of the line in pixel units.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing). Note that line plots already use a different form of anti-aliasing.
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each point in the line by passing a `Vector` of colors or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`.
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for line position. See `Makie.spaces()` for possible inputs.
 """
 @recipe(Lines, positions) do scene
     Attributes(;
@@ -165,11 +260,34 @@ end
 
 """
     linesegments(positions)
+    linesegments(vector_of_2tuples_of_points)
     linesegments(x, y)
     linesegments(x, y, z)
 
 Plots a line for each pair of points in `(x, y, z)`, `(x, y)`, or `positions`.
 
+## Attributes
+
+### Specific to `LineSegments`
+
+- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
+- `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
+- `linewidth::Real = 1.5` sets the width of the line in pixel units.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing). Note that line plots already use a different form of anti-aliasing.
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each point in the line by passing a `Vector` or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`. 
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for line position. See `Makie.spaces()` for possible inputs.
 """
 @recipe(LineSegments, positions) do scene
     default_theme(scene, Lines)
@@ -184,6 +302,33 @@ end
 
 Plots a 3D or 2D mesh. Supported `mesh_object`s include `Mesh` types from [GeometryBasics.jl](https://github.com/JuliaGeometry/GeometryBasics.jl).
 
+## Attributes
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. A `Vector` of any of these can be passed to define the color per vertex. (It may be helpful to check `GeometryBasics.coordinates(my_mesh)` for this.) A `Vector{<: Real}` can also be passed to sample a colormap for each vertex. And finally, if the mesh includes uv coordinates you can pass a `Matrix` of colors to be used as a texture.
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for vertex positions. See `Makie.spaces()` for possible inputs.
+- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
+- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
+- `interpolate::Bool = true` wether color=Matrix gets interpolated or not
+
+### Generic 3D
+
+- `shading = true` enables lighting.
+- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light.
+- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
+- `shininess::Real = 32.0` sets how sharp the reflection is.
+- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
 """
 @recipe(Mesh, mesh) do scene
     Attributes(;
@@ -210,6 +355,19 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
 
 ## Attributes
 
+### Specific to `Scatter`
+
+- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
+- `marker::Union{Symbol, Char, Matrix{<:Colorant}}` sets the scatter marker.
+- `markersize::Union{<:Real, Vec2f} = 9` sets the size of the marker.
+- `markerspace::Symbol = :pixel` sets the space in which `markersize` is given. See `Makie.spaces()` for possible inputs.
+- `strokewidth::Real = 0` sets the width of the outline around a marker.
+- `strokecolor::Union{Symbol, <:Colorant} = :black` sets the color of the outline around a marker.
+- `glowwidth::Real = 0` sets the size of a glow effect around the marker.
+- `glowcolor::Union{Symbol, <:Colorant} = (:black, 0)` sets the color of the glow effect.
+- `rotations::Union{Real, Billboard, Quaternion} = Billboard(0f0)` sets the rotation of the marker. A `Billboard` rotation is always around the depth axis.
+- `transform_marker::Bool = false` controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker.)
+
 ### Generic
 
 - `visible::Bool = true` sets whether the plot will be rendered or not.
@@ -224,20 +382,6 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
 - `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
 - `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
 - `space::Symbol = :data` sets the transformation space for positions of markers. See `Makie.spaces()` for possible inputs.
-    
-### Other
-
-- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
-- `marker::Union{Symbol, Char, Matrix{<:Colorant}}` sets the scatter marker.
-- `markersize::Union{<:Real, Vec2f} = 9` sets the size of the marker.
-- `markerspace::Symbol = :pixel` sets the space in which `markersize` is given. See `Makie.spaces()` for possible inputs.
-- `strokewidth::Real = 0` sets the width of the outline around a marker.
-- `strokecolor::Union{Symbol, <:Colorant} = :black` sets the color of the outline around a marker.
-- `glowwidth::Real = 0` sets the size of a glow effect around the marker.
-- `glowcolor::Union{Symbol, <:Colorant} = (:black, 0)` sets the color of the glow effect.
-- `rotations::Union{Real, Billboard, Quaternion} = Billboard(0f0)` sets the rotation of the marker. A `Billboard` rotation is always around the depth axis.
-- `transform_marker::Bool = false` controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker.)
-
 """
 @recipe(Scatter, positions) do scene
     Attributes(;
@@ -274,6 +418,37 @@ end
 Plots a mesh for each element in `(x, y, z)`, `(x, y)`, or `positions` (similar to `scatter`).
 `markersize` is a scaling applied to the primitive passed as `marker`.
 
+## Attributes
+
+### Specific to `MeshScatter`
+
+- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
+- `marker::Union{Symbol, GeometryBasics.GeometryPrimitive, GeometryBasics.Mesh}` sets the scattered mesh.
+- `markersize::Union{<:Real, Vec3f} = 0.1` sets the scale of the mesh. This can be given as a Vector to apply to each scattered mesh individually.
+- `rotations::Union{Real, Vec3f, Quaternion} = 0` sets the rotation of the mesh. A numeric rotation is around the z-axis, a `Vec3f` causes the mesh to rotate such that the the z-axis is now that vector, and a quaternion describes a general rotation. This can be given as a Vector to apply to each scattered mesh individually.
+
+### Generic
+
+- `visible::Bool = true` sets whether the plot will be rendered or not.
+- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
+- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
+- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
+- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
+- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
+- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
+- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each scattered mesh by passing a `Vector` of colors or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`. 
+- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
+- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
+- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
+- `space::Symbol = :data` sets the transformation space for the positions of meshes. See `Makie.spaces()` for possible inputs.
+
+### Generic 3D
+
+- `shading = true` enables lighting.
+- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light. 
+- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
+- `shininess::Real = 32.0` sets how sharp the reflection is.
+- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
 """
 @recipe(MeshScatter, positions) do scene
     Attributes(;
@@ -303,7 +478,7 @@ Plots one or multiple texts passed via the `text` keyword.
 
 ## Attributes
 
-### `Text` specific attributes
+### Specific to `Text`
 
 - `text` specifies one piece of text or a vector of texts to show, where the number has to match the number of positions given. Makie supports `String` which is used for all normal text and `LaTeXString` which layouts mathematical expressions using `MathTeXEngine.jl`.
 - `align::Tuple{Union{Symbol, Real}, Union{Symbol, Real}} = (:left, :bottom)` sets the alignment of the string w.r.t. `position`. Uses `:left, :center, :right, :top, :bottom, :baseline` or fractions.

--- a/docs/examples/plotting_functions/heatmap.md
+++ b/docs/examples/plotting_functions/heatmap.md
@@ -2,30 +2,6 @@
 
 {{doc heatmap}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` is set by the plot.
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for the position of the heatmap. See `Makie.spaces()` for possible inputs.
-
-### Other
-
-- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
-- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
-- `interpolate::Bool = false` sets whether colors should be interpolated.
-
-
 ## Examples
 
 ### Two vectors and a matrix

--- a/docs/examples/plotting_functions/image.md
+++ b/docs/examples/plotting_functions/image.md
@@ -2,30 +2,6 @@
 
 {{doc image}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing).
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` is set by the plot.
-- `colormap::Union{Symbol, Vector{<:Colorant}} = [:black, :white` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for the position of the image. See `Makie.spaces()` for possible inputs.
-  
-### Other
-
-- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
-- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
-- `interpolate::Bool = true` sets whether colors should be interpolated.
-
-
 ## Examples
 
 \begin{examplefigure}{}

--- a/docs/examples/plotting_functions/lines.md
+++ b/docs/examples/plotting_functions/lines.md
@@ -2,30 +2,6 @@
 
 {{doc lines}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing). Note that line plots already use a different form of anti-aliasing.
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each point in the line by passing a `Vector` of colors or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`.
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for line position. See `Makie.spaces()` for possible inputs.
-
-### Other
-
-- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
-- `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
-- `linewidth::Real = 1.5` sets the width of the line in pixel units.
-
-
 ## Examples
 
 \begin{examplefigure}{svg = true}

--- a/docs/examples/plotting_functions/linesegments.md
+++ b/docs/examples/plotting_functions/linesegments.md
@@ -2,30 +2,6 @@
 
 {{doc linesegments}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = false` adjusts whether the plot is rendered with fxaa (anti-aliasing). Note that line plots already use a different form of anti-aliasing.
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each point in the line by passing a `Vector` or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`. 
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for line position. See `Makie.spaces()` for possible inputs.
-
-### Other
-
-- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
-- `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
-- `linewidth::Real = 1.5` sets the width of the line in pixel units.
-
-
 ## Examples
 
 \begin{examplefigure}{}

--- a/docs/examples/plotting_functions/mesh.md
+++ b/docs/examples/plotting_functions/mesh.md
@@ -2,36 +2,6 @@
 
 {{doc mesh}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. A `Vector` of any of these can be passed to define the color per vertex. (It may be helpful to check `GeometryBasics.coordinates(my_mesh)` for this.) A `Vector{<: Real}` can also be passed to sample a colormap for each vertex. And finally, if the mesh includes uv coordinates you can pass a `Matrix` of colors to be used as a texture.
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for vertex positions. See `Makie.spaces()` for possible inputs.
-- `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
-- `highclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value above the colorrange.
-- `interpolate::Bool = true` wether color=Matrix gets interpolated or not
-
-
-### Generic 3D
-
-- `shading = true` enables lighting.
-- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light.
-- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
-- `shininess::Real = 32.0` sets how sharp the reflection is.
-- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
-
-
 ## Examples
 
 \begin{examplefigure}{}

--- a/docs/examples/plotting_functions/meshscatter.md
+++ b/docs/examples/plotting_functions/meshscatter.md
@@ -2,39 +2,6 @@
 
 {{doc meshscatter}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw). 
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `color` sets the color of the plot. It can be given as a named color `Symbol` or a `Colors.Colorant`. Transparency can be included either directly as an alpha value in the `Colorant` or as an additional float in a tuple `(color, alpha)`. The color can also be set for each scattered mesh by passing a `Vector` of colors or be used to index the `colormap` by passing a `Real` number or `Vector{<: Real}`. 
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for the positions of meshes. See `Makie.spaces()` for possible inputs.
-
-### Generic 3D
-
-- `shading = true` enables lighting.
-- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light. 
-- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
-- `shininess::Real = 32.0` sets how sharp the reflection is.
-- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
-
-### Other
-
-- `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
-- `marker::Union{Symbol, GeometryBasics.GeometryPrimitive, GeometryBasics.Mesh}` sets the scattered mesh.
-- `markersize::Union{<:Real, Vec3f} = 0.1` sets the scale of the mesh. This can be given as a Vector to apply to each scattered mesh individually.
-- `rotations::Union{Real, Vec3f, Quaternion} = 0` sets the rotation of the mesh. A numeric rotation is around the z-axis, a `Vec3f` causes the mesh to rotate such that the the z-axis is now that vector, and a quaternion describes a general rotation. This can be given as a Vector to apply to each scattered mesh individually.
-
-
 ## Examples
 
 \begin{examplefigure}{}

--- a/docs/examples/plotting_functions/volume.md
+++ b/docs/examples/plotting_functions/volume.md
@@ -2,36 +2,6 @@
 
 {{doc volume}}
 
-## Attributes
-
-### Generic
-
-- `visible::Bool = true` sets whether the plot will be rendered or not.
-- `overdraw::Bool = false` sets whether the plot will draw over other plots. This specifically means ignoring depth checks in GL backends.
-- `transparency::Bool = false` adjusts how the plot deals with transparency. In GLMakie `transparency = true` results in using Order Independent Transparency.
-- `fxaa::Bool = true` adjusts whether the plot is rendered with fxaa (anti-aliasing).
-- `inspectable::Bool = true` sets whether this plot should be seen by `DataInspector`.
-- `depth_shift::Float32 = 0f0` adjusts the depth value of a plot after all other transformations, i.e. in clip space, where `0 <= depth <= 1`. This only applies to GLMakie and WGLMakie and can be used to adjust render order (like a tunable overdraw).
-- `model::Makie.Mat4f` sets a model matrix for the plot. This replaces adjustments made with `translate!`, `rotate!` and `scale!`.
-- `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
-- `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
-- `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
-- `space::Symbol = :data` sets the transformation space for box encompassing the volume plot. See `Makie.spaces()` for possible inputs.
-### Generic 3D
-
-- `shading = true` enables lighting.
-- `diffuse::Vec3f = Vec3f(0.4)` sets how strongly the red, green and blue channel react to diffuse (scattered) light.
-- `specular::Vec3f = Vec3f(0.2)` sets how strongly the object reflects light in the red, green and blue channels.
-- `shininess::Real = 32.0` sets how sharp the reflection is.
-- `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
-
-### Other
-
-- `algorithm::Union{Symbol, RaymarchAlgorithm} = :mip` sets the volume algorithm that is used.
-- `isorange::Real = 0.05` sets the range of values picked up by the IsoValue algorithm.
-- `isovalue = 0.5` sets the target value for the IsoValue algorithm.
-
-
 ## Examples
 
 \begin{examplefigure}{}


### PR DESCRIPTION
The docstrings you'd get for `?volume` etc were super short, with most info in the documentation. Now the info is in the docstrings and displayed at the same position in the docs anyway, because the docstring is printed there first before showing examples.