### PR TITLE
add setindex() for Attributes

### DIFF
--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -94,6 +94,13 @@ function Base.setindex!(x::Attributes, value::NamedTuple, key::Symbol)
     return x[key] = Attributes(value)
 end
 
+function Base.setindex(x::Attributes, value::Observable, key::Symbol)
+    y = copy(x)
+    y[key] = value
+    return y
+end
+Base.setindex(x::Attributes, value, key::Symbol) = setindex(x, Observable(value), key)
+
 function Base.setproperty!(x::Union{Attributes, AbstractPlot}, key::Symbol, value)
     if hasfield(typeof(x), key)
         setfield!(x, key, value)


### PR DESCRIPTION
# Description

It's often useful to create a copy of Attributes with some value changed. `Base.setindex` is the function that does exactly this.

Afaict (correct me if I'm wrong), the implementation is correct for this purpose: if the new value is observable it just gets assigned, otherwise the value is converted to an observable and assigned. I tried assigning non-observables directly, but this affects the original Attributes as well, not just the copy.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added unit tests for new algorithms, conversion methods, etc.