### PR TITLE
`band` docs enhancement: add alpha transparency

### DIFF
--- a/docs/src/reference/plots/band.md
+++ b/docs/src/reference/plots/band.md
@@ -33,7 +33,7 @@ X = X .- X[:, 1]
 μ = vec(mean(X, dims=1)) # mean
 lines!(t, μ)              # plot mean line
 σ = vec(std(X, dims=1))  # stddev
-band!(t, μ + σ, μ - σ)   # plot stddev band
+band!(t, μ + σ, μ - σ; alpha=0.5)   # plot stddev band
 f
 ```
 


### PR DESCRIPTION
Adding transparency to the band plot makes the lineplot (mean) also visible.

This was a regression compared to the docs from v0.23: 
- https://docs.makie.org/v0.23/reference/plots/band
- https://docs.makie.org/v0.24/reference/plots/band
