### PR TITLE
Fix error inside error message

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -116,11 +116,11 @@ function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
         end
     else
         renderobject = get(screen.cache, objectid(plot)) do
-            error("Could not find $(typeof(subplot)) in current GLMakie screen!")
+            error("Could not find $(typeof(plot)) in current GLMakie screen!")
         end
 
         # These need explicit clean up because (some of) the source observables
-        # remain whe the plot is deleated.
+        # remain when the plot is deleated.
         for k in (:normalmatrix, )
             if haskey(renderobject.uniforms, k)
                 n = renderobject.uniforms[k]

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -120,7 +120,7 @@ function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
         end
 
         # These need explicit clean up because (some of) the source observables
-        # remain when the plot is deleated.
+        # remain when the plot is deleted.
         for k in (:normalmatrix, )
             if haskey(renderobject.uniforms, k)
                 n = renderobject.uniforms[k]


### PR DESCRIPTION
# Description

Fixes an `UndefVarError` that prevented the content of an error message to be shown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)