### PR TITLE
Cycle plotlist

### DIFF
--- a/Makie/src/specapi.jl
+++ b/Makie/src/specapi.jl
@@ -596,6 +596,7 @@ end
 function plot_cycle_index(parent::PlotList, plot::Plot)
     return _plot_cycle_index(parent, plot)
 end
+plot_cycle_can_recurse(::PlotList)=true
 
 function plot_cycle_index(specs, spec::PlotSpec, plot::Plot)
     cycle = plot.cycle[]
@@ -608,7 +609,7 @@ function plot_cycle_index(specs, spec::PlotSpec, plot::Plot)
         plotfunc(p) !== plotfunc_spec && continue
         _plot = to_plot_object(p)
         if !isnothing(_plot.cycle[])
-            is_cycling = any(syms) do x
+            is_cycling = any(syms) do sym
                 !haskey(p.kwargs, sym) && return true
                 return isnothing(p.kwargs[sym])
             end


### PR DESCRIPTION
# Description
Plots created by `plotlist` don't cycle properly.
Computation of the `cycle_index` via `plot_cycle_index` can now also work with `PlotList` objects.
We also recurse `PlotList` objects in `scene.plots`.
In `diff_plotlist!` we have to keep in mind that the current `plotlist` is not yet in `scene.plots`, so compute an offset.

`plot_cycle_index` did not look quite right with the `specs, spec::PlotSpec, plot::Plot` signature, but I don't know how to test it.

Seems to fix #4843 #4353 #4322

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
