### PR TITLE
pretty sure this is unsafe without preserve

### DIFF
--- a/GLMakie/src/GLAbstraction/GLExtendedFunctions.jl
+++ b/GLMakie/src/GLAbstraction/GLExtendedFunctions.jl
@@ -9,9 +9,11 @@ function glGetShaderiv(shaderID::GLuint, variable::GLenum)
     return result[]
 end
 function glShaderSource(shaderID::GLuint, shadercode::Vector{UInt8})
-    shader_code_ptrs = Ptr{UInt8}[pointer(shadercode)]
-    len = Ref{GLint}(length(shadercode))
-    return glShaderSource(shaderID, 1, shader_code_ptrs, len)
+    GC.@preserve shadercode begin
+        shader_code_ptrs = Ptr{UInt8}[pointer(shadercode)]
+        len = Ref{GLint}(length(shadercode))
+        return glShaderSource(shaderID, 1, shader_code_ptrs, len)
+    end
 end
 glShaderSource(shaderID::GLuint, shadercode::String) = glShaderSource(shaderID, Vector{UInt8}(shadercode))
 function glGetAttachedShaders(program::GLuint)


### PR DESCRIPTION
Just noticed we dont preserve the array from which we take the pointer - I guess it doesn't lead to problems since we usually keep the parent array around, although especially the function below creates a throw away array which should be pretty unsafe.
Noticed while looking into : https://github.com/JuliaGL/ModernGL.jl/issues/84