### PR TITLE
Fix Resampler for RGB-images

### DIFF
--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -712,7 +712,7 @@ function Makie.plot!(p::HeatmapShader)
     map!(xy_to_rect, p.attributes, [:x, :y], :data_limits)
 
 
-    T = eltype(p.image[].data) <: RGB ? RGB{Float32} : Float32
+    T = eltype(p.image[].data) <: Colors.Colorant ? RGB{Float32} : Float32
     map!(p.attributes, [:image, :x, :y, :max_resolution, :data_limits, :colorrange], [:x_endpoints, :y_endpoints, :overview_image, :computed_colorrange]) do image, x, y, max_resolution, image_area, crange
         x, y, img = resample_image(x, y, image.data, max_resolution, image_area)
         cr = calculate_colorrange(img, crange)


### PR DESCRIPTION
# Description

Fixes calling `heatmap(Resampler(img::Matrix{RGB}))`, which is used in the example at https://docs.makie.org/dev/reference/plots/heatmap#Plotting-large-Heatmaps. Running this exampled resulted in a conversion error from `RGB{}` to `Float32` [here](https://github.com/johroj/Makie.jl/blob/master/ComputePipeline/src/ComputePipeline.jl#L586). 

I believe this was probably broken [here](https://github.com/johroj/Makie.jl/commit/90bff47ee745bc351c3e3d1fcf7782541a670ace) or [here](https://github.com/johroj/Makie.jl/commit/09fcab1da0150f2008a075b6bae6e084bf1702cb#diff-e5d29117c4a61ff872d1749369ca4c0c465854ee7b99fa7fb1ef542a25de9c01). 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


