### PR TITLE
Fix minor ticks z-shift

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -370,17 +370,21 @@ function initialize_block!(ax::Axis; palette = nothing)
     end
 
     xticksmirrored = lift(mirror_ticks, xaxis.tickpositions, ax.xticksize, ax.xtickalign, Ref(scene.px_area), :x, ax.xaxisposition[])
-    linesegments!(topscene, xticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xticksvisible)),
+    xticksmirrored_lines = linesegments!(topscene, xticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xticksvisible)),
         linewidth = ax.xtickwidth, color = ax.xtickcolor)
+    translate!(xticksmirrored_lines, 0, 0, 10)
     yticksmirrored = lift(mirror_ticks, yaxis.tickpositions, ax.yticksize, ax.ytickalign, Ref(scene.px_area), :y, ax.yaxisposition[])
-    linesegments!(topscene, yticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yticksvisible)),
+    yticksmirrored_lines = linesegments!(topscene, yticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yticksvisible)),
         linewidth = ax.ytickwidth, color = ax.ytickcolor)
+    translate!(yticksmirrored_lines, 0, 0, 10)
     xminorticksmirrored = lift(mirror_ticks, xaxis.minortickpositions, ax.xminorticksize, ax.xminortickalign, Ref(scene.px_area), :x, ax.xaxisposition[])
-    linesegments!(topscene, xminorticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xminorticksvisible)),
+    xminorticksmirrored_lines = linesegments!(topscene, xminorticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xminorticksvisible)),
         linewidth = ax.xminortickwidth, color = ax.xminortickcolor)
+    translate!(xminorticksmirrored_lines, 0, 0, 10)
     yminorticksmirrored = lift(mirror_ticks, yaxis.minortickpositions, ax.yminorticksize, ax.yminortickalign, Ref(scene.px_area), :y, ax.yaxisposition[])
-    linesegments!(topscene, yminorticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yminorticksvisible)),
+    yminorticksmirrored_lines = linesegments!(topscene, yminorticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yminorticksvisible)),
         linewidth = ax.yminortickwidth, color = ax.yminortickcolor)
+    translate!(yminorticksmirrored_lines, 0, 0, 10)
 
     xoppositeline = linesegments!(topscene, xoppositelinepoints, linewidth = ax.spinewidth,
         visible = xoppositespinevisible, color = xoppositespinecolor, inspectable = false,

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -266,6 +266,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
         linestyle = nothing, visible = minorticksvisible, inspectable = false
     )
     decorations[:minorticklines] = minorticklines
+    translate!(minorticklines, 0, 0, 10)
 
     realticklabelalign = Observable{Tuple{Symbol, Symbol}}((:none, :none); ignore_equal_values=true)
 


### PR DESCRIPTION
# Description

Fixes #2225 by translating minor ticks, as well as all mirrored ticks, forward in z-level. This gives the following picture now:

```julia
using GLMakie
GLMakie.activate!()

xs = 1:0.2:10
ys = abs.(sin.(xs))

f = Figure()
ax = Axis(f[1, 1],
    xticks = 0:10,
    xticksmirrored = true,
    xminorticksvisible = true,
    xminortickalign = 1,
    xtickalign = 1,
    xtickwidth = 10,
    xticksize = 20,
    xtickcolor = :red,
    xminortickwidth = 5,
    xminorticksize = 10,
    xminortickcolor = :yellow
)
barplot!(xs, ys, color = :green, strokecolor = :black, strokewidth = 1, gap = 0)
ylims!(ax, (0.0, 0.5))

f
```

![image](https://user-images.githubusercontent.com/26469701/188287735-f278ac42-b153-4fd1-80f4-a0cb50ef3253.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)