### PR TITLE
Fix scroll lock in Menu

### DIFF
--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -242,10 +242,14 @@ function initialize_block!(m::Menu; default = nothing)
     end
 
     on(menuscene.events.scroll) do (x, y)
-        t = translation(menuscene)[]
-        new_y = max(min(t[2] - y, 0), height(menuscene.px_area[]) - listheight[])
-        translate!(menuscene, t[1], new_y, t[3])
-        return Consume(true)
+        if is_mouseinside(menuscene)
+            t = translation(menuscene)[]
+            new_y = max(min(t[2] - y, 0), height(menuscene.px_area[]) - listheight[])
+            translate!(menuscene, t[1], new_y, t[3])
+            return Consume(true)
+        else
+            return Consume(false)
+        end
     end
 
     on(m.options) do options

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -241,7 +241,7 @@ function initialize_block!(m::Menu; default = nothing)
         return Consume(false)
     end
 
-    on(menuscene.events.scroll) do (x, y)
+    on(menuscene.events.scroll, priority=61) do (x, y)
         if is_mouseinside(menuscene)
             t = translation(menuscene)[]
             new_y = max(min(t[2] - y, 0), height(menuscene.px_area[]) - listheight[])


### PR DESCRIPTION
# Description

Currently the scrolling interaction of menu scenes always triggers and always blocks lower priority/later scroll events (as long as it isn't blocked by something else). This means that creating a `Menu` before an `Axis` will make you unable to zoom in that axis.

This is fixed here by only running code and returning `Consume(true)` if `is_mouseinside(menuscene)` is true. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
