### PR TITLE
Update StatsBase compat to allow 0.35

### DIFF
--- a/Makie/Project.toml
+++ b/Makie/Project.toml
@@ -72,7 +72,6 @@ DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 MakieDynamicQuantitiesExt = "DynamicQuantities"
 
 [compat]
-Agents = "1, 2, 3, 4, 5, 6"  # Allow all Agents versions to work around transitive dependency constraints
 Animations = "0.4"
 Base64 = "1.0, 1.6"
 CRC32c = "1.0, 1.6"


### PR DESCRIPTION
## Description

This PR updates the `StatsBase` compatibility constraint in `Makie/Project.toml` to include version 0.35, allowing Makie.jl to work with the latest StatsBase releases.

**Change**: `StatsBase = "0.31, 0.32, 0.33, 0.34"` → `StatsBase = "0.31, 0.32, 0.33, 0.34, 0.35"`

## Motivation

StatsBase 0.35 has been released and is being used by other packages in the ecosystem. This update allows Makie.jl to be compatible with projects that require StatsBase 0.35, improving interoperability and enabling users to use the latest versions of StatsBase without conflicts.

## Testing

- [x] Package precompiles successfully with StatsBase 0.35
- [x] No breaking changes observed
- [x] Compatible with existing StatsBase 0.31-0.34 versions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

**Note**: This is a compatibility update that doesn't require documentation changes or new tests.