### PR TITLE
generalize lift() and @lift()

### DIFF
--- a/src/interaction/observables.jl
+++ b/src/interaction/observables.jl
@@ -1,5 +1,15 @@
-# lift makes it easier to search + replace observable code, while `map` is really hard to differentiate from `map(f, array)`
-const lift = map
+# mimick Observables.jl map() signature to forward directly:
+lift(f, arg::AbstractObservable, args...; kwargs...) = map(f, arg, args...; kwargs...)
+# handle the general case:
+function lift(f, args...; kwargs...)
+    if !any(a -> isa(a, AbstractObservable), args)
+        # there are no observables
+        f(args...)
+    else
+        # there are observables, but not in the first position
+        lift((_, as...) -> f(as...), Observable(nothing), args...; kwargs...)
+    end
+end
 
 """
 Observables.off but without throwing an error

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -150,6 +150,10 @@ function Observables.onany(@nospecialize(f), @nospecialize(scene::Union{Plot,Sce
     return to_deregister
 end
 
+lift(f, @nospecialize(arg::Union{Plot,Scene}), args...; kwargs...) = map(f, arg, args...; kwargs...)
+
+# map! and map are for backward compatibility
+# can move everything to use lift() in the future
 @inline function Base.map!(f, @nospecialize(scene::Union{Plot,Scene}), result::AbstractObservable, os...;
                            update::Bool=true, priority = 0)
     # note: the @inline prevents de-specialization due to the splatting

--- a/test/observables.jl
+++ b/test/observables.jl
@@ -1,7 +1,17 @@
 @testset "lift macro" begin
+    u_noobs = "a"
     x = Observable(1.0)
     y = Observable(2.0)
     z = (x = x, y = y)
+
+    noobs = @lift u_noobs * "b"
+    @test noobs == "ab"
+
+    noobs = @lift $u_noobs * "b"
+    @test noobs == "ab"
+
+    xx = @lift $x
+    @test xx[] == 1.0
 
     t1 = @lift($x + $y)
     @test t1[] == 3.0


### PR DESCRIPTION
`@lift`: allow single observable, or no observables at all
`lift`: allow operating on non-observables

Motivation:
this enables preparing plotting arguments without manually handling observable and non-observable cases, like
```julia
# works no matter if x is a regular value or observable
y = lift(myfunc, x)
# or
y = @lift myfunc($x)

plot(y)
```
Fixes https://github.com/MakieOrg/Makie.jl/issues/3801 and #1662.

---

**UPD:** this PR appears to be effectively rejected here, but this exact `lift`/`@lift` functionality is made available in MakieExtra.jl.