### PR TITLE
Cairo (scene) render order

### DIFF
--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -37,7 +37,7 @@ end
     scatter(f[1, 2], LinRange(0, 1, 10), RNG.rand(10))
     colors = Makie.resample(to_colormap(:Spectral), 20)
     scatter!(RNG.rand(20), RNG.rand(20), markersize=RNG.rand(20) .* 20, color=colors)
-    
+
     scatter(f[2, 1], -1..1, x -> x^2)
     scatter(f[2, 2], RNG.randn(10), color=:blue, glowcolor=:orange, glowwidth=10)
     f
@@ -58,7 +58,7 @@ end
     f
 end
 
-@reference_test "contour small x or y" begin 
+@reference_test "contour small x or y" begin
     f = Figure(size = (500, 300))
     contour(f[1, 1], RNG.rand(10, 50))
     contour(f[1, 2], RNG.rand(50, 10))
@@ -69,7 +69,7 @@ end
     f = Figure()
     contour(f[1, 1], RNG.randn(50, 40), levels=3)
     contour(f[1, 2], RNG.randn(50, 40), levels=[0.1, 0.5, 0.8])
-    contour(f[2, 1], RNG.randn(33, 30),  levels=[0.1, 0.5, 0.9], 
+    contour(f[2, 1], RNG.randn(33, 30),  levels=[0.1, 0.5, 0.9],
         color=[:black, :green, (:blue, 0.4)], linewidth=2)
     contour(
         f[2, 2], RNG.rand(33, 30) .* 6 .- 3, levels = [-2.5, 0.4, 0.5, 0.6, 2.5],
@@ -84,7 +84,7 @@ end
     streamplot(v, -2..2, -2..2)
 end
 
-@reference_test "meshscatter colors, Axis3" begin 
+@reference_test "meshscatter colors, Axis3" begin
     f = Figure()
     meshscatter(f[1, 1], RNG.rand(10), RNG.rand(10), RNG.rand(10), color=RNG.rand(10))
     meshscatter(f[1, 2], RNG.rand(10), RNG.rand(10), RNG.rand(10), color=RNG.rand(RGBAf, 10), transparency=true)
@@ -325,3 +325,41 @@ end
 #     # reference test the zoomed out plot
 #     f
 # end
+
+
+@reference_test "Scene (insertion) order and clearing" begin
+    scene = Scene(backgroundcolor = :darkblue, clear = true)
+    colorbuffer(scene) # trigger screen setup
+
+    # TODO: plots trigger scene insertion, potentially causing order differences
+    # TODO: clear all first causes plots behind scenes to still render
+    scene2 = Scene(scene, viewport = Observable(Rect2i(50, 50, 150, 150)),
+        backgroundcolor = :darkred, clear = true)
+    scene3 = Scene(scene, viewport = Observable(Rect2i(100, 100, 150, 150)),
+        backgroundcolor = :darkgreen, clear = true)
+
+    scene4 = Scene(scene, viewport = Observable(Rect2i(350, 50, 150, 150)),
+        backgroundcolor = :darkred, clear = true)
+    scene5 = Scene(scene, viewport = Observable(Rect2i(400, 100, 150, 150)),
+        backgroundcolor = :darkgreen, clear = true)
+
+    text!(scene3, "scene3", color = RGBf(1,0,1), align = (:center, :center), fontsize = 32)
+    text!(scene2, "scene2", color = :cyan, align = (:center, :center), fontsize = 32)
+
+    text!(scene4, "scene4", color = :cyan, align = (:center, :center), fontsize = 32)
+    text!(scene5, "scene5", color = RGBf(1,0,1), align = (:center, :center), fontsize = 32)
+
+    # TODO: no insert on scene causes scenes to not display
+    scene6 = Scene(scene, viewport = Observable(Rect2i(100, 300, 400, 100)),
+        backgroundcolor = :gray, clear = true)
+    scene7 = Scene(scene, viewport = Observable(Rect2i(150, 325, 300, 50)),
+        backgroundcolor = :black, clear = true)
+
+    # TODO: insertion order:   scene7 plots first, scene8 second
+    #       depth-first order: scene8 plots first, scene7 second <- want this?
+    # TODO: Should this be allowed to spill out of scene6?
+    scene8 = Scene(scene6, viewport = Observable(Rect2i(275, 275, 50, 150)),
+        backgroundcolor = :orange, clear = true)
+
+    scene
+end

--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -328,7 +328,7 @@ end
 
 
 @reference_test "Scene (insertion) order and clearing" begin
-    scene = Scene(backgroundcolor = :darkblue, clear = true)
+    scene = Scene(size = (600, 450), backgroundcolor = :darkblue, clear = true)
     colorbuffer(scene) # trigger screen setup
 
     # TODO: plots trigger scene insertion, potentially causing order differences


### PR DESCRIPTION
# Description

This is effectively #4150 for CairoMakie. The problems I'm trying to solve in that pr are:
1. (after display) scenes are not inserted immediately, but when plotted to. This can cause scene order to differ from later displaying and it can cause scene backgrounds to just be ignored
2. all scene clearing happens before plot rendering, resulting in plots drawing over scenes that they should be behind

Since there is no interactive adding of scene to the CairoMakie screen, Problem (1) doesn't apply here. Problem (2) is fairly easily fixed by just drawing scene-by-scene and only clearing the currently picked scene. This change is implemented here.

I added a refimg test that highlights these issues. For CairoMakie:

| before | after (correct?) |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/98d204e1-9d17-4da2-a644-aaf59bf4e749) | ![after](https://github.com/user-attachments/assets/39c17f4c-5da4-4db5-902e-745dc11ddda8) |

For reference this is what the other backends produce: (#4150 reproduces CairoMakie after, but AA is broken iirc)

| GLMakie | WGLMakie |
| --- | --- |
| ![GLMakie](https://github.com/user-attachments/assets/080ad465-5557-41f3-8a00-b6ac69659197) | ![WGLMakie](https://github.com/user-attachments/assets/0f9cc7e6-7a50-4301-8f49-7d984e5ff194) |

The lack of z sorting across multiple scenes breaks a bunch of assumptions made in MakieLayout. This includes:
- "Legend draw order" test being broken
- plot vs grid order changing in PolarAxis
- axis frame drawing behind plots
- Axis3 axis labels may now get clipped

Most of these issues could be fixed by adding an overlay scene and moving the respective plots there. Some cases, like the PolarAxis grid would be more complicated. Currently the grid can be moved behind or in front of plots, which would require moving the grid from a background scene to a foreground scene or vice versa.

Perhaps a better, less breaking option would be to "merge" scenes with `clear = false`. I the currently rendered `clear = true` scene has children with `clear = false`, consider all their plots part of the current scene, sorting them like we would now. (I think this would also be a good optimization for GLMakie if we don't want to rely on stencil buffers.)

This pr is currently more for testing plans/discussion/getting a CI run to look at. Maybe it gets to a point where we consider CairoMakie correct without breaking other backends, and maybe we can merge this then. Getting the other backends to match will take more effort I think.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
