### PR TITLE
Fix relocatability CI run for (W)GLMakie

### DIFF
--- a/.github/workflows/relocatability.yml
+++ b/.github/workflows/relocatability.yml
@@ -30,14 +30,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:
           - x64
         backend:
-          #- GLMakie
-          #- WGLMakie
+          - GLMakie
+          - WGLMakie
           - CairoMakie
     steps:
       - name: Checkout


### PR DESCRIPTION
Lets face it, these don't run anymore.
It's a bit of a riddle why they stopped working, but I assume OOM, due to a larger compilation workload.
I tried them locally on linux, where everything works fine,  but it did require quite a lot of ram (19gb), which made me think it's RAM related.
The tricks to cut down on RAM usage with env vars and disabling precompile workload was not successful, which is a bit weird, considering that it was working well some weeks ago, and I dont think our ram usage can have grown by that much.