### PR TITLE
Validate text align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).
 - Fixed `contourf` not rendering non-closed contours [#5651](https://github.com/MakieOrg/Makie.jl/issues/5651).
 - Fixed WGLMakie flickering while continuously resizing a canvas by re-rendering right after the resize.
 - Fixed WGLMakie crashing on a `null` WebGL context; it now shows the WebGL error message and requests the context with `failIfMajorPerformanceCaveat: false`.

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -11,7 +11,27 @@ conversion_trait(::Type{<:Text}, args...) = PointBased()
 convert_attribute(o, ::key"offset", ::key"text") = to_3d_offset(o) # same as marker_offset in scatter
 convert_attribute(f, ::key"font", ::key"text") = f # later conversion with fonts
 # text also allows :baseline and resolves it later
-convert_attribute(align, ::key"align", ::key"text") = Ref{Any}(align)
+function convert_attribute(align, ::key"align", ::key"text")
+    validate_text_align(align)
+    return Ref{Any}(align)
+end
+
+function validate_text_align(al::Union{Tuple, StaticVector})
+    if length(al) != 2
+        error("Text align must be a two-element tuple, got $(repr(al))")
+    end
+    if !(al[1] isa Real || al[1] in (:left, :right, :center))
+        error("Horizontal text align must be a Real or :left, :right, :center. Got $(repr(al[1]))")
+    end
+    if !(al[2] isa Real || al[2] in (:top, :bottom, :center, :baseline))
+        error("Vertical text align must be a Real or :top, :bottom, :center, :baseline. Got $(repr(al[2]))")
+    end
+    return
+end
+
+validate_text_align(als::AbstractVector) = foreach(validate_text_align, als)
+
+validate_text_align(al) = error("Text align must be a two-element tuple, got $(repr(al))")
 
 # Positions are always vectors so text should be too
 convert_attribute(str::AbstractString, ::key"text", ::key"text") = Ref{Any}([str]) # don't fix string type

--- a/Makie/test/plots/text.jl
+++ b/Makie/test/plots/text.jl
@@ -225,3 +225,15 @@ end
         @test length(unique([a, b, c])) == 2
     end
 end
+
+@testset "align validation" begin
+    @test_throws "Text align must be a two-element tuple, got :center" text(1, 2, align = :center)
+    @test_throws "Vertical text align must be a Real or :top, :bottom, :center, :baseline. Got :centr" text(1, 2, align = (1, :centr))
+    @test_throws "Horizontal text align must be a Real or :left, :right, :center. Got :centr" text(1, 2, align = (:centr, 1))
+    @test_throws "Text align must be a two-element tuple, got :center" text(1:2, 3:4, text = ["A", "B"], align = [:center, :center])
+    @test_throws "Vertical text align must be a Real or :top, :bottom, :center, :baseline. Got :centr" text(1:2, 3:4, text = ["A", "B"], align = [(:center, :centr), (:center, :center)])
+
+    @test text(1, 2, align = (:center, :baseline)) isa Makie.FigureAxisPlot
+    @test text(1, 2, align = Vec2f(0, 0)) isa Makie.FigureAxisPlot
+    @test text(1:2, 3:4, text = ["A", "B"], align = [Vec2f(0, 0), Vec2f(1, 1)]) isa Makie.FigureAxisPlot
+end


### PR DESCRIPTION
Before, you'd get an obscure error when accidentally passing a bare symbol like `text(..., align = :center)` instead of a tuple:

```
ERROR: MethodError: no method matching iterate(::Symbol)
```

wrapped in a `ComputePipeline.ResolveException`. Invalid symbols inside the tuple (e.g. `align = (:centr, 1)`) were even worse: they were silently ignored and fell back to a default alignment.

This adds explicit validation in `convert_attribute` for `align`, so both cases now error with a clear message:

```
Text align must be a two-element tuple, got :center
Horizontal text align must be a Real or :left, :right, :center. Got :centr
Vertical text align must be a Real or :top, :bottom, :center, :baseline. Got :centr
```

`to_align` can't be reused here because it maps to floats in `[0, 1]` and the vertical component additionally accepts `:baseline`, which has no such mapping.
