### PR TITLE
Cristobaltapia feat 2156 additional kws to poly

### DIFF
--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -195,3 +195,22 @@ end
 @reference_test "pattern barplot" begin
     barplot(1:5, color=Makie.LinePattern(linecolor=:red, background_color=:orange))
 end
+
+
+@reference_test "poly + lowclip, highclip, nan_color" begin
+    poly(
+        [
+            Point2f[(2, 0), (4, 0), (4, 1), (2, 1)],
+            Point2f[(0, 0), (2, 0), (2, 1), (0, 1)],
+            Point2f[(2, 1), (4, 1), (4, 2), (2, 2)],
+            Point2f[(0, 1), (2, 1), (2, 2), (0, 2)],
+        ];
+        color=[1, 2, NaN, 4],
+        colormap=:viridis,
+        colorrange=(2, 3),
+        lowclip=:white,
+        highclip=:black,
+        nan_color = :green,
+        strokewidth=2,
+    )
+end

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -190,8 +190,10 @@ function plot!(plot::Mesh{<: Tuple{<: AbstractVector{P}}}) where P <: Union{Abst
                 to_color.(colors)
             end
             # Consider low- and highclips
-            single_colors[colors .< crange[1]] .= parse(RGBA, lclip)
-            single_colors[colors .> crange[2]] .= parse(RGBA, hclip)
+            if isa(crange, Tuple)
+                single_colors[colors .< crange[1]] .= to_color(lclip)
+                single_colors[colors .> crange[2]] .= to_color(hclip)
+            end
             real_colors = RGBAf[]
             # Map one single color per mesh to each vertex
             for (mesh, color) in zip(meshes, single_colors)


### PR DESCRIPTION
Continuation of https://github.com/JuliaPlots/Makie.jl/pull/2175
with:

1) improvements from #2056, so that high/low clip doesn't need to be handled in recipe
2) overload `convert_arguments` for single geometries, to not dispatch them to the multi mesh recipes (it seems like that was the case for all these years, which should have made `poly(Rect(...))` unnecessarily slow)
3) added a test for low/high clip