### PR TITLE
fix DQ test

### DIFF
--- a/ReferenceTests/src/tests/dynamicquantities.jl
+++ b/ReferenceTests/src/tests/dynamicquantities.jl
@@ -2,7 +2,7 @@ using Test
 import ReferenceTests.DynamicQuantities as DQ
 
 @reference_test "DQ combining units, error for numbers" begin
-    f, ax, pl = scatter(((1:600:(100 * 60))DQ.u"s") .|> DQ.us"min", 1:10, markersize = 20, color = 1:10)
+    f, ax, pl = scatter(((1:600:(100 * 60)) .* DQ.u"s") .|> DQ.us"min", 1:10, markersize = 20, color = 1:10)
     scatter!(ax, (1:10)DQ.u"hr", 1:10; markersize = 20, color = 1:10, colormap = :reds)
     @test_throws ResolveException scatter!(ax, rand(10), 1:10) # should error!
     f


### PR DESCRIPTION
# Description

I can't reproduce this locally with the versions I happen to have but since #5306 is fine with the DQ expression split over two lines I'm guessing that it's an execution order problem. Maybe moving a parenthesis is enough to fix the error.

## Type of change

- test/CI fix