### PR TITLE
Fix left-justification for Textboxes with multiline text content

### DIFF
--- a/Makie/src/makielayout/blocks/textbox.jl
+++ b/Makie/src/makielayout/blocks/textbox.jl
@@ -75,7 +75,7 @@ function initialize_block!(tbox::Textbox)
     t = Label(
         scene, text = tbox.displayed_string, bbox = bbox, halign = :left, valign = :top,
         width = Auto(true), height = Auto(true), color = realtextcolor,
-        fontsize = tbox.fontsize, padding = tbox.textpadding
+        fontsize = tbox.fontsize, padding = tbox.textpadding, justification = :left
     )
 
     textplot = t.blockscene.plots[1]


### PR DESCRIPTION
# Description

Previously, multiline text content in Textboxes was center-justified. This is now fixed.

- specified left-justification during Label initialization as part of Textbox definition
- specifying left-justification overrides the internal Label's default center-justification

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
