### PR TITLE
Remove gensyms that tripped up revise on 1.12

### DIFF
--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -55,13 +55,13 @@ macro Block(_name::Union{Expr, Symbol}, body::Expr = Expr(:block))
 
     push!(fields_vector, constructor)
 
-    docs_placeholder = gensym()
+    docs_placeholder = Symbol("#__", name, "_docs_placeholder")
 
     q = quote
         # This part is as far as I know the only way to modify the docstring on top of the
         # recipe, so that we can offer the convenience of automatic augmented docstrings
         # but combine them with the simplicity of using a normal docstring.
-        # The trick is to mark some variable (in this case a gensymmed placeholder) with the
+        # The trick is to mark some variable with the
         # Core.@__doc__ macro, which causes this variable to get assigned the docstring on top
         # of the @recipe invocation. From there, it can then be retrieved, modified, and later
         # attached to plotting function by using @doc again. We also delete the binding to the

--- a/Makie/src/recipes.jl
+++ b/Makie/src/recipes.jl
@@ -286,6 +286,7 @@ macro DocumentedAttributes(expr::Expr)
     closure_exprs = []
     mixin_exprs = Expr[]
 
+    mixin_idx = 0
     for arg in expr.args
         arg isa LineNumberNode && continue
 
@@ -326,15 +327,13 @@ macro DocumentedAttributes(expr::Expr)
             end
             push!(metadata_exprs, metadata)
         elseif is_mixin_line
-            # this intermediate variable is needed to evaluate each mixin only once
-            # and is inserted at the start of the final code block
-            gsym = gensym("mixin")
+            mixin_idx += 1
             mixin = only(attr.args)
             push!(
                 mixin_exprs, quote
-                    $gsym = $(esc(mixin))
-                    if !($gsym isa DocumentedAttributes)
-                        error("Mixin was not a DocumentedAttributes but $($gsym)")
+                    mixins[$mixin_idx] = $(esc(mixin))
+                    if !(mixins[$mixin_idx] isa DocumentedAttributes)
+                        error("Mixin was not a DocumentedAttributes but $(mixins[$mixin_idx])")
                     end
                 end
             )
@@ -342,7 +341,7 @@ macro DocumentedAttributes(expr::Expr)
             # docstrings and default expressions of the mixed in
             # DocumentedAttributes are inserted
             metadata_exp = quote
-                for (key, value) in $gsym.d
+                for (key, value) in mixins[$mixin_idx].d
                     if haskey(d, key)
                         error("Mixin `$($(QuoteNode(mixin)))` had the key :$key which already existed. It's not allowed for mixins to overwrite keys to avoid accidental overwrites. Drop those keys from the mixin first.")
                     end
@@ -356,6 +355,7 @@ macro DocumentedAttributes(expr::Expr)
     end
 
     return quote
+        mixins = Dict{Int, DocumentedAttributes}()
         $(mixin_exprs...)
         d = Dict{Symbol, AttributeMetadata}()
         $(metadata_exprs...)
@@ -485,14 +485,14 @@ function create_recipe_expr(Tsym, args, attrblock)
     # attrblock = expand_mixins(attrblock)
     # attrs = [extract_attribute_metadata(arg) for arg in attrblock.args if !(arg isa LineNumberNode)]
 
-    docs_placeholder = gensym()
-    attr_placeholder = gensym()
+    docs_placeholder = Symbol("#__", funcname_sym, "_docs_placeholder")
+    attr_placeholder = Symbol("#__", funcname_sym, "_attr_placeholder")
 
     q = quote
         # This part is as far as I know the only way to modify the docstring on top of the
         # recipe, so that we can offer the convenience of automatic augmented docstrings
         # but combine them with the simplicity of using a normal docstring.
-        # The trick is to mark some variable (in this case a gensymmed placeholder) with the
+        # The trick is to mark some variable with the
         # Core.@__doc__ macro, which causes this variable to get assigned the docstring on top
         # of the @recipe invocation. From there, it can then be retrieved, modified, and later
         # attached to plotting function by using @doc again. We also delete the binding to the


### PR DESCRIPTION
I guess these were not strictly needed and did mess up Revise's variable tracking (at least on the new 1.12 version that can revise structs). After these changes the previous Revise errors go away, however I still got a wall of this kind of text when I did the test of editing one field of the `ScrollZoom` struct:

```
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `Makie.#LineElement#5383` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `Makie.#distance_score#5480` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `Makie.#MeshScatterElement#5406` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
WARNING: Detected access to binding `Makie.#onmouseleftdoubleclick#5520` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
```

@timholy note that I saw for example `onmouseleftup` in that list, which seems to be only used in `function initialize_block!(b::Button)` https://github.com/MakieOrg/Makie.jl/blob/3d3afc598d6645aeee478c0c7dca7b24a3d5878a/Makie/src/makielayout/blocks/button.jl#L65-L68 for which I can't see a connection to the `ScrollZoom` struct at all. So there still seems to be more reevaluation than strictly necessary, at least with my very limited understanding of how Revise might work. 