### PR TITLE
feat: add lowclip and highclip keywords to poly

### DIFF
--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -190,8 +190,10 @@ function plot!(plot::Mesh{<: Tuple{<: AbstractVector{P}}}) where P <: Union{Abst
                 to_color.(colors)
             end
             # Consider low- and highclips
-            single_colors[colors .< crange[1]] .= parse(RGBA, lclip)
-            single_colors[colors .> crange[2]] .= parse(RGBA, hclip)
+            if isa(crange, Tuple)
+                single_colors[colors .< crange[1]] .= to_color(lclip)
+                single_colors[colors .> crange[2]] .= to_color(hclip)
+            end
             real_colors = RGBAf[]
             # Map one single color per mesh to each vertex
             for (mesh, color) in zip(meshes, single_colors)


### PR DESCRIPTION
# Description

Fixes #2156 

Adds support for the keywords `lowclip` and `highclip` to the function `poly`.
I still would need to add documentation, but first I wanted to ask, whether the implementation and the code style was ok. Specifically, I would like to know whether the handling of the colors is correctly done with `parse(RGBA, lowclip)`.

Cheers,

Cristóbal

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
