### PR TITLE
Fix docstring type signature for `Tick`

### DIFF
--- a/Makie/src/types.jl
+++ b/Makie/src/types.jl
@@ -40,7 +40,7 @@ Identifies the source of a tick:
 end
 
 """
-    struct TickState
+    struct Tick
 
 Contains information for tick events:
 - `state::TickState`: identifies what caused the tick (see Makie.TickState)


### PR DESCRIPTION

# Description

The main signature for the `Tick` struct incorrectly identified it as a `TickState`. This PR corrects the naming.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
