### PR TITLE
Add missing backticks and full stop

### DIFF
--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -3,8 +3,8 @@
     contour(x, y, z)
     contour(z::Matrix)
 
-Creates a contour plot of the plane spanning x::Vector, y::Vector, z::Matrix
-If only `z::Matrix` is supplied, the indices of the elements in `z` will be used as the x and y locations when plotting the contour.
+Creates a contour plot of the plane spanning `x::Vector`, `y::Vector`, `z::Matrix`.
+If only `z::Matrix` is supplied, the indices of the elements in `z` will be used as the `x` and `y` locations when plotting the contour.
 
 The attribute levels can be either
 


### PR DESCRIPTION
# Description

Add missing backticks and full stop to `contour` docstring.

## Type of change

Delete options that do not apply:

Only change is to docstring for `contour`

## Checklist

- [x] Added or changed relevant sections in the documentation
