### PR TITLE
close the crossbar shape

### DIFF
--- a/src/stats/crossbar.jl
+++ b/src/stats/crossbar.jl
@@ -88,7 +88,9 @@ function Makie.plot!(plot::CrossBar)
                 fpoint.(l, ymax),
                 fpoint.(l, nmax),
                 fpoint.(m .- nw .* hw, y), # notch left
-                fpoint.(l, nmin),)))
+                fpoint.(l, nmin),
+                fpoint.(l, ymin)
+               )))
             boxes = if points isa AbstractVector{<: Point} # poly
                 [GeometryBasics.triangle_mesh(points)]
             else # multiple polys (Vector{Vector{<:Point}})


### PR DESCRIPTION
# Description

Fixes #2242 

The `crossbar` recipe was missing the last point to close the shape which caused missing strokes to show up in `boxplots`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
