### PR TITLE
Add Clustering Extension for dendrogram

### DIFF
--- a/Makie/Project.toml
+++ b/Makie/Project.toml
@@ -66,15 +66,18 @@ UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [weakdeps]
+Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 
 [extensions]
+MakieClusteringExt = "Clustering"
 MakieDynamicQuantitiesExt = "DynamicQuantities"
 
 [compat]
 Animations = "0.4"
 Base64 = "1.0, 1.6"
 CRC32c = "1.0, 1.6"
+Clustering = "0.15"
 ColorBrewer = "0.4"
 ColorSchemes = "3.5"
 ColorTypes = "0.8, 0.9, 0.10, 0.11, 0.12"

--- a/Makie/ext/MakieClusteringExt.jl
+++ b/Makie/ext/MakieClusteringExt.jl
@@ -1,0 +1,11 @@
+module MakieClusteringExt
+
+import Makie as M
+import Clustering as C
+
+function M.convert_arguments(::Type{<:M.Dendrogram}, hcl::C.Hclust; useheight = false)
+    nodes = M.hcl_nodes(hcl; useheight = useheight)
+    return (nodes,)
+end
+
+end # module

--- a/docs/src/reference/plots/dendrogram.md
+++ b/docs/src/reference/plots/dendrogram.md
@@ -75,6 +75,22 @@ dendrogram!(a, leaves, merges, linewidth = 3, color = :black, linestyle = :dash,
 f
 ```
 
+### Using with Clustering.jl
+
+When `Clustering.jl` is loaded, dendrograms can be plotted directly from `Hclust` objects:
+
+```@figure
+using CairoMakie
+using Clustering, Distances
+
+# Generate sample data and compute hierarchical clustering
+data = randn(5, 50)
+dist = pairwise(Euclidean(), data, dims=2)
+hcl = hclust(dist; linkage=:average)
+
+dendrogram(hcl)
+```
+
 ## Attributes
 
 ```@attrdocs


### PR DESCRIPTION
# Description

Extends #2755 to add a package extension for the Clustering.jl `HClust` type. Draft still because I wasn't sure how (or if I should) add the `useheight` parameter to enable usage of the heights in the `HClust`. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
