### PR TITLE
annotation: default textcolor to color

### DIFF
--- a/src/basic_recipes/annotation.jl
+++ b/src/basic_recipes/annotation.jl
@@ -69,7 +69,7 @@ be very close to their associated data points so connection plots are typically 
     """
     The color of the text labels.
     """
-    textcolor = :black
+    textcolor = nothing
     """
     The basic color of the connection object. For more fine-grained adjustments, modify the `style` object directly.
     """
@@ -199,7 +199,7 @@ function Makie.plot!(p::Annotation{<:Tuple{<:AbstractVector{<:Vec4}}})
         text = p.text,
         align = p.align,
         offset = zeros(Vec2d, length(textpositions[])),
-        color = p.textcolor,
+        color = lift(something, p.textcolor, p.color),
         font = p.font,
         fonts = p.fonts,
         justification = p.justification,


### PR DESCRIPTION
# Description

Now `color` adjusts both line and text color, unless a `textcolor` is passed explicitly.
Opening this quick PR following Julius advice from slack.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.