### PR TITLE
Add possibility to collect legend entries from multiple axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added possibility to gather legend entries from multiple axes [#5500](https://github.com/MakieOrg/Makie.jl/pull/5500)
 - Added loading spinner in WGLMakie that displays while the plot is being loaded [#5469](https://github.com/MakieOrg/Makie.jl/pull/5469)
 - Moved decoration plots in `Axis3` to `ax.blockscene` so they no longer show up as user plots in the Axis3 [#5463](https://github.com/MakieOrg/Makie.jl/pull/5463)
 - Fixed issue with `transformation` being applied multiple times when set by a user in a recipe that passes applicable attributes to child plots [#5464](https://github.com/MakieOrg/Makie.jl/pull/5464)

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -1075,7 +1075,7 @@ get_plots(p::PlotList) = haskey(p.attributes, :label) && p.attributes[:label] is
 
 get_plots(ax::Union{Axis, Axis3}) = get_plots(ax.scene)
 get_plots(lscene::LScene) = get_plots(lscene.scene)
-get_plots(axes::AbstractVector) =  collect(Iterators.flatmap(get_plots, axes))
+get_plots(axes::AbstractVector) = collect(Iterators.flatmap(get_plots, axes))
 function get_plots(scene::Scene)
     plots = AbstractPlot[]
     for p in scene.plots

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -997,13 +997,15 @@ end
 
 
 """
-    Legend(fig_or_scene, axis::Union{Axis, Scene, LScene}, title = nothing; merge = false, unique = false, kwargs...)
+    Legend(fig_or_scene, axis::Union{Axis, Axis3, Scene, LScene, AbstractVector{<:Union{Axis, Axis3, Scene, LScene}}}, title = nothing; merge = false, unique = false, kwargs...)
 
 Create a single-group legend with all plots from `axis` that have the
 attribute `label` set.
 
 If `merge` is `true`, all plot objects with the same label will be layered on top of each other into one legend entry.
 If `unique` is `true`, all plot objects with the same plot type and label will be reduced to one occurrence.
+
+To create a joint legend for multiple axes it is also possible to pass a `Vector` of axis objects.
 """
 function Legend(fig_or_scene, axis::Union{Axis, Axis3, Scene, LScene, AbstractVector{<:Union{Axis, Axis3, Scene, LScene}}}, title = nothing; merge = false, unique = false, kwargs...)
     plots, labels = get_labeled_plots(axis, merge = merge, unique = unique)

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -1005,7 +1005,7 @@ attribute `label` set.
 If `merge` is `true`, all plot objects with the same label will be layered on top of each other into one legend entry.
 If `unique` is `true`, all plot objects with the same plot type and label will be reduced to one occurrence.
 """
-function Legend(fig_or_scene, axis::Union{Axis, Axis3, Scene, LScene}, title = nothing; merge = false, unique = false, kwargs...)
+function Legend(fig_or_scene, axis::Union{Axis, Axis3, Scene, LScene, AbstractVector{<:Union{Axis, Axis3, Scene, LScene}}}, title = nothing; merge = false, unique = false, kwargs...)
     plots, labels = get_labeled_plots(axis, merge = merge, unique = unique)
     isempty(plots) && error("There are no plots with labels in the given axis that can be put in the legend. Supply labels to plotting functions like `plot(args...; label = \"My label\")`")
     return Legend(fig_or_scene, plots, labels, title; kwargs...)
@@ -1075,6 +1075,7 @@ get_plots(p::PlotList) = haskey(p.attributes, :label) && p.attributes[:label] is
 
 get_plots(ax::Union{Axis, Axis3}) = get_plots(ax.scene)
 get_plots(lscene::LScene) = get_plots(lscene.scene)
+get_plots(axes::AbstractVector) =  collect(Iterators.flatmap(get_plots, axes))
 function get_plots(scene::Scene)
     plots = AbstractPlot[]
     for p in scene.plots

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -535,25 +535,22 @@ end
 end
 
 @testset "Joint legend data gathering" begin
-    function make_fig_joint(plot_func, args...)
-        f = Figure()
-        ax1 = Axis(f[1, 1])
-        plot_func(ax1, args..., label = "test")
-        ax2 = Axis(f[1, 2])
-        plot_func(ax2, args..., label = "test")
-        Legend(f[1, 3], [ax1, ax2], merge = true)
-        return f
-    end
+    f = Figure()
+    ax1 = Axis(f[1, 1])
+    l1a = lines!(ax1, rand(10), label = "test a")
+    l1b = lines!(ax1, rand(10), label = "test b")
+    ax2 = Axis(f[1, 2])
+    l2a = lines!(ax2, rand(10), label = "test a")
+    leg = Legend(f[1, 3], [ax1, ax2], merge = true)
 
-    @test make_fig_joint(density!, rand(100)) isa Figure
-    @test make_fig_joint(poly!, Rect2f(0, 0, 1, 1)) isa Figure
-    @test make_fig_joint(band!, rand(3), rand(3), rand(3)) isa Figure
-    @test make_fig_joint(violin!, rand(1:3, 10), rand(10)) isa Figure
-    @test make_fig_joint(boxplot!, rand(1:3, 10), rand(10)) isa Figure
-    @test make_fig_joint(crossbar!, rand(3), rand(3), rand(3) .- 1, rand(3) .+ 1) isa Figure
-    @test make_fig_joint(scatter!, rand(3)) isa Figure
-    @test make_fig_joint(lines!, rand(3)) isa Figure
-    @test make_fig_joint(linesegments!, rand(8)) isa Figure
+    @test f isa Figure
+    # The joint legend has two entries
+    @test length(leg.entrygroups[][][2]) == 2
+    # The first entry has two linked plots
+    @test length(leg.entrygroups[][][2][1].elements) == 2
+    # The two linked plots are the plots from two different axes
+    @test leg.entrygroups[][][2][1].elements[1].plots[] == l1a
+    @test leg.entrygroups[][][2][1].elements[2].plots[] == l2a
 end
 
 @testset "ReversibleScale" begin

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -541,7 +541,7 @@ end
         plot_func(ax1, args..., label = "test")
         ax2 = Axis(f[1, 2])
         plot_func(ax2, args..., label = "test")
-        Legend(f[1, 3], [ax1, ax2], merge=true)
+        Legend(f[1, 3], [ax1, ax2], merge = true)
         return f
     end
 

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -534,6 +534,28 @@ end
     @test make_fig(linesegments!, rand(8)) isa Figure
 end
 
+@testset "Joint legend data gathering" begin
+    function make_fig_joint(plot_func, args...)
+        f = Figure()
+        ax1 = Axis(f[1, 1])
+        plot_func(ax1, args..., label = "test")
+        ax2 = Axis(f[1, 2])
+        plot_func(ax2, args..., label = "test")
+        Legend(f[1, 3], [ax1, ax2], merge=true)
+        return f
+    end
+
+    @test make_fig_joint(density!, rand(100)) isa Figure
+    @test make_fig_joint(poly!, Rect2f(0, 0, 1, 1)) isa Figure
+    @test make_fig_joint(band!, rand(3), rand(3), rand(3)) isa Figure
+    @test make_fig_joint(violin!, rand(1:3, 10), rand(10)) isa Figure
+    @test make_fig_joint(boxplot!, rand(1:3, 10), rand(10)) isa Figure
+    @test make_fig_joint(crossbar!, rand(3), rand(3), rand(3) .- 1, rand(3) .+ 1) isa Figure
+    @test make_fig_joint(scatter!, rand(3)) isa Figure
+    @test make_fig_joint(lines!, rand(3)) isa Figure
+    @test make_fig_joint(linesegments!, rand(8)) isa Figure
+end
+
 @testset "ReversibleScale" begin
     @test ReversibleScale(identity).inverse === identity
     @test ReversibleScale(log).inverse === exp

--- a/docs/src/reference/blocks/legend.md
+++ b/docs/src/reference/blocks/legend.md
@@ -60,6 +60,8 @@ With the keywords `merge` and `unique` you can control how plot objects with the
 If `merge` is `true`, all plot objects with the same label will be layered on top of each other into one legend entry.
 If `unique` is `true`, all plot objects with the same plot type and label will be reduced to one occurrence.
 
+To create a joint legend for multiple axes it is also possible to pass a `Vector` of axis objects.
+
 ```@figure
 
 f = Figure()

--- a/docs/src/reference/blocks/legend.md
+++ b/docs/src/reference/blocks/legend.md
@@ -60,8 +60,6 @@ With the keywords `merge` and `unique` you can control how plot objects with the
 If `merge` is `true`, all plot objects with the same label will be layered on top of each other into one legend entry.
 If `unique` is `true`, all plot objects with the same plot type and label will be reduced to one occurrence.
 
-To create a joint legend for multiple axes it is also possible to pass a `Vector` of axis objects.
-
 ```@figure
 
 f = Figure()
@@ -89,6 +87,25 @@ end
 f
 ```
 
+To create a joint legend for multiple axes it is also possible to pass a `Vector` of axis objects. Together with the `merge` keyword this can be useful for legend interactivity spanning multiple axes.
+
+```@figure
+
+f = Figure()
+
+ax1 = Axis(f[1, 1])
+ax2 = Axis(f[1, 2])
+
+xs = range(0, 4pi, length = 31)
+lines!(ax1, xs, sin, label = "sin", color = :blue)
+lines!(ax2, xs, cos, label = "cos", color = :red)
+scatter!(ax1, xs, sin, label = "Points", color = :black)
+scatter!(ax2, xs, cos, label = "Points", color = :black)
+
+f[0, 1:2] = Legend(f, [ax1, ax2], "Automatic Joint Legend", merge = true, orientation = :horizontal, tellheight = true)
+
+f
+```
 
 ## Legend Inside An Axis
 


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

I added a convenient way to gather legend entries from multiple axes, i.e. 
```julia
using GLMakie

fig = Figure()
ax1 = Axis(fig[1,1])
ax2 = Axis(fig[1,2])
lines!(ax1, randn(10), label="Trace 1")
lines!(ax1, randn(10), label="Trace 2")
lines!(ax1, randn(10), label="Trace 3")
lines!(ax2, randn(10), label="Trace 1")
lines!(ax2, randn(10), label="Trace 2")
Legend(fig[1,3], [ax1, ax2], merge=true)
```
will produce a joint legend for both axes. 
<img width="337" height="250" alt="img1" src="https://github.com/user-attachments/assets/ce273cf0-a32e-423f-8b6a-c89a7f62f173" />

The main reason why this is relevant for me is that the interactivity is then linked as well:
<img width="337" height="250" alt="img2" src="https://github.com/user-attachments/assets/40390c71-a2f5-458d-b0c0-48ee35b8273f" />


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
