### PR TITLE
Generalize `width` and `dodge_gap` logic to accept multiple values

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,11 +1,1 @@
-always_for_in = true
-always_use_return = true
-import_to_using = false
-margin = 110
-pipe_to_function_call = true
-remove_extra_newlines = true
-short_to_long_function_def = false
-style = "blue"
-whitespace_in_kwargs = false
-whitespace_ops_in_indices = true
-whitespace_typedefs = false
+style = "yas"

--- a/Makie/src/stats/boxplot.jl
+++ b/Makie/src/stats/boxplot.jl
@@ -219,7 +219,7 @@ function Makie.plot!(plot::BoxPlot)
         gap = 0, color = plot.boxcolor, width = plot.boxwidth,
         show_midline = plot.show_median, midlinecolor = plot.mediancolor, midlinewidth = plot.medianlinewidth,
         # These should not be passed/defaulted
-        n_dodge = automatic, dodge = automatic
+        n_dodge = automatic, dodge = automatic, dodge_gap = 0.0
     )
     return plot
 end

--- a/Makie/src/stats/crossbar.jl
+++ b/Makie/src/stats/crossbar.jl
@@ -22,7 +22,16 @@ It is most commonly used as part of the `boxplot`.
     orientation = :vertical
 
     # box and dodging
-    "(Unscaled) width of the box."
+    """
+    Sets the (unscaled) width of the crossbar. When `dodge` is used, width can be a
+    single value or a vector of `n_dodge` values. As a single value it specifies the
+    combined width of all dodged elements in a single category/x value. As multiple values
+    it specifies the relative width of each of the dodged elements times the total width:
+    that is, `mean(width)` will comprise the full width of each category/x value. Variable
+    dodge widths can be useful when combining multiple elements (e.g. crossbars and violins)
+    in the same figure at different dodge positions: each plot element would correspond to a
+    distinct dodge index in this case.
+    """
     width = automatic
     """
     Dodge can be used to separate crossbars drawn at the same `x` positions. For this
@@ -38,7 +47,11 @@ It is most commonly used as part of the `boxplot`.
     n_dodge = automatic
     "Size of the gap between crossbars. The modified width is `width * (1 - gap)`."
     gap = 0.2
-    "Sets the gap between dodged crossbars relative to the size of them."
+    """
+    Sets the gap between dodged crossbars relative to their size. Can be a single
+    number or `n_dodge - 1` numbers to indicate a different gap between
+    each dodged element.
+    """
     dodge_gap = 0.03
 
     "Sets the outline linewidth of crossbars."

--- a/docs/src/explanations/dodging.md
+++ b/docs/src/explanations/dodging.md
@@ -1,0 +1,125 @@
+# Dodging
+
+Dodging a visual element is the practice of offsetting its position relative to the other visual elements so that they do not overlap. For example, in a barplot, we can show three groups (color) at three distinct levels (x-axis), like so:
+
+```@figure barplot
+tbl = (cat = [1, 1, 1, 2, 2, 2, 3, 3, 3],
+       height = 0.1:0.1:0.9,
+       grp = [1, 2, 3, 1, 2, 3, 1, 2, 3],
+       grp1 = [1, 2, 2, 1, 1, 2, 1, 1, 2],
+       grp2 = [1, 1, 2, 1, 2, 1, 1, 2, 1]
+       )
+
+barplot(tbl.cat, tbl.height,
+        dodge = tbl.grp,
+        color = tbl.grp,
+        axis = (xticks = (1:3, ["left", "middle", "right"]),
+                title = "Dodged bars"),
+        )
+```
+
+## Variable gap and width
+
+When `dodge_gap` is a scalar, all dodged elements are spaced with the same gap. You can instead pass a vector of length N-1 (where N is the number of dodged elements) to vary the gap between each adjacent pair. This is useful for visually grouping related sub-groups closer together.
+
+```@figure dodge_gap_vector
+times = repeat(1:3, inner=6)
+doses = repeat(1:2, inner=3, outer=3)
+thirds = repeat(1:3, outer=6)
+y = [0.4, 0.6, 0.5, 0.7, 0.3, 0.8, 0.5, 0.4, 0.7, 0.6, 0.8, 0.3, 0.3, 0.7, 0.6, 0.5, 0.4, 0.9]
+
+# 6 dodged elements: gaps between elements 1-2, 2-3, 3-4, 4-5, 5-6
+# Use a large gap between dose groups (positions 3-4) and small gaps within each dose group
+dodge_gap = [0.05, 0.05, 0.3, 0.05, 0.05]
+dodge = (doses .- 1) .* 3 .+ thirds
+
+barplot(times, y;
+        dodge = dodge,
+        color = thirds,
+        dodge_gap = dodge_gap,
+        axis = (xticks = (1:3, ["Time 1", "Time 2", "Time 3"]),
+                title = "Varying dodge gap"),
+        )
+```
+
+Similarly, `width` can be a vector to give each dodged element a different width:
+
+```@figure dodge_width_vector
+times = repeat(1:3, inner=4)
+doses = repeat(1:2, inner=2, outer=3)
+halves = repeat(1:2, outer=6)
+y = [0.6, 0.4, 0.7, 0.3, 0.5, 0.8, 0.4, 0.6, 0.7, 0.3, 0.5, 0.8]
+dodge = (doses .- 1) .* 2 .+ halves
+
+barplot(times, y;
+        dodge = dodge,
+        color = halves,
+        width = [1.0, 0.4, 1.0, 0.4],
+        dodge_gap = fill(0.1, 3),
+        axis = (xticks = (1:3, ["Time 1", "Time 2", "Time 3"]),
+                title = "Varying dodge width"),
+        )
+```
+
+Both can be combined to give full control over the layout of each dodge group:
+
+```@figure dodge_gap_and_width
+times = repeat(1:3, inner=4)
+doses = repeat(1:2, inner=2, outer=3)
+halves = repeat(1:2, outer=6)
+y = [0.6, 0.4, 0.7, 0.3, 0.5, 0.8, 0.4, 0.6, 0.7, 0.3, 0.5, 0.8]
+dodge = (doses .- 1) .* 2 .+ halves
+
+barplot(times, y;
+        dodge = dodge,
+        color = halves,
+        width = [1.0, 0.4, 1.0, 0.4],
+        dodge_gap = [0.05, 0.3, 0.05],
+        axis = (xticks = (1:3, ["Time 1", "Time 2", "Time 3"]),
+                title = "Varying gap and width"),
+        )
+```
+
+## Compositing plot types
+
+By using `n_dodge` you can align different plot types on the same axis so they share the same dodge layout. Each plot type occupies a specific slot within the shared dodge space. This enables rich composite visualizations, such as pairing a violin with a boxplot:
+
+```@figure composite_dodge
+using Random
+rng = Xoshiro(2025_10_30)
+
+values = [randn(rng, 100) .* 3 .+ 1; randn(rng, 100) .* 2 .+ 5; randn(rng, 100) .* -1;
+          randn(rng, 100) .* 8 .+ 5; randn(rng, 100) .* 5 .+ 6; randn(rng, 100) .* 2 .+ 8]
+types = repeat(1:6; inner=100)
+x = (types .- 1) .÷ 3
+colors = types .% 3
+data = (; x, y=values, colors)
+
+# Each color group occupies 2 slots: violin (slot *2+1), boxplot (slot *2+2)
+n = length(unique(data.colors)) * 2
+palette = Makie.current_default_theme()[:palette][:color][]
+
+fig = Figure()
+ax = Axis(fig[1, 1])
+
+violin!(ax, data.x, data.y;
+        side = :left,
+        gap = 0.4,
+        dodge = data.colors .* 2 .+ 1,
+        n_dodge = n,
+        width = repeat([2.0, 0.3], 3),
+        color = palette[data.colors .+ 1],
+        dodge_gap = [-0.2, 0.0, -0.2, 0.0, -0.2])
+
+boxplot!(ax, data.x, data.y;
+         gap = 0.4,
+         dodge = data.colors .* 2 .+ 2,
+         n_dodge = n,
+         width = repeat([2.0, 0.3], 3),
+         dodge_gap = [-0.2, 0.0, -0.2, 0.0, -0.2],
+         color = palette[data.colors .+ 1])
+
+fig
+```
+
+Negative gap values in `dodge_gap` cause adjacent elements to overlap, which is useful for nesting related plot types (e.g., overlapping a boxplot onto its corresponding violin).

--- a/docs/src/reference/plots/rainclouds.md
+++ b/docs/src/reference/plots/rainclouds.md
@@ -7,6 +7,9 @@ rainclouds
 "Raincloud" plots are a combination of a (half) violin plot, box plot and scatter plots. The
 three together can make an appealing and informative visual, particularly for large N datasets.
 
+!!! note
+    Ultimately, variable length `dodge` and `width` values provide a more principled,
+    flexible approach to creating raincloud plots. See the [dodging](@ref) explanation for details.
 
 ```@figure rainclouds
 using Random


### PR DESCRIPTION
 <!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ```
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix.
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

This is a PR started during the JuliaCon 2025 hack-a-thon.

@jkrumbiegel and I discussed at the conference that a good first step towards #4921 could be to make it possible to have a different `width` for each `dodge` index, and a different `dodge_gap` between each two contiguous dodge indices. This makes it possible to implement the composition of graphical elements with dodge (e.g. to make a raincloud plot, where each element of the figure is a different dodge index), without preventing us from using dodge (and e.g. color) as a way to represent some variable of interest (e.g. x-axis could be time-point, and dodge and color could be dose)—this requires that we can dodge the indiviudal graphic elements, but also—at a level above that—dodging each composed set of elements from one another with a wider gap than used within each composed element. A follow-up PR can address some limitations in AlgebraOfGraphics around passing `n_dodge` appropriately.

Seems like there isn't yet any API documentation for all relevant attributes here, so I  updated those to include both the scalar-valued and iterator-valued use cases.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
  - [x] updated receipies
    - [x] boxplot 
    - [x] violin
    - [x] barplot
    - [x] crossbar
    - [x] waterfall
  - [x] add an explanation
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc. (use examples below)
- [ ] formatting: I noticed that `barplot.jl` does not seem to conform to `.JuliaFormatting.toml`. Should I address that here?
- [x] think through more edge cases and test any I think of
- [x] debug of any issue raised in tests

Here is the script I used to play around with what I have so far (see comments below for updated script). All of these examples are working well.

```julia
using CairoMakie, DataFrames, Random

n = 1000

times = 1:3
doses = 1:2
halves = 1:2

df = DataFrame([(; time, dose, half) for time in times for dose in doses for half in halves])
df.y = rand(nrow(df))

function unique_indices(xs)
    mapping = Dict(x => i for (i, x) in enumerate(unique(xs)))
    return [mapping[x] for x in xs]
end

df.dodge = unique_indices(tuple.(df.dose, df.half))

barplot(df.time, df.y; color=df.half, width=fill(0.8, 4), dodge=df.dodge,
        dodge_gap=fill(0.1, 3))

# changing gaps
barplot(df.time, df.y; color=df.half, width=0.8, dodge=df.dodge,
        dodge_gap=0.1)

barplot(df.time, df.y; color=df.half, width=fill(0.5, 4), dodge=df.dodge,
        dodge_gap=[0.05, 0.3, 0.05])

# changing width
barplot(df.time, df.y; color=df.half, width=[1, 0.3, 1, 0.3], dodge=df.dodge,
        dodge_gap=[0.1, 0.1, 0.1])

# changing both
barplot(df.time, df.y; color=df.half, width=[1, 0.3, 1, 0.3], dodge=df.dodge,
        dodge_gap=[0.1, 0.3, 0.1])

barplot(df.time, df.y; color=df.half, width=0.5(rand(4) .+ 1), dodge=df.dodge,
        dodge_gap=rand(3)*0.3)

# now with six instead of four elements

times = 1:3
doses = 1:2
thirds = 1:3

df = DataFrame([(; time, dose, third) for time in times for dose in doses for third in thirds])
df.y = rand(nrow(df))
df.dodge = unique_indices(tuple.(df.dose, df.third))

# changing gap
barplot(df.time, df.y; color=df.third, width=fill(0.5, 6), dodge=df.dodge,
        dodge_gap=[0.05, 0.05, 0.3, 0.05, 0.05])

# changing width
barplot(df.time, df.y; color=df.third, width=[1, 0.5, 0.2, 1, 0.5, 0.2], dodge=df.dodge,
        dodge_gap=fill(0.1, 5))

# changing both
barplot(df.time, df.y; color=df.third, width=[1, 0.5, 0.2, 1, 0.5, 0.2], dodge=df.dodge,
        dodge_gap=[0.05, 0.05, 0.3, 0.05, 0.05])


barplot(df.time, df.y; color=df.third, width=0.5(rand(6) .+ 1), dodge=df.dodge,
        dodge_gap=rand(5)*0.1)
```