### PR TITLE
small performance tweak for errorbars/rangebars

### DIFF
--- a/Makie/src/basic_recipes/error_and_rangebars.jl
+++ b/Makie/src/basic_recipes/error_and_rangebars.jl
@@ -161,7 +161,7 @@ function generate_segments(data, in_y::Bool)
     # using list comprehension leads to `push!()` with this
     output = Vector{Point2d}(undef, 2 * length(data))
     for (i, item) in enumerate(data)
-        output[2i-1], output[2i] = inner_segment(item, in_y)
+        output[2i - 1], output[2i] = inner_segment(item, in_y)
     end
     return output
 end


### PR DESCRIPTION
# Description

While checking some benchmarks for #5004 I noticed that a fairly large chunk of time is now spent on `generate_segments` and that `push!()` is being called there. I assume that means Julia fails to determine the array size and dynamically resizes it instead. This pr replaces the list comprehension for a written out loop to avoid that. This reduces the call from about 850µs mean to about 250µs with `rand(Vec3f, 10^5)`. The benchmarks I posted in #5004 speed up by 600-800µs.

## Type of change

- performance tweak (non-breaking)
