### PR TITLE
Minor fixes to documentation

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -450,7 +450,7 @@ See the docs of [`VideoStream`](@ref) for how to create a VideoStream.
 If you want a simpler interface, consider using [`record`](@ref).
 
 ### Keyword Arguments:
-- `framrate = 24`: The target framerate.
+- `framerate = 24`: The target framerate.
 - `compression = 0`: Controls the video compression with `0` being lossless and
                      `51` being the highest compression. Note that `compression = 0`
                      only works with `.mp4` if `profile = high444`.
@@ -567,7 +567,7 @@ end
 ```
 
 ### Keyword Arguments:
-- `framrate = 24`: The target framerate.
+- `framerate = 24`: The target framerate.
 - `compression = 0`: Controls the video compression with `0` being lossless and
                      `51` being the highest compression. Note that `compression = 0`
                      only works with `.mp4` if `profile = high444`.

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -9,7 +9,7 @@ Draw a violin plot.
 - `orientation=:vertical`: orientation of the violins (`:vertical` or `:horizontal`)
 - `width=1`: width of the box before shrinking
 - `gap=0.2`: shrinking factor, `width -> width * (1 - gap)`
-- `show_median=true`: show median as midline
+- `show_median=false`: show median as midline
 - `side=:both`: specify `:left` or `:right` to only plot the violin on one side
 - `datalimits`: specify values to trim the `violin`. Can be a `Tuple` or a `Function` (e.g. `datalimits=extrema`)
 """


### PR DESCRIPTION
# Description

Fixes # (issue)

Minor fixes to documentation errors.
violin() had kwarg show_median=true instead of false
record() had framerate kwarg incorrectly spelled as framrate

## Type of change

Delete options that do not apply:


## Checklist
