### PR TITLE
Skip the benchmark CI step for outside contributors

### DIFF
--- a/.github/workflows/compilation-benchmark.yaml
+++ b/.github/workflows/compilation-benchmark.yaml
@@ -50,13 +50,28 @@ jobs:
     permissions:
       statuses: write       # Permission to post workflow status
     steps:
+      - name: Check token validity
+        id: check_token
+        env:
+          BENCHMARK_KEY: ${{ secrets.BENCHMARK_KEY }}
+        run: |
+          if [ -z "$BENCHMARK_KEY" ]; then
+            echo "Benchmark key missing — skipping benchmark upload."
+            echo "NOTE: Benchmark key is not accessible for outside contributors"
+            echo "has_token=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_token=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download artifacts
+        if: steps.check_token.outputs.has_token == 'true'
         uses: actions/download-artifact@v5
         with:
           path: ./images
           merge-multiple: true
 
       - name: Create Gist with images
+        if: steps.check_token.outputs.has_token == 'true'
         env:
           GH_TOKEN: ${{ secrets.BENCHMARK_KEY }}
         run: |
@@ -69,6 +84,7 @@ jobs:
           echo "GIST_URL_USERCONTENT=$(echo $gist_url | sed 's|github|githubusercontent|')" >> $GITHUB_ENV
 
       - name: Post workflow status with gist link
+        if: steps.check_token.outputs.has_token == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -82,7 +98,9 @@ jobs:
             -f "context=Benchmark Results" \
             -f "description=Plots are available under Details" \
             -f "target_url=$gist_url"
+
       - name: Post comment
+        if: steps.check_token.outputs.has_token == 'true'
         uses: thollander/actions-comment-pull-request@v3
         with:
           github-token: ${{ secrets.BENCHMARK_KEY }}


### PR DESCRIPTION
- **fix(CI): Skip the upload of benchmark when key is missing**
- **chore(github): Update the CHANGELOG.md**

Fixes #5338
