### PR TITLE
hoist transform_func() calls out of loops for type stability and performance

### DIFF
--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -264,6 +264,7 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
         transform_marker = false
     )
 
+    transfunc = transform_func(plot)
     lift(plot, scene.camera.projectionview, transformationmatrix(plot), scene.viewport,
             labels, labelcolor, labelformatter, lev_pos_col
         ) do _, _, _, labels, labelcolor, labelformatter, lev_pos_col
@@ -273,8 +274,8 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
         col = texts.color[]; empty!(col)
         lbl = texts.text[]; empty!(lbl)
         for (lev, (p1, p2, p3), color) in lev_pos_col
-            px_pos1 = project(scene, apply_transform(transform_func(plot), p1))
-            px_pos3 = project(scene, apply_transform(transform_func(plot), p3))
+            px_pos1 = project(scene, apply_transform(transfunc, p1))
+            px_pos3 = project(scene, apply_transform(transfunc, p3))
             rot_from_horz::Float32 = angle(px_pos1, px_pos3)
             # transition from an angle from horizontal axis in [-π; π]
             # to a readable text with a rotation from vertical axis in [-π / 2; π / 2]
@@ -299,7 +300,7 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
         labels || return
         return broadcast(texts.plots[1][1].val, texts.positions.val, texts.rotation.val) do gc, pt, rot
             # drop the depth component of the bounding box for 3D
-            px_pos = project(scene, apply_transform(transform_func(plot), pt))
+            px_pos = project(scene, apply_transform(transfunc, pt))
             bb = unchecked_boundingbox(gc, to_ndim(Point3f, px_pos, 0f0), to_rotation(rot))
             isfinite_rect(bb) || return Rect2f()
             Rect2f(bb)
@@ -319,14 +320,14 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
             if isnan(p) && n < nlab
                 bb = bboxes[n += 1]  # next segment is materialized by a NaN, thus consider next label
                 # wireframe!(plot, bb, space = :pixel)  # toggle to debug labels
-            elseif project(scene, apply_transform(transform_func(plot), p)) in bb
+            elseif project(scene, apply_transform(transfunc, p)) in bb
                 masked[i] = nan
                 for dir in (-1, +1)
                     j = i
                     while true
                         j += dir
                         checkbounds(Bool, segments, j) || break
-                        project(scene, apply_transform(transform_func(plot), segments[j])) in bb || break
+                        project(scene, apply_transform(transfunc, segments[j])) in bb || break
                         masked[j] = nan
                     end
                 end

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -261,8 +261,9 @@ function plot_to_screen(plot, points::AbstractVector)
     spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) *
         f32_convert_matrix(plot, space) * transformationmatrix(plot)[]
 
+    transfunc = transform_func(plot)
     return map(points) do p
-        transformed = apply_transform(transform_func(plot), p)
+        transformed = apply_transform(transfunc, p)
         p4d = spvm * to_ndim(Point4d, to_ndim(Point3d, transformed, 0), 1)
         return Point2f(p4d) / p4d[4]
     end


### PR DESCRIPTION
# Description

Fixes # (issue)

I noticed a very slow `rangebars` plot, and found that the vast majority of time was spent in 
https://github.com/MakieOrg/Makie.jl/blob/e4b3b5b5ebde7de7b4f745b859f68ab27667e364/src/basic_recipes/error_and_rangebars.jl#L265-L267
Turns out, this is caused by type instability: the type of `plot` doesn't tell anything about the type of `transform_func(plot)`. Hoisting that call out of the `map` loop helps immensely.

I also did a search for `transform_func` calls in loops, and found only one in contours – hoisted that call out of the loop as well.

No behavior changes anywhere, just performance improvements.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
