### PR TITLE
merge themes recursive

### DIFF
--- a/Makie/src/theming.jl
+++ b/Makie/src/theming.jl
@@ -161,7 +161,12 @@ function merge_without_obs!(result::Attributes, theme::Attributes)
     dict = attributes(result)
     for (key, value) in theme
         if !haskey(dict, key)
-            dict[key] = Observable{Any}(to_value(value)) # the deepcopy part for observables
+            new_value = if value isa Attributes
+                merge_without_obs!(Attributes(), value) # the deepcopy part for Attributes
+            else
+                value
+            end
+            dict[key] = Observable{Any}(to_value(new_value)) # the deepcopy part for observables
         else
             current_value = result[key]
             if value isa Attributes && current_value isa Attributes
@@ -179,14 +184,24 @@ function merge_without_obs_reverse!(result::Attributes, priority::Attributes)
     result_dict = attributes(result)
     for (key, value) in priority
         if !haskey(result_dict, key)
-            result_dict[key] = Observable{Any}(to_value(value)) # the deepcopy part for observables
+            new_value = if value isa Attributes
+                merge_without_obs_reverse!(Attributes(), value) # the deepcopy part for Attributes
+            else
+                value
+            end
+            result_dict[key] = Observable{Any}(to_value(new_value)) # the deepcopy part for observables
         else
             current_value = result[key]
             if value isa Attributes && current_value isa Attributes
                 # if nested attribute, we merge recursively
                 merge_without_obs_reverse!(current_value, value)
             else
-                result_dict[key] = Observable{Any}(to_value(value))
+                new_value = if value isa Attributes
+                    merge_without_obs_reverse!(Attributes(), value)
+                else
+                    value
+                end
+                result_dict[key] = Observable{Any}(to_value(new_value)) # the deepcopy part for observables
             end
         end
     end

--- a/Makie/test/issues.jl
+++ b/Makie/test/issues.jl
@@ -106,4 +106,28 @@
         p.sdf_uv[]
         @test true
     end
+
+    @testset "Merging Themes is not recursive when key does not exist in result" begin
+        t1 = Theme(x = 1, nested = (; y = 2))
+        t1_merged = Makie.merge_without_obs!(Attributes(), t1)
+        t1_merged.nested.y = 3
+
+        @test t1.nested.y[] == 2
+        @test t1_merged.nested.y[] == 3
+
+        t2 = Theme(x = 1, nested = (; y = 2))
+        t2_merged = Makie.merge_without_obs_reverse!(Attributes(), t2)
+        t2_merged.nested.y = 3
+
+        @test t2.nested.y[] == 2
+        @test t2_merged.nested.y[] == 3
+
+        t3 = Theme(x = 1, nested = 2)
+        t4 = Theme(nested = (; y = 5))
+        t5 = Makie.merge_without_obs_reverse!(t3, t4)
+        t5.nested.y = 100
+
+        @test t4.nested.y[] == 5
+        @test t5.nested.y[] == 100
+    end
 end


### PR DESCRIPTION
Merging themes was shallow, which lead to strange behaviour where overwriting nested attributes would lead to these changes leaking out of `with_theme`. This PR changes this behaviour by ensuring that all nested, incoming attributes are correctly and recursively copied/merged as well.

My original problem looked like this:
```julia
using CairoMakie

function my_general_theme()
    return Theme(backgroundcolor = :lightblue)
end

function inset_theme(fontsize)
    pt = 4 / 3 * fontsize
    return Makie.Theme(
        Axis = (
            xlabelsize = pt,
            ylabelsize = pt,
            xticklabelsize = pt,
            yticklabelsize = pt,
            titlesize = pt,
            backgroundcolor = :orange,
        ),
    )
end

with_theme(my_general_theme(), fontsize = 30) do
    f = Figure()
    ax = Axis(f[1, 1], xlabel = "time", ylabel = "space")
    lines!(ax, rand(100))

    with_theme(inset_theme(4)) do
        ax = Axis(
            f[1, 1],
            width = Relative(0.4),
            height = Relative(0.4),
            halign = 0.9,
            valign = 0.9,
        )
        translate!(ax.blockscene, 0, 0, 150)
        scatter!(ax, rand(20))
        ax
    end
    f
end
```
Which now repeatedly produces the expected result.

Fixes #5497 

While this works, the story seems to be slightly more complicated, as something like this
```julia
with_theme(fontsize = 30) do
    f = Figure()
    ax = Axis(f[1, 1], xlabel = "time", ylabel = "space")
    lines!(ax, rand(100))

    with_theme(fontsize = 4) do
        ax = Axis(f[1, 1], width = Relative(0.4), height = Relative(0.4))
        translate!(ax.blockscene, 0, 0, 150)
        scatter!(ax, rand(20))
    end
    f
end
```
Does not correctly (at least for my understanding of correctly) make the inner axis inherit the fontsize from the new theme, but instead seems to take it from the figure? I guess the answer lies in
https://github.com/MakieOrg/Makie.jl/blob/d8bebb874ce1ae32299c2f001e62df1bc70da021/Makie/src/makielayout/blocks.jl#L163-L173
I think that ordering is reasonable enough and I can not really think of a reasonably easy way of making the full inheritance chains work for nested themes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.
