### PR TITLE
due to padding html widget textbox input would clip

### DIFF
--- a/WGLMakie/src/html-widgets.jl
+++ b/WGLMakie/src/html-widgets.jl
@@ -383,20 +383,25 @@ function replace_widget!(textbox::Makie.Textbox)
 
     # Determine input type based on validator
     input_type = "text"
+
+    # Input styled directly - no padding (which causes clipping due to browser's
+    # `overflow: clip !important` for text <input>), instead use text-indent for horizontal offset
     input_styles = Styles(
         CSS(
             "width" => "100%",
             "height" => "100%",
+            "box-sizing" => "border-box",
             "font-family" => "inherit",
             "font-size" => "calc(var(--winscale) * $(fontsize) * 1px)",
             "color" => textcolor,
             "border" => "calc(var(--winscale) * $(borderwidth) * 1px) solid $(bordercolor)",
             "border-radius" => "calc(var(--winscale) * $(cornerradius) * 1px)",
             "background-color" => boxcolor,
-            "padding" => "calc(var(--winscale) * $(text_padding[1]) * 1px) calc(var(--winscale) * $(text_padding[2]) * 1px) calc(var(--winscale) * $(text_padding[3]) * 1px) calc(var(--winscale) * $(text_padding[4]) * 1px)",
+            "padding" => "0",
             "outline" => "none",
-            "box-sizing" => "border-box",
             "transition" => "border-color 0.2s, background-color 0.2s",
+            # Use text-indent for horizontal padding (doesn't affect content box)
+            "text-indent" => "calc(var(--winscale) * $(text_padding[4]) * 1px)",
         ),
         CSS(
             ":hover",
@@ -423,7 +428,6 @@ function replace_widget!(textbox::Makie.Textbox)
         onchange = js"""
             function(event) {
                 let value = event.target.value;
-                console.log("Textbox value changed:", value);
                 // Handle validation for numeric types
                 if ($(input_type) === "number") {
                     const numValue = parseFloat(value);


### PR DESCRIPTION
The padding was taking up space from the text input box, and the browsers <input>  has `clip important!`, which means we cant easily overwrite it. 
Now we use text-indent to position the text with padding, so that the padding doesn't take away "clip" space.
This ignores bottom/top/right padding, which I think is an ok compromise for now.