### PR TITLE
feat: SkiaMakie backend prototype using Skia.jl

### DIFF
--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -66,6 +66,47 @@ jobs:
         with:
           file: lcov.info
 
+  skiamakie:
+    name: SkiaMakie Julia ${{ matrix.version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
+      - name: Install Julia dependencies
+        shell: julia --project=monorepo {0}
+        run: |
+          using Pkg;
+          pkg"registry up"
+          Pkg.update()
+          pkg"dev ./Makie ./SkiaMakie ./ReferenceTests ./ComputePipeline"
+      - name: Run the tests
+        continue-on-error: true
+        run: >
+          julia --color=yes --project=monorepo -e 'using Pkg; Pkg.test("SkiaMakie", coverage=true)'
+          && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
+      - name: Upload test Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ReferenceImages_SkiaMakie_${{ matrix.version }}
+          path: ./SkiaMakie/test/reference_images/
+      - name: Fail after artifacts if tests failed
+        if: ${{ env.TESTS_SUCCESSFUL != 'true' }}
+        run: exit 1
+
   glmakie:
     name: GLMakie Julia ${{ matrix.version }}
     env:
@@ -178,8 +219,8 @@ jobs:
   consolidation:
     name: Merge artifacts
     runs-on: ubuntu-latest
-    if: ${{ always() }} # run even if any of the three backend test jobs failed
-    needs: [cairomakie, glmakie, wglmakie]
+    if: ${{ always() }} # run even if any of the backend test jobs failed
+    needs: [cairomakie, skiamakie, glmakie, wglmakie]
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -193,6 +234,11 @@ jobs:
         with:
           name: ReferenceImages_GLMakie_1
           path: ./ReferenceImages/GLMakie
+      - uses: actions/download-artifact@v8
+        if: ${{ needs.skiamakie.result == 'success' || needs.skiamakie.result == 'failure' }}
+        with:
+          name: ReferenceImages_SkiaMakie_1
+          path: ./ReferenceImages/SkiaMakie
       - name: Consolidate reference image folders
         run: |
           baseDir="./ReferenceImages"
@@ -208,7 +254,9 @@ jobs:
           > "./ReferenceImagesCombined/new_files.txt"
 
           # Loop through the directories and concatenate the files, and copy recorded folders
-          for dir in WGLMakie CairoMakie GLMakie; do
+          for dir in WGLMakie CairoMakie GLMakie SkiaMakie; do
+              # Skip if the directory doesn't exist (e.g. SkiaMakie may not have run)
+              [ -d "${baseDir}/${dir}" ] || continue
               # Concatenate scores.tsv, new_files.txt and missing_files.txt
               cat "${baseDir}/${dir}/scores.tsv" >> "./ReferenceImagesCombined/scores.tsv"
               cat "${baseDir}/${dir}/new_files.txt" >> "./ReferenceImagesCombined/new_files.txt"

--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -48,7 +48,8 @@ macro reference_test(name, code)
                     size = (500, 500),
                     CairoMakie = (; px_per_unit = 1),
                     GLMakie = (; scalefactor = 1, px_per_unit = 1),
-                    WGLMakie = (; scalefactor = 1, px_per_unit = 1)
+                    WGLMakie = (; scalefactor = 1, px_per_unit = 1),
+                    SkiaMakie = (; px_per_unit = 1)
                 )
                 ReferenceTests.RNG.seed_rng!()
                 result = let

--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -49,7 +49,7 @@ macro reference_test(name, code)
                     CairoMakie = (; px_per_unit = 1),
                     GLMakie = (; scalefactor = 1, px_per_unit = 1),
                     WGLMakie = (; scalefactor = 1, px_per_unit = 1),
-                    SkiaMakie = (; px_per_unit = 1)
+                    SkiaMakie = (; px_per_unit = 1, pt_per_unit = 0.75, antialias = :best, visible = false, start_renderloop = false)
                 )
                 ReferenceTests.RNG.seed_rng!()
                 result = let

--- a/ReferenceTests/src/runtests.jl
+++ b/ReferenceTests/src/runtests.jl
@@ -18,7 +18,9 @@ function record_comparison(base_folder::String, backend::String; record_folder_n
     end
 
     open(joinpath(base_folder, "missing_files.txt"), "w") do file
-        backend_ref_dir = joinpath(reference_folder, backend)
+        ref_backend_aliases = Dict("SkiaMakie" => "CairoMakie")
+        ref_backend = get(ref_backend_aliases, backend, backend)
+        backend_ref_dir = joinpath(reference_folder, ref_backend)
         recorded_paths = mapreduce(vcat, walkdir(backend_ref_dir)) do (root, dirs, files)
             relpath.(joinpath.(root, files), reference_folder)
         end
@@ -56,8 +58,19 @@ function compare(
         scores = Dict{String, Float64}()
     )
 
+    # Allow backends to share reference images (e.g. SkiaMakie → CairoMakie)
+    ref_backend_aliases = Dict("SkiaMakie" => "CairoMakie")
+
     for relative_test_path in relative_test_paths
-        ref_path = joinpath(reference_dir, relative_test_path)
+        # Remap backend prefix in the reference path if an alias exists
+        ref_relative = relative_test_path
+        for (from, to) in ref_backend_aliases
+            if startswith(ref_relative, from * "/") || startswith(ref_relative, from * "\\")
+                ref_relative = to * ref_relative[length(from)+1:end]
+                break
+            end
+        end
+        ref_path = joinpath(reference_dir, ref_relative)
         rec_path = joinpath(record_dir, relative_test_path)
         if !isfile(ref_path)
             push!(missing_refimages, relative_test_path)

--- a/SkiaMakie/Project.toml
+++ b/SkiaMakie/Project.toml
@@ -1,0 +1,25 @@
+name = "SkiaMakie"
+uuid = "76793118-35c1-4747-aff5-edca4b36395e"
+version = "0.1.0"
+
+[deps]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Skia = "d59498f3-381e-4841-a765-4609d464ae1b"
+
+[compat]
+Colors = "0.10, 0.11, 0.12, 0.13"
+FileIO = "1.1"
+FreeType = "3, 4.0"
+GeometryBasics = "0.5"
+LinearAlgebra = "1.0, 1.6"
+Makie = "=0.24.9"
+Skia = "0.1"
+julia = "1.10"
+
+[sources.Makie]
+path = "../Makie"

--- a/SkiaMakie/src/SkiaMakie.jl
+++ b/SkiaMakie/src/SkiaMakie.jl
@@ -1,0 +1,72 @@
+module SkiaMakie
+
+using Makie.ComputePipeline
+using Makie, LinearAlgebra
+using Colors, GeometryBasics, FileIO
+using Colors: N0f8
+using Skia
+using Skia: SK_COLOR_TYPE_RGBA_8888, SK_ALPHA_TYPE_PREMUL,
+    SK_PAINT_STYLE_FILL, SK_PAINT_STYLE_STROKE, SK_PAINT_STYLE_STROKE_AND_FILL,
+    SK_STROKE_CAP_BUTT, SK_STROKE_CAP_ROUND, SK_STROKE_CAP_SQUARE,
+    SK_STROKE_JOIN_MITER, SK_STROKE_JOIN_ROUND, SK_STROKE_JOIN_BEVEL,
+    SK_CLIP_OP_INTERSECT, SK_CLIP_OP_DIFFERENCE,
+    SK_PATH_DIRECTION_CW, SK_PATH_DIRECTION_CCW,
+    SK_PATH_FILLTYPE_WINDING, SK_PATH_FILLTYPE_EVENODD,
+    SK_FILTER_MODE_NEAREST, SK_FILTER_MODE_LINEAR,
+    SK_MIPMAP_MODE_NONE, SK_MIPMAP_MODE_NEAREST, SK_MIPMAP_MODE_LINEAR,
+    SRC_RECT_CONSTRAINT_STRICT, SRC_RECT_CONSTRAINT_FAST,
+    sk_image_info_t, sk_rect_t, sk_matrix_t, sk_point_t,
+    sk_sampling_options_t, sk_image_caching_hint_t, sk_text_encoding_t,
+    sk_surface_t, sk_canvas_t, sk_paint_t, sk_path_t, sk_image_t,
+    sk_data_t, sk_shader_t, sk_path_effect_t, sk_color_space_t,
+    sk_font_t, sk_typeface_t, sk_font_mgr_t, sk_text_blob_t,
+    sk_text_blob_builder_t, sk_text_blob_builder_run_buffer_t,
+    SK_TEXT_ENCODING_UTF8, SK_TEXT_ENCODING_GLYPH_ID,
+    sk_document_t, sk_wstream_t, sk_file_wstream_t,
+    SK_FONT_HINTING_NONE, SK_FONT_EDGING_ANTIALIAS
+
+using Makie: Scene, Lines, Text, Image, Heatmap, Scatter, @key_str, broadcast_foreach
+using Makie: convert_attribute, @extractvalue, LineSegments, to_ndim, NativeFont
+using Makie: @info, @get_attribute, Plot, MakieScreen
+using Makie: to_value, to_colormap, extrema_nan
+using Makie.Observables
+using Makie: spaces, is_data_space, is_pixel_space, is_relative_space, is_clip_space
+using Makie: numbers_to_colors
+using Makie: Mat3f, Mat4f, Mat3d, Mat4d
+using Makie: sv_getindex
+using Makie: compute_colors
+
+# re-export Makie, including deprecated names
+for name in names(Makie, all = true)
+    if Base.isexported(Makie, name)
+        @eval using Makie: $(name)
+        @eval export $(name)
+    end
+end
+
+include("skia-helpers.jl")
+include("screen.jl")
+include("display.jl")
+include("plot-primitives.jl")
+include("utils.jl")
+include("lines.jl")
+include("scatter.jl")
+include("image-hmap.jl")
+include("mesh.jl")
+include("overrides.jl")
+
+function __init__()
+    # Register default screen config with Makie's theme system
+    if !haskey(Makie.CURRENT_DEFAULT_THEME, :SkiaMakie)
+        Makie.CURRENT_DEFAULT_THEME[:SkiaMakie] = Makie.Attributes(
+            px_per_unit = 2.0,
+            pt_per_unit = 0.75,
+            antialias = :best,
+            visible = true,
+            start_renderloop = false,
+        )
+    end
+    return activate!()
+end
+
+end

--- a/SkiaMakie/src/display.jl
+++ b/SkiaMakie/src/display.jl
@@ -1,0 +1,109 @@
+#########################################
+# Backend interface to Makie #
+#########################################
+
+function tryrun(cmd::Cmd)
+    try
+        return success(cmd)
+    catch e
+        return false
+    end
+end
+
+function openurl(url::String)
+    if Sys.isapple()
+        tryrun(`open $url`) && return
+    elseif Sys.iswindows()
+        tryrun(`powershell.exe start $url`) && return
+    elseif Sys.isunix()
+        tryrun(`xdg-open $url`) && return
+        tryrun(`gnome-open $url`) && return
+    end
+    tryrun(`python -mwebbrowser $(url)`) && return
+    tryrun(`python3 -mwebbrowser $(url)`) && return
+    return @warn("Can't find a way to open a browser, open $(url) manually!")
+end
+
+function Base.display(screen::Screen, scene::Scene; connect = false, figure = nothing)
+    return screen
+end
+
+function Base.display(screen::Screen{IMAGE}, scene::Scene; connect = false, figure = nothing, screen_config...)
+    config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}(screen_config))
+    screen = Makie.apply_screen_config!(screen, config, scene)
+    path = joinpath(mktempdir(), "display.png")
+    Makie.push_screen!(scene, screen)
+    skia_draw(screen, scene)
+    save_surface_to_png(screen.surface, path)
+    if screen.visible
+        openurl("file:///" * path)
+    end
+    return screen
+end
+
+# Disabling mimes and showable
+
+const DISABLED_MIMES = Set{String}()
+const SUPPORTED_MIMES = Set(
+    [
+        map(x -> string(x()), Makie.WEB_MIMES)...,
+        "image/svg+xml",
+        "application/pdf",
+        "image/png",
+    ]
+)
+
+function Makie.backend_showable(::Type{Screen}, ::MIME{SYM}) where {SYM}
+    supported_mimes = Base.setdiff(SUPPORTED_MIMES, DISABLED_MIMES)
+    return string(SYM) in supported_mimes
+end
+
+function Makie.backend_show(screen::Screen{IMAGE}, io::IO, ::MIME"image/png", scene::Scene, figure = nothing)
+    Makie.push_screen!(scene, screen)
+    empty!(screen)
+    skia_draw(screen, scene)
+    w, h = Base.size(screen)
+    snapshot = sk_surface_make_image_snapshot(screen.surface)
+    pngdata = sk_encode_png(C_NULL, snapshot, Int32(0))
+    # Read the encoded PNG data and write to IO
+    data_size = sk_data_get_size(pngdata)
+    data_ptr = sk_data_get_data(pngdata)
+    write(io, unsafe_wrap(Array, Ptr{UInt8}(data_ptr), data_size))
+    return screen
+end
+
+function to_mime_string(mime::Union{String, Symbol, MIME})
+    if mime isa MIME
+        mime_str = string(mime)
+        !(mime_str in SUPPORTED_MIMES) && error("Mime $(mime) not supported by SkiaMakie")
+        return mime_str
+    else
+        mime_str = string(mime)
+        if !(mime_str in SUPPORTED_MIMES)
+            mime_str = string(to_mime(convert(RenderType, mime_str)))
+        end
+        return mime_str
+    end
+end
+
+function disable_mime!(mimes::Union{String, Symbol, MIME}...)
+    empty!(DISABLED_MIMES)
+    isempty(mimes) && return
+    mime_strings = Set{String}()
+    for mime in mimes
+        push!(mime_strings, to_mime_string(mime))
+    end
+    union!(DISABLED_MIMES, mime_strings)
+    return
+end
+
+function enable_only_mime!(mimes::Union{String, Symbol, MIME}...)
+    empty!(DISABLED_MIMES)
+    isempty(mimes) && return
+    mime_strings = Set{String}()
+    for mime in mimes
+        push!(mime_strings, to_mime_string(mime))
+    end
+    union!(DISABLED_MIMES, setdiff(SUPPORTED_MIMES, mime_strings))
+    return
+end

--- a/SkiaMakie/src/image-hmap.jl
+++ b/SkiaMakie/src/image-hmap.jl
@@ -1,0 +1,176 @@
+function image_grid!(::typeof(heatmap), attr)
+    Makie.add_computation!(attr, nothing, Val(:heatmap_transform))
+    return register_computation!(attr, [:x_transformed_f32c, :y_transformed_f32c], [:grid_x, :grid_y]) do (x, y), _, _
+        xs = regularly_spaced_array_to_range(x)
+        ys = regularly_spaced_array_to_range(y)
+        return (xs, ys)
+    end
+end
+
+function image_grid!(::typeof(image), attr)
+    return register_computation!(attr, [:positions_transformed_f32c, :image], [:grid_x, :grid_y]) do (positions, image), _, _
+        (x0, y0), _, (x1, y1), _ = positions
+        xs = range(x0, x1, length = size(image, 1) + 1)
+        ys = range(y0, y1, length = size(image, 2) + 1)
+        return (xs, ys)
+    end
+end
+
+function draw_atomic(scene::Scene, screen::Screen, plot::Union{Heatmap, Image})
+    attr = plot.attributes
+    image_grid!(Makie.plotfunc(plot), attr)
+    add_constant!(attr, :is_image, plot isa Image)
+    if plot isa Heatmap && !haskey(attr, :uv_transform)
+        add_constant!(attr, :uv_transform, nothing)
+    end
+    imagelike_uv_transform!(attr)
+    Makie.compute_colors!(attr)
+    inputs = [
+        :grid_x, :grid_y, :image,
+        :interpolate, :space, :projectionview, :model_f32c,
+        :clip_planes, :cairo_uv_transform, :resolution, :computed_color,
+    ]
+    extract_attributes!(attr, inputs, :skia_attributes)
+    canvas = screen.canvas
+    is_vector = is_vector_backend(screen)
+    return draw_image(canvas, is_vector, attr[:skia_attributes][])
+end
+
+function imagelike_uv_transform!(attr)
+    return map!(attr, [:uv_transform, :image, :is_image], :cairo_uv_transform) do T, image, is_image
+        if is_image
+            T3 = Mat3f(T[1], T[2], 0, T[3], T[4], 0, T[5], T[6], 1)
+            T3 = Makie.uv_transform(Vec2f(size(image))) * T3 *
+                Makie.uv_transform(Vec2f(0, 1), 1.0f0 ./ Vec2f(size(image, 1), -size(image, 2)))
+            return T3[Vec(1, 2), Vec(1, 2, 3)]
+        else
+            return Mat{2, 3, Float32}(1, 0, 0, 1, 0, 0)
+        end
+    end
+end
+
+function draw_image(canvas, is_vector, attr)
+    model = attr.model_f32c
+    xs = attr.grid_x
+    ys = attr.grid_y
+    projectionview = attr.projectionview
+    resolution = attr.resolution
+    interpolate = attr.interpolate
+    clip_planes = attr.clip_planes
+    color_image = attr.computed_color
+    space = attr.space
+
+    is_identity_transform = Makie.is_translation_scale_matrix(model)
+    is_regular_grid = xs isa AbstractRange && ys isa AbstractRange
+
+    xy = cairo_project_to_screen_impl(projectionview, resolution, model, Point2(first(xs), first(ys)))
+    xymax = cairo_project_to_screen_impl(projectionview, resolution, model, Point2(last(xs), last(ys)))
+    w, h = xymax .- xy
+
+    can_use_fast_path = !(is_vector && !interpolate) && is_regular_grid && is_identity_transform && isempty(clip_planes)
+
+    if can_use_fast_path
+        # Create Skia image from color data
+        skia_img, _pixels = colormatrix_to_skia_image(color_image)
+        iw = size(color_image, 1)
+        ih = size(color_image, 2)
+
+        # Skia requires left < right and top < bottom in dst_rect.
+        # When h < 0 (y-flipped projection), we normalize the rect and
+        # apply a canvas transform to flip the image content.
+        x1, x2 = minmax(Float32(xy[1]), Float32(xy[1] + w))
+        y1, y2 = minmax(Float32(xy[2]), Float32(xy[2] + h))
+        need_yflip = h < 0
+
+        src_rect = Ref(sk_rect_t(0.0f0, 0.0f0, Float32(iw), Float32(ih)))
+        dst_rect = Ref(sk_rect_t(x1, y1, x2, y2))
+
+        paint = new_paint()
+        filter_mode = interpolate ? SK_FILTER_MODE_LINEAR : SK_FILTER_MODE_NEAREST
+        cubic = Skia.sk_cubic_resampler_t(0.0f0, 0.0f0)
+        sampling = Ref(sk_sampling_options_t(Int32(0), false, cubic, filter_mode, SK_MIPMAP_MODE_NONE))
+
+        sk_canvas_save(canvas)
+        if need_yflip
+            # Flip vertically around the center of the dst rect
+            cy = (y1 + y2) / 2
+            sk_canvas_translate(canvas, 0.0f0, cy)
+            sk_canvas_scale(canvas, 1.0f0, -1.0f0)
+            sk_canvas_translate(canvas, 0.0f0, -cy)
+        end
+        sk_canvas_draw_image_rect(canvas, skia_img, src_rect, dst_rect, sampling, paint,
+            SRC_RECT_CONSTRAINT_STRICT)
+        sk_canvas_restore(canvas)
+        sk_paint_delete(paint)
+    else
+        # Slow path: draw per-pixel rectangles
+        xys = let
+            transformed = [Point2f(x, y) for x in xs, y in ys]
+            planes = if Makie.is_data_space(space)
+                to_model_space(model, clip_planes)
+            else
+                Plane3f[]
+            end
+            for i in eachindex(transformed)
+                if is_clipped(planes, transformed[i])
+                    transformed[i] = Point2f(NaN)
+                end
+            end
+            cairo_project_to_screen_impl(projectionview, resolution, model, transformed)
+        end
+
+        ni, nj = size(color_image)
+        _draw_rect_heatmap(canvas, xys, ni, nj, color_image)
+    end
+    return
+end
+
+function regularly_spaced_array_to_range(arr)
+    diffs = unique!(sort!(diff(arr)))
+    step = sum(diffs) ./ length(diffs)
+    if all(x -> x ≈ step, diffs)
+        m, M = extrema(arr)
+        if step < zero(step)
+            m, M = M, m
+        end
+        return range(m; step = step, length = length(arr))
+    else
+        return arr
+    end
+end
+regularly_spaced_array_to_range(arr::AbstractRange) = arr
+
+function _draw_rect_heatmap(canvas, xys, ni, nj, colors)
+    paint = new_paint()
+    @inbounds for i in 1:ni, j in 1:nj
+        p1 = xys[i, j]
+        p2 = xys[i + 1, j]
+        p3 = xys[i + 1, j + 1]
+        p4 = xys[i, j + 1]
+        if isnan(p1) || isnan(p2) || isnan(p3) || isnan(p4)
+            continue
+        end
+
+        # Pad to avoid antialiasing gaps
+        if alpha(colors[i, j]) == 1
+            v1 = normalize(p2 - p1)
+            v2 = normalize(p4 - p1)
+            p2 += Float32(i != ni) * v1
+            p3 += Float32(i != ni) * v1 + Float32(j != nj) * v2
+            p4 += Float32(j != nj) * v2
+        end
+
+        set_paint_color!(paint, colors[i, j])
+        # Draw as a quad path
+        path = sk_path_new()
+        sk_path_move_to(path, Float32(p1[1]), Float32(p1[2]))
+        sk_path_line_to(path, Float32(p2[1]), Float32(p2[2]))
+        sk_path_line_to(path, Float32(p3[1]), Float32(p3[2]))
+        sk_path_line_to(path, Float32(p4[1]), Float32(p4[2]))
+        sk_path_close(path)
+        sk_canvas_draw_path(canvas, path, paint)
+        sk_path_delete(path)
+    end
+    sk_paint_delete(paint)
+    return
+end

--- a/SkiaMakie/src/lines.jl
+++ b/SkiaMakie/src/lines.jl
@@ -1,0 +1,388 @@
+function draw_atomic(::Scene, screen::Screen, plot::PT) where {PT <: Union{Lines, LineSegments}}
+    canvas = screen.canvas
+    attr = plot.attributes
+    add_constant!(attr, :is_lines_plot, plot isa Lines)
+    if plot isa LineSegments
+        add_constant!(attr, :joinstyle, nothing)
+        add_constant!(attr, :miter_limit, nothing)
+    end
+
+    Makie.compute_colors!(attr)
+    add_projected_line_points!(attr)
+    extract_attributes!(
+        plot.attributes, [
+            :clipped_points, :clipped_linewidths, :clipped_colors,
+            :linestyle, :linecap, :joinstyle, :miter_limit, :is_lines_plot,
+        ], :skia_attributes
+    )
+    draw_lineplot(canvas, attr.skia_attributes[])
+    return
+end
+
+function draw_lineplot(canvas, attributes)
+    positions = attributes.clipped_points
+    isempty(positions) && return
+
+    linewidth = attributes.clipped_linewidths
+    color = attributes.clipped_colors
+    linestyle = attributes.linestyle
+    miter_limit = attributes.miter_limit
+    is_lines_plot = attributes.is_lines_plot
+    linecap = attributes.linecap
+
+    # Skia draws hairlines for linewidth=0, unlike Cairo which draws nothing.
+    # Skip drawing if the uniform linewidth is effectively zero.
+    if !(linewidth isa AbstractArray) && linewidth <= 0
+        return
+    end
+
+    if color isa AbstractArray || linewidth isa AbstractArray
+        draw_multi(
+            is_lines_plot, canvas,
+            positions,
+            color, linewidth,
+            isnothing(linestyle) ? nothing : diff(Float64.(linestyle))
+        )
+    else
+        paint = new_paint(style = SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, color)
+        sk_paint_set_stroke_width(paint, Float32(linewidth))
+        sk_paint_set_stroke_cap(paint, to_skia_linecap(linecap))
+
+        miter_angle = is_lines_plot ? miter_limit : 2pi / 3
+        sk_paint_set_stroke_miter(paint, Float32(to_skia_miter_limit(miter_angle)))
+        joinstyle = is_lines_plot ? attributes.joinstyle : 0
+        sk_paint_set_stroke_join(paint, to_skia_joinstyle(joinstyle))
+
+        dash_effect = to_skia_dash_effect(linestyle, linewidth)
+        if dash_effect != C_NULL
+            sk_paint_set_path_effect(paint, dash_effect)
+        end
+
+        draw_single(is_lines_plot, canvas, paint, positions)
+        sk_paint_delete(paint)
+    end
+    return
+end
+
+function add_projected_line_points!(attr)
+    inputs = [:positions_transformed_f32c, :model_f32c, :projectionview]
+    map!(attr, inputs, :clipspace_points) do points, model_f32c, projectionview
+        transform = projectionview * model_f32c
+        return map(points) do point
+            return transform * to_ndim(Vec4d, to_ndim(Vec3d, point, 0), 1)
+        end
+    end
+    Makie.add_computation!(attr, Val(:uniform_clip_planes), :clip)
+    inputs = [:clipspace_points, :computed_color, :linewidth, :is_lines_plot, :uniform_clip_planes, :resolution]
+    outputs = [:clipped_points, :clipped_colors, :clipped_linewidths]
+    return register_computation!(attr, inputs, outputs) do (clip_points, colors, linewidths, is_lines_plot, clip_planes, res), _, _
+        return clip_line_points(clip_points, colors, linewidths, is_lines_plot, clip_planes, res)
+    end
+end
+
+function clip_line_points(clip_points, colors, linewidths, is_lines_plot, clip_planesv4f, res)
+    per_point_colors = colors isa AbstractArray
+    per_point_linewidths = is_lines_plot && (linewidths isa AbstractArray)
+
+    clip_planes = map(clip_planesv4f) do plane
+        return Plane3f(plane[Vec(1, 2, 3)], plane[4])
+    end
+    push!(
+        clip_planes,
+        Plane3f(Vec3f(-1, 0, 0), -1.0f0), Plane3f(Vec3f(+1, 0, 0), -1.0f0),
+        Plane3f(Vec3f(0, -1, 0), -1.0f0), Plane3f(Vec3f(0, +1, 0), -1.0f0)
+    )
+
+    screen_points = sizehint!(Vec2f[], length(clip_points))
+    color_output = sizehint!(eltype(colors)[], length(clip_points))
+    linewidth_output = sizehint!(eltype(linewidths)[], length(clip_points))
+
+    if is_lines_plot
+        clip_lines!(
+            clip_points, colors, linewidths, clip_planes, res, per_point_colors, per_point_linewidths,
+            screen_points, color_output, linewidth_output
+        )
+    else
+        clip_linesegments!(
+            clip_points, colors, clip_planes, res, per_point_colors,
+            screen_points, color_output
+        )
+    end
+    return screen_points, ifelse(per_point_colors, color_output, colors),
+        ifelse(per_point_linewidths, linewidth_output, linewidths)
+end
+
+# Reuse the exact same clipping logic from CairoMakie
+function clip_linesegments!(
+        clip_points, colors, clip_planes, res, per_point_colors,
+        screen_points, color_output
+    )
+    for i in 1:2:(length(clip_points) - 1)
+        if per_point_colors
+            c1 = colors[i]
+            c2 = colors[i + 1]
+        end
+        p1 = clip_points[i]
+        p2 = clip_points[i + 1]
+        v = p2 - p1
+
+        if p1[4] <= 0.0
+            p1 = p1 + (-p1[4] - p1[3]) / (v[3] + v[4]) * v
+            per_point_colors && (c1 = c1 + (-p1[4] - p1[3]) / (v[3] + v[4]) * (c2 - c1))
+        end
+        if p2[4] <= 0.0
+            p2 = p2 + (-p2[4] - p2[3]) / (v[3] + v[4]) * v
+            per_point_colors && (c2 = c2 + (-p2[4] - p2[3]) / (v[3] + v[4]) * (c2 - c1))
+        end
+
+        for plane in clip_planes
+            d1 = dot(plane.normal, Vec3f(p1)) - plane.distance * p1[4]
+            d2 = dot(plane.normal, Vec3f(p2)) - plane.distance * p2[4]
+            if (d1 < 0.0) && (d2 < 0.0)
+                p1 = Vec4f(NaN); p2 = Vec4f(NaN); break
+            elseif (d1 < 0.0)
+                p1 = p1 - d1 * (p2 - p1) / (d2 - d1)
+                per_point_colors && (c1 = c1 - d1 * (c2 - c1) / (d2 - d1))
+            elseif (d2 < 0.0)
+                p2 = p2 - d2 * (p1 - p2) / (d1 - d2)
+                per_point_colors && (c2 = c2 - d2 * (c1 - c2) / (d1 - d2))
+            end
+        end
+
+        push!(screen_points, clip2screen(p1, res), clip2screen(p2, res))
+        per_point_colors && push!(color_output, c1, c2)
+    end
+    return
+end
+
+function clip_lines!(
+        clip_points, colors, linewidths, clip_planes, res, per_point_colors, per_point_linewidths,
+        screen_points, color_output, linewidth_output
+    )
+    last_is_nan = true
+    for i in 1:(length(clip_points) - 1)
+        hidden = false
+        disconnect1 = false
+        disconnect2 = false
+
+        per_point_colors && (c1 = colors[i]; c2 = colors[i + 1])
+
+        p1 = clip_points[i]
+        p2 = clip_points[i + 1]
+        v = p2 - p1
+
+        if p1[4] <= 0.0
+            disconnect1 = true
+            p1 = p1 + (-p1[4] - p1[3]) / (v[3] + v[4]) * v
+            per_point_colors && (c1 = c1 + (-p1[4] - p1[3]) / (v[3] + v[4]) * (c2 - c1))
+        end
+        if p2[4] <= 0.0
+            disconnect2 = true
+            p2 = p2 + (-p2[4] - p2[3]) / (v[3] + v[4]) * v
+            per_point_colors && (c2 = c2 + (-p2[4] - p2[3]) / (v[3] + v[4]) * (c2 - c1))
+        end
+
+        for plane in clip_planes
+            d1 = dot(plane.normal, Vec3f(p1)) - plane.distance * p1[4]
+            d2 = dot(plane.normal, Vec3f(p2)) - plane.distance * p2[4]
+            if (d1 < 0.0) && (d2 < 0.0)
+                hidden = true; break
+            elseif (d1 < 0.0)
+                disconnect1 = true
+                p1 = p1 - d1 * (p2 - p1) / (d2 - d1)
+                per_point_colors && (c1 = c1 - d1 * (c2 - c1) / (d2 - d1))
+            elseif (d2 < 0.0)
+                disconnect2 = true
+                p2 = p2 - d2 * (p1 - p2) / (d1 - d2)
+                per_point_colors && (c2 = c2 - d2 * (c1 - c2) / (d1 - d2))
+            end
+        end
+
+        if hidden && !last_is_nan
+            last_is_nan = true
+            push!(screen_points, Vec2f(NaN))
+            per_point_linewidths && push!(linewidth_output, linewidths[i])
+            per_point_colors && push!(color_output, c1)
+        elseif !hidden
+            if disconnect1 && !last_is_nan
+                push!(screen_points, Vec2f(NaN))
+                per_point_linewidths && push!(linewidth_output, linewidths[i])
+                per_point_colors && push!(color_output, c1)
+            end
+            last_is_nan = false
+            push!(screen_points, clip2screen(p1, res))
+            per_point_linewidths && push!(linewidth_output, linewidths[i])
+            per_point_colors && push!(color_output, c1)
+            if disconnect2
+                last_is_nan = true
+                push!(screen_points, clip2screen(p2, res), Vec2f(NaN))
+                per_point_linewidths && push!(linewidth_output, linewidths[i + 1], linewidths[i + 1])
+                per_point_colors && push!(color_output, c2, c2)
+            end
+        end
+    end
+
+    if !last_is_nan
+        push!(screen_points, clip2screen(clip_points[end], res))
+        per_point_linewidths && push!(linewidth_output, linewidths[end])
+        per_point_colors && push!(color_output, colors[end])
+    end
+    return
+end
+
+function draw_multi(islines, canvas, positions, colors, linewidths, dash)
+    if islines
+        return draw_multi_lines(canvas, positions, colors, linewidths, dash)
+    else
+        return draw_multi_segments(canvas, positions, colors, linewidths, dash)
+    end
+end
+
+function draw_multi_segments(canvas, positions, colors, linewidths, dash)
+    @assert iseven(length(positions))
+    paint = new_paint(style = SK_PAINT_STYLE_STROKE)
+
+    for i in 1:2:length(positions)
+        (isnan(positions[i + 1]) || isnan(positions[i])) && continue
+        lw = sv_getindex(linewidths, i)
+
+        sk_paint_set_stroke_width(paint, Float32(lw))
+        if !isnothing(dash)
+            effect = sk_path_effect_create_dash(Float32.(dash .* lw), Int32(length(dash)), 0.0f0)
+            sk_paint_set_path_effect(paint, effect)
+        end
+
+        c1 = sv_getindex(colors, i)
+        c2 = sv_getindex(colors, i + 1)
+        if c1 == c2
+            set_paint_color!(paint, c1)
+        else
+            # For gradient segments, use the average color (Skia has no direct line gradient)
+            avg = RGBAf(
+                (red(c1) + red(c2)) / 2, (green(c1) + green(c2)) / 2,
+                (blue(c1) + blue(c2)) / 2, (alpha(c1) + alpha(c2)) / 2
+            )
+            set_paint_color!(paint, avg)
+        end
+        p1 = positions[i]
+        p2 = positions[i + 1]
+        sk_canvas_draw_line(canvas, Float32(p1[1]), Float32(p1[2]),
+            Float32(p2[1]), Float32(p2[2]), paint)
+    end
+    sk_paint_delete(paint)
+    return
+end
+
+function draw_multi_lines(canvas, positions, colors, linewidths, dash)
+    isempty(positions) && return
+    paint = new_paint(style = SK_PAINT_STYLE_STROKE)
+
+    # Draw contiguous segments of the same color as paths
+    prev_color = sv_getindex(colors, 1)
+    prev_linewidth = sv_getindex(linewidths, 1)
+    prev_nan = isnan(positions[begin])
+
+    path = sk_path_new()
+    path_started = false
+
+    if !prev_nan
+        sk_path_move_to(path, Float32(positions[begin][1]), Float32(positions[begin][2]))
+        path_started = true
+    end
+
+    function flush_path!()
+        if path_started
+            set_paint_color!(paint, prev_color)
+            sk_paint_set_stroke_width(paint, Float32(prev_linewidth))
+            if !isnothing(dash)
+                effect = sk_path_effect_create_dash(Float32.(dash .* prev_linewidth), Int32(length(dash)), 0.0f0)
+                sk_paint_set_path_effect(paint, effect)
+            end
+            sk_canvas_draw_path(canvas, path, paint)
+            sk_path_delete(path)
+        end
+    end
+
+    for i in eachindex(positions)[(begin + 1):end]
+        this_position = positions[i]
+        this_color = sv_getindex(colors, i)
+        this_nan = isnan(this_position)
+        this_linewidth = sv_getindex(linewidths, i)
+
+        if this_nan && path_started
+            flush_path!()
+            path = sk_path_new()
+            path_started = false
+        elseif prev_nan && !this_nan
+            if !path_started
+                path = sk_path_new()
+            end
+            sk_path_move_to(path, Float32(this_position[1]), Float32(this_position[2]))
+            path_started = true
+        elseif !prev_nan && !this_nan
+            if this_color != prev_color
+                # flush old color, start new path from previous position
+                flush_path!()
+                path = sk_path_new()
+                sk_path_move_to(path, Float32(positions[i-1][1]), Float32(positions[i-1][2]))
+                sk_path_line_to(path, Float32(this_position[1]), Float32(this_position[2]))
+                path_started = true
+            else
+                sk_path_line_to(path, Float32(this_position[1]), Float32(this_position[2]))
+            end
+        end
+
+        prev_nan = this_nan
+        prev_color = this_color
+        prev_linewidth = this_linewidth
+    end
+
+    flush_path!()
+    sk_paint_delete(paint)
+    return
+end
+
+function draw_single(is_lines_plot::Bool, canvas, paint, positions)
+    if is_lines_plot
+        return draw_single_lines(canvas, paint, positions)
+    else
+        return draw_single_segments(canvas, paint, positions)
+    end
+end
+
+function draw_single_lines(canvas, paint, positions)
+    isempty(positions) && return
+    n = length(positions)
+    path = sk_path_new()
+
+    @inbounds for i in 1:n
+        p = positions[i]
+        if !isnan(p)
+            if i == 1 || isnan(positions[i - 1])
+                sk_path_move_to(path, Float32(p[1]), Float32(p[2]))
+            else
+                sk_path_line_to(path, Float32(p[1]), Float32(p[2]))
+                if i == n || isnan(positions[i + 1])
+                    sk_canvas_draw_path(canvas, path, paint)
+                    sk_path_delete(path)
+                    path = sk_path_new()
+                end
+            end
+        end
+    end
+    sk_path_delete(path)
+    return
+end
+
+function draw_single_segments(canvas, paint, positions)
+    @assert iseven(length(positions))
+    @inbounds for i in 1:2:(length(positions) - 1)
+        p1 = positions[i]
+        p2 = positions[i + 1]
+        (isnan(p1) || isnan(p2)) && continue
+        sk_canvas_draw_line(canvas, Float32(p1[1]), Float32(p1[2]),
+            Float32(p2[1]), Float32(p2[2]), paint)
+    end
+    return
+end

--- a/SkiaMakie/src/mesh.jl
+++ b/SkiaMakie/src/mesh.jl
@@ -1,0 +1,346 @@
+function draw_atomic(scene::Scene, screen::Screen, primitive::Makie.Mesh)
+    Makie.compute_colors!(primitive.attributes)
+    if Makie.cameracontrols(scene) isa Union{Camera2D, Makie.PixelCamera, Makie.EmptyCamera}
+        draw_mesh2D(scene, screen, primitive.attributes)
+    else
+        draw_mesh3D(scene, screen, primitive.attributes)
+    end
+    return nothing
+end
+
+function draw_mesh2D(scene, screen, attr::ComputeGraph)
+    vs = cairo_project_to_screen(attr)
+    fs = attr.faces[]
+    uv = attr.texturecoordinates[]
+    uv_transform = attr.pattern_uv_transform[]
+    if uv isa Vector{Vec2f} && to_value(uv_transform) !== nothing
+        uv = map(uv -> uv_transform * to_ndim(Vec3f, uv, 1), uv)
+    end
+    color = compute_colors(attr)
+    cols = per_face_colors(color, nothing, fs, nothing, uv)
+    return draw_mesh2D(screen, cols, vs, fs)
+end
+
+function draw_mesh2D(screen::Screen, color, vs::Vector, fs::Vector{GLTriangleFace})
+    return _draw_mesh2D_triangles(screen.canvas, color, vs, fs)
+end
+
+function _draw_mesh2D_triangles(canvas, per_face_cols, vs::Vector, fs::Vector{GLTriangleFace})
+    paint = new_paint()
+
+    for i in eachindex(fs)
+        c1, c2, c3 = per_face_cols[i]
+        t1, t2, t3 = vs[fs[i]]
+
+        if isnan(t1) || isnan(t2) || isnan(t3)
+            continue
+        end
+
+        # Use average color for the triangle (Skia doesn't have mesh gradient patterns)
+        avg_color = RGBAf(
+            (red(c1) + red(c2) + red(c3)) / 3,
+            (green(c1) + green(c2) + green(c3)) / 3,
+            (blue(c1) + blue(c2) + blue(c3)) / 3,
+            (alpha(c1) + alpha(c2) + alpha(c3)) / 3,
+        )
+        set_paint_color!(paint, avg_color)
+
+        path = sk_path_new()
+        sk_path_move_to(path, Float32(t1[1]), Float32(t1[2]))
+        sk_path_line_to(path, Float32(t2[1]), Float32(t2[2]))
+        sk_path_line_to(path, Float32(t3[1]), Float32(t3[2]))
+        sk_path_close(path)
+        sk_canvas_draw_path(canvas, path, paint)
+        sk_path_delete(path)
+    end
+
+    sk_paint_delete(paint)
+    return nothing
+end
+
+function average_z(positions, face)
+    vs = positions[face]
+    return sum(v -> v[3], vs) / length(vs)
+end
+
+function strip_translation(M::Mat4{T}) where {T}
+    return @inbounds Mat4{T}(
+        M[1], M[2], M[3], M[4],
+        M[5], M[6], M[7], M[8],
+        M[9], M[10], M[11], M[12],
+        0, 0, 0, M[16],
+    )
+end
+
+function _calculate_shaded_vertexcolors(N, v, c, lightdir, light_color, ambient, diffuse, specular, shininess)
+    L = lightdir
+    diff_coeff = max(dot(L, -N), 0.0f0)
+    H = normalize(L + v)
+    spec_coeff = max(dot(H, -N), 0.0f0)^shininess
+    c = RGBAf(c)
+    new_c_part1 = (ambient .+ light_color .* diff_coeff .* diffuse) .* Vec3f(c.r, c.g, c.b)
+    new_c = new_c_part1 .+ light_color .* specular * spec_coeff
+    return RGBAf(new_c..., c.alpha)
+end
+
+to_vec(c::Colorant) = Vec3f(red(c), green(c), blue(c))
+prepare_normals(normalmatrix::Mat3f, normals::Nothing) = nothing
+function prepare_normals(normalmatrix::Mat3f, normals::Vector{Vec3f})
+    return [zero_normalize(normalmatrix * normal) for normal in normals]
+end
+
+function draw_mesh3D(scene, screen, plot::ComputeGraph)
+    clip_planes = plot.clip_planes[]::Vector{Plane3f}
+    uv_transform = plot.pattern_uv_transform[]::Union{Nothing, Mat{2, 3, Float32, 6}}
+
+    world_points = Makie.apply_model(
+        plot.model_f32c[]::Mat4f,
+        plot.positions_transformed_f32c[]::Union{Vector{Point3f}, Vector{Point2f}}
+    )
+    screen_points = cairo_project_to_screen(plot, output_type = Point3f)::Vector{Point3f}
+    meshfaces = plot.faces[]::Vector{GLTriangleFace}
+    meshnormals = plot.normals[]::Union{Nothing, Vector{Vec3f}}
+    _meshuvs = plot.texturecoordinates[]
+
+    if (_meshuvs isa AbstractVector{<:Vec3})
+        error("Only 2D texture coordinates are supported right now.")
+    end
+    meshuvs::Union{Nothing, Vector{Vec2f}} = _meshuvs
+
+    color = compute_colors(plot)
+
+    return draw_mesh3D(
+        scene, screen, plot,
+        world_points, screen_points, meshfaces, meshnormals, meshuvs,
+        uv_transform, color, clip_planes
+    )
+end
+
+function draw_mesh3D(
+        scene, screen, plot::ComputeGraph,
+        world_points, screen_points, meshfaces, meshnormals, meshuvs,
+        uv_transform, color, clip_planes, model = plot.model_f32c[]::Mat4f
+    )
+
+    local shading::Bool = plot.shading[] && (scene.compute.shading[] != NoShading)
+
+    if meshuvs isa Vector{Vec2f} && uv_transform !== nothing
+        uvt = uv_transform::Mat{2, 3, Float32, 6}
+        meshuvs = map(uv -> uvt * to_ndim(Vec3f, uv, 1), meshuvs)
+    end
+
+    matcap::Union{Nothing, Matrix{RGBAf}} = to_value(get(plot, :matcap, nothing))
+    space = plot.space[]::Symbol
+
+    per_face_col = per_face_colors(
+        color::Union{RGBAf, Vector{RGBAf}, Matrix{RGBAf}},
+        matcap, meshfaces, meshnormals, meshuvs
+    )
+
+    local faceculling::Int = to_value(get(plot, :faceculling, -10))
+
+    return draw_mesh3D(
+        scene, screen, space, world_points, screen_points, meshfaces, meshnormals, per_face_col,
+        model, shading, plot.diffuse[]::Vec3f,
+        plot.specular[]::Vec3f, plot.shininess[]::Float32, faceculling,
+        clip_planes, plot.eyeposition[]::Vec3f
+    )
+end
+
+function draw_mesh3D(
+        scene, screen, space, world_points, screen_points, meshfaces, meshnormals, per_face_col,
+        model, shading, diffuse, specular, shininess, faceculling, clip_planes, eyeposition
+    )
+    canvas = screen.canvas
+    i = Vec(1, 2, 3)
+    normalmatrix = transpose(inv(Mat3f(model[i, i])))
+    ns = prepare_normals(normalmatrix, meshnormals)
+
+    average_zs = map(f -> average_z(screen_points, f), meshfaces)
+    zorder = sortperm(average_zs)
+
+    if Makie.is_data_space(space) && !isempty(clip_planes)
+        valid = Bool[is_visible(clip_planes, p) for p in world_points]
+        filter!(zorder) do face_index
+            face = meshfaces[face_index]
+            return all(vertex_index -> valid[vertex_index], face)
+        end
+    end
+
+    viewdir = scene.camera.view_direction[]::Vec3f
+    if !isnothing(ns)
+        filter!(zorder) do face_index
+            face = meshfaces[face_index]
+            return any(vertex_index -> dot(-ns[vertex_index], viewdir) > faceculling, face)
+        end
+    end
+
+    ambient = to_vec(scene.compute[:ambient_color][])
+    light_color = to_vec(scene.compute[:dirlight_color][])
+    light_direction = scene.compute[:dirlight_final_direction][]::Vec3f
+    vs = map(v -> normalize(to_ndim(Point3f, v, 0) - eyeposition), world_points)
+
+    paint = new_paint()
+    for k in reverse(zorder)
+        f = meshfaces[k]
+        t1 = screen_points[f[1]]
+        t2 = screen_points[f[2]]
+        t3 = screen_points[f[3]]
+        (isnan(t1) || isnan(t2) || isnan(t3)) && continue
+
+        facecolors = per_face_col[k]
+        if shading && !isnothing(ns)
+            mean_normal = sum(i -> ns[i], f) / length(f)
+            c1, c2, c3 = Base.Cartesian.@ntuple 3 i -> begin
+                N = normalize(ns[f[i]] + 1.0e-20 * mean_normal)
+                v = vs[f[i]]
+                c = facecolors[i]
+                _calculate_shaded_vertexcolors(N, v, c, light_direction, light_color, ambient, diffuse, specular, shininess)
+            end
+        else
+            c1, c2, c3 = facecolors
+        end
+
+        avg_color = RGBAf(
+            (red(c1) + red(c2) + red(c3)) / 3,
+            (green(c1) + green(c2) + green(c3)) / 3,
+            (blue(c1) + blue(c2) + blue(c3)) / 3,
+            (alpha(c1) + alpha(c2) + alpha(c3)) / 3,
+        )
+        set_paint_color!(paint, avg_color)
+
+        path = sk_path_new()
+        sk_path_move_to(path, Float32(t1[1]), Float32(t1[2]))
+        sk_path_line_to(path, Float32(t2[1]), Float32(t2[2]))
+        sk_path_line_to(path, Float32(t3[1]), Float32(t3[2]))
+        sk_path_close(path)
+        sk_canvas_draw_path(canvas, path, paint)
+        sk_path_delete(path)
+    end
+    sk_paint_delete(paint)
+    return
+end
+
+function draw_atomic(scene::Scene, screen::Screen, @nospecialize(plot::Makie.MeshScatter))
+    transformed_pos = Makie.apply_model(
+        plot.model_f32c[]::Mat4f,
+        plot.positions_transformed_f32c[]::Union{Vector{Point2f}, Vector{Point3f}}
+    )
+    colors = compute_colors(plot)
+    uv_transform = plot.pattern_uv_transform[]
+
+    return draw_scattered_mesh(
+        scene, screen, plot.attributes, plot.marker[],
+        transformed_pos, plot.markersize[], plot.rotation[], colors,
+        plot.clip_planes[], plot.transform_marker[]::Bool, uv_transform
+    )
+end
+
+function draw_scattered_mesh(
+        scene, screen, plot::ComputeGraph, mesh,
+        positions, scales, rotations, colors,
+        clip_planes, transform_marker, uv_transform
+    )
+    space = plot.space[]
+
+    meshpoints = decompose(Point3f, mesh)
+    meshfaces = decompose(GLTriangleFace, mesh)
+    meshnormals = normals(mesh)
+    meshuvs = texturecoordinates(mesh)
+
+    f32c_model = ifelse(transform_marker, strip_translation(plot.model[]::Mat4d), Mat4d(I))
+    if !isnothing(scene.float32convert) && Makie.is_data_space(space)
+        f32c_model = Makie.scalematrix(scene.float32convert.scaling[].scale::Vec3d) * f32c_model
+    end
+
+    view = plot.view[]::Mat4f
+    zorder = sortperm(
+        positions, by = p -> begin
+            p4d = to_ndim(Vec4d, p, 1)
+            cam_pos = view[Vec(3, 4), Vec(1, 2, 3, 4)] * p4d
+            cam_pos[1] / cam_pos[2]
+        end, rev = false
+    )
+
+    proj_mat = cairo_viewport_matrix(plot.resolution[]) * plot.projectionview[]
+
+    for i in zorder
+        element_color = Makie.sv_getindex(colors, i)
+        element_uv_transform = Makie.sv_getindex(uv_transform, i)
+        element_translation = to_ndim(Point4d, positions[i], 0)
+        element_rotation = Makie.rotationmatrix4(Makie.sv_getindex(rotations, i))
+        element_scale = Makie.sv_getindex(scales, i)
+        element_scale_matrix = Makie.scalematrix(element_scale)
+        element_transform = f32c_model * element_rotation * element_scale_matrix
+
+        element_world_pos = map(meshpoints) do p
+            p4d = to_ndim(Point4d, to_ndim(Point3d, p, 0), 1)
+            p4d = element_transform * p4d + element_translation
+            return Point3f(p4d) / p4d[4]
+        end
+
+        element_screen_pos = project_position(Point3f, proj_mat, element_world_pos, eachindex(element_world_pos))
+
+        finite_element_scale = @. ifelse(element_scale >= 0, +1, -1) * max(abs(element_scale), 1.0e-6)
+        model = f32c_model * element_rotation * Makie.scalematrix(finite_element_scale)
+
+        draw_mesh3D(
+            scene, screen, plot,
+            element_world_pos, element_screen_pos, meshfaces, meshnormals, meshuvs,
+            element_uv_transform, element_color, clip_planes, model
+        )
+    end
+    return nothing
+end
+
+function draw_atomic(scene::Scene, screen::Screen, plot::Makie.Surface)
+    attr = plot.attributes
+    Makie.add_computation!(attr, Val(:surface_as_mesh))
+    Makie.register_pattern_uv_transform!(attr)
+    draw_mesh3D(scene, screen, attr)
+    return nothing
+end
+
+function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Voxels))
+    pos = Makie.voxel_positions(primitive)
+    scale = Makie.voxel_size(primitive)
+    colors = Makie.voxel_colors(primitive)
+    marker = GeometryBasics.expand_faceviews(normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1))))
+
+    transformed_pos = _transform_to_world(scene, primitive, pos)
+
+    clip_planes = primitive.clip_planes[]::Vector{Plane3f}
+    if !isempty(clip_planes) && Makie.is_data_space(primitive)
+        valid = [is_visible(clip_planes, p) for p in transformed_pos]
+        transformed_pos = transformed_pos[valid]
+        colors = colors[valid]
+    end
+
+    Makie.register_computation!(primitive.attributes::Makie.ComputeGraph, [:model], [:model_f32c]) do (model,), _, __
+        return (Mat4f(model),)
+    end
+
+    draw_scattered_mesh(
+        scene, screen, primitive.attributes, marker,
+        transformed_pos, scale, Quaternionf(0, 0, 0, 1), colors,
+        Plane3f[], true, primitive.uv_transform[]
+    )
+    return nothing
+end
+
+function _transform_to_world(scene::Scene, @nospecialize(plot), pos)
+    space = plot.space[]::Symbol
+    model = plot.model[]::Mat4d
+    f32_model = Makie.f32_convert_matrix(scene.float32convert, space) * model
+    tf = Makie.transform_func(plot)
+    return _transform_to_world(f32_model, tf, pos)
+end
+
+function _transform_to_world(f32_model, tf, pos)
+    return map(pos) do p
+        transformed = Makie.apply_transform(tf, p)
+        p4d = to_ndim(Point4d, to_ndim(Point3d, transformed, 0), 1)
+        p4d = f32_model * p4d
+        return p4d[Vec(1, 2, 3)] / p4d[4]
+    end
+end

--- a/SkiaMakie/src/overrides.jl
+++ b/SkiaMakie/src/overrides.jl
@@ -1,0 +1,417 @@
+################################################################################
+#                    Poly - the not so primitive, primitive                    #
+################################################################################
+
+deref(x) = x
+deref(x::Base.RefValue) = x[]
+
+function draw_plot(scene::Scene, screen::Screen, poly::Poly)
+    if Base.hasmethod(draw_poly, Tuple{Scene, Screen, typeof(poly), typeof.(deref(poly.args[]))...})
+        return draw_poly(scene, screen, poly, deref(poly.args[])...)
+    elseif Base.hasmethod(draw_poly, Tuple{Scene, Screen, typeof(poly), typeof.(deref(poly.converted[]))...})
+        return draw_poly(scene, screen, poly, deref(poly.converted[])...)
+    else
+        return draw_poly_as_mesh(scene, screen, poly)
+    end
+end
+
+is_skiamakie_atomic_plot(plot::Poly) = true
+
+function draw_poly_as_mesh(scene, screen, poly)
+    for i in eachindex(poly.plots)
+        draw_plot(scene, screen, poly.plots[i])
+    end
+    return
+end
+
+########################################
+### outline methods (::Vector{<:VecTypes{2}})
+########################################
+
+function draw_poly(scene::Scene, screen::Screen, poly, points::Vector{<:Point2})
+    color = to_skia_plotcolor(poly.color[], poly)
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    strokestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    draw_poly(
+        scene, screen, poly, points, color,
+        poly.model[], strokecolor, strokestyle, poly.strokewidth[], miter_limit, joinstyle, linecap
+    )
+    return
+end
+
+function draw_poly(scene::Scene, screen::Screen, poly, points_list::Vector{<:Vector{<:Point2}})
+    color = to_skia_plotcolor(poly.color[], poly)
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    strokestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    broadcast_foreach(
+        points_list, color,
+        strokecolor, strokestyle, poly.strokewidth[], Ref(poly.model[])
+    ) do points, color, strokecolor, strokestyle, strokewidth, model
+        draw_poly(scene, screen, poly, points, color, model, strokecolor, strokestyle, strokewidth, miter_limit, joinstyle, linecap)
+    end
+    return
+end
+
+draw_poly(scene::Scene, screen::Screen, poly, circle::Circle) = draw_poly(scene, screen, poly, decompose(Point2f, circle))
+
+function draw_poly(
+        scene::Scene, screen::Screen, poly, points::Vector{<:Point2}, color::Colorant,
+        model, strokecolor, strokestyle, strokewidth, miter_limit, joinstyle, linecap
+    )
+    space = poly.space[]
+    points = apply_transform(transform_func(poly), points)
+    points = clip_poly(poly.clip_planes[], points, space, model)
+    points = _project_position(scene, space, points, model, true)
+
+    isempty(points) && return
+
+    path = points_to_path(points)
+
+    # Fill
+    paint = new_paint(color = to_skia_color(color))
+    sk_canvas_draw_path(screen.canvas, path, paint)
+
+    # Stroke
+    sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+    set_paint_color!(paint, to_color(strokecolor))
+    sk_paint_set_stroke_width(paint, Float32(strokewidth))
+    sk_paint_set_stroke_join(paint, joinstyle)
+    sk_paint_set_stroke_cap(paint, linecap)
+    sk_paint_set_stroke_miter(paint, Float32(miter_limit))
+
+    dash_effect = to_skia_dash_effect(strokestyle, strokewidth)
+    if dash_effect != C_NULL
+        sk_paint_set_path_effect(paint, dash_effect)
+    end
+
+    sk_canvas_draw_path(screen.canvas, path, paint)
+    sk_paint_delete(paint)
+    sk_path_delete(path)
+    return
+end
+
+function draw_poly(
+        scene::Scene, screen::Screen, poly, points, color,
+        model, strokecolor, strokestyle, strokewidth, miter_limit, joinstyle, linecap
+    )
+    return draw_poly_as_mesh(scene, screen, poly)
+end
+
+########################################
+### GeometryPrimtive and BezierPath methods
+########################################
+
+draw_poly(scene::Scene, screen::Screen, poly, rect::Rect2) = draw_poly(scene, screen, poly, [rect])
+draw_poly(scene::Scene, screen::Screen, poly, bezierpath::BezierPath) = draw_poly(scene, screen, poly, [bezierpath])
+
+function draw_poly(scene::Scene, screen::Screen, poly, shapes::Vector{<:Union{Rect2, BezierPath}})
+    model = poly.model[]::Mat4d
+    space = poly.space[]::Symbol
+    planes = poly.clip_planes[]::Vector{Plane3f}
+
+    projected_shapes = map(shapes) do shape
+        clipped = clip_shape(planes, shape, space, model)
+        return project_shape(poly, space, clipped, model)
+    end
+
+    color = to_skia_plotcolor(poly.color[], poly)
+    linestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    broadcast_foreach(projected_shapes, color, strokecolor, poly.strokewidth[]) do shape, c, sc, sw
+        path = shape_to_skia_path(shape)
+
+        paint = new_paint(color = to_skia_color(c))
+        sk_canvas_draw_path(screen.canvas, path, paint)
+
+        sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, to_color(sc))
+        sk_paint_set_stroke_width(paint, Float32(sw))
+        sk_paint_set_stroke_join(paint, joinstyle)
+        sk_paint_set_stroke_cap(paint, linecap)
+        sk_paint_set_stroke_miter(paint, Float32(miter_limit))
+
+        dash_effect = to_skia_dash_effect(linestyle, sw)
+        if dash_effect != C_NULL
+            sk_paint_set_path_effect(paint, dash_effect)
+        end
+
+        sk_canvas_draw_path(screen.canvas, path, paint)
+        sk_paint_delete(paint)
+        sk_path_delete(path)
+    end
+    return
+end
+
+function project_shape(scene, space, shape::BezierPath, model)
+    commands = Makie.PathCommand[]
+    for cmd in shape.commands
+        if cmd isa EllipticalArc
+            bezier = Makie.elliptical_arc_to_beziers(cmd)
+            for b in bezier.commands
+                push!(commands, project_command(b, scene, space, model))
+            end
+        else
+            push!(commands, project_command(cmd, scene, space, model))
+        end
+    end
+    return BezierPath(commands)
+end
+
+function project_command(m::MoveTo, scene, space, model)
+    return MoveTo(project_position(scene, space, m.p, model))
+end
+function project_command(l::LineTo, scene, space, model)
+    return LineTo(project_position(scene, space, l.p, model))
+end
+function project_command(c::CurveTo, scene, space, model)
+    return CurveTo(
+        project_position(scene, space, c.c1, model),
+        project_position(scene, space, c.c2, model),
+        project_position(scene, space, c.p, model),
+    )
+end
+project_command(c::ClosePath, scene, space, model) = c
+
+function shape_to_skia_path(r::Rect2)
+    o = origin(r)
+    w, h = widths(r)
+    path = sk_path_new()
+    sk_path_add_rect(path, Ref(sk_rect_t(Float32(o[1]), Float32(o[2]),
+        Float32(o[1] + w), Float32(o[2] + h))), SK_PATH_DIRECTION_CW)
+    return path
+end
+
+function shape_to_skia_path(b::BezierPath)
+    return bezierpath_to_skia_path(b)
+end
+
+draw_poly(scene::Scene, screen::Screen, poly, polygon::Polygon) = draw_poly(scene, screen, poly, [polygon])
+draw_poly(scene::Scene, screen::Screen, poly, multipolygon::MultiPolygon) = draw_poly(scene, screen, poly, multipolygon.polygons)
+
+function draw_poly(scene::Scene, screen::Screen, poly, polygons::AbstractArray{<:Polygon})
+    model = poly.model[]
+    space = poly.space[]
+    projected_polys = map(polygons) do polygon
+        return project_polygon(poly, space, polygon, poly.clip_planes[], model)
+    end
+
+    color = to_skia_plotcolor(poly.color[], poly)
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    strokestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    broadcast_foreach(projected_polys, color, strokecolor, poly.strokewidth[]) do po, c, sc, sw
+        path = polygon_to_skia_path(po)
+        paint = new_paint(color = to_skia_color(c))
+        sk_canvas_draw_path(screen.canvas, path, paint)
+        sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, to_color(sc))
+        sk_paint_set_stroke_width(paint, Float32(sw))
+        sk_paint_set_stroke_join(paint, joinstyle)
+        sk_paint_set_stroke_cap(paint, linecap)
+        sk_paint_set_stroke_miter(paint, Float32(miter_limit))
+
+        dash_effect = to_skia_dash_effect(strokestyle, sw)
+        if dash_effect != C_NULL
+            sk_paint_set_path_effect(paint, dash_effect)
+        end
+
+        sk_canvas_draw_path(screen.canvas, path, paint)
+        sk_paint_delete(paint)
+        sk_path_delete(path)
+    end
+    return
+end
+
+function draw_poly(scene::Scene, screen::Screen, poly, polygons::AbstractArray{<:MultiPolygon})
+    model = poly.model[]
+    space = poly.space[]
+    projected_polys = map(polygons) do polygon
+        project_multipolygon(poly, space, polygon, poly.clip_planes[], model)
+    end
+
+    color = to_skia_plotcolor(poly.color[], poly)
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    strokestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    broadcast_foreach(projected_polys, color, strokecolor, poly.strokewidth[]) do mpo, c, sc, sw
+        for po in mpo.polygons
+            path = polygon_to_skia_path(po)
+            paint = new_paint(color = to_skia_color(c))
+            sk_canvas_draw_path(screen.canvas, path, paint)
+            sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+            set_paint_color!(paint, to_color(sc))
+            sk_paint_set_stroke_width(paint, Float32(sw))
+            sk_paint_set_stroke_join(paint, joinstyle)
+            sk_paint_set_stroke_cap(paint, linecap)
+            sk_paint_set_stroke_miter(paint, Float32(miter_limit))
+
+            dash_effect = to_skia_dash_effect(strokestyle, sw)
+            if dash_effect != C_NULL
+                sk_paint_set_path_effect(paint, dash_effect)
+            end
+
+            sk_canvas_draw_path(screen.canvas, path, paint)
+            sk_paint_delete(paint)
+            sk_path_delete(path)
+        end
+    end
+    return
+end
+
+function polygon_to_skia_path(polygon)
+    isempty(polygon.exterior) && return sk_path_new()
+    ext = decompose(Point2f, polygon.exterior)
+    path = sk_path_new()
+    sk_path_set_filltype(path, SK_PATH_FILLTYPE_EVENODD)
+    sk_path_move_to(path, Float32(ext[1][1]), Float32(ext[1][2]))
+    for point in ext[2:end]
+        sk_path_line_to(path, Float32(point[1]), Float32(point[2]))
+    end
+    sk_path_close(path)
+    interiors = decompose.(Point2f, polygon.interiors)
+    for interior in interiors
+        n = length(interior)
+        sk_path_move_to(path, Float32(interior[1][1]), Float32(interior[1][2]))
+        for idx in 2:n
+            point = interior[idx]
+            sk_path_line_to(path, Float32(point[1]), Float32(point[2]))
+        end
+        sk_path_close(path)
+    end
+    return path
+end
+
+################################################################################
+#                                     Band                                     #
+################################################################################
+
+function draw_plot(
+        scene::Scene, screen::Screen,
+        band::Band{<:Tuple{<:AbstractVector{<:Point2}, <:AbstractVector{<:Point2}}}
+    )
+    if !(band.color[] isa AbstractArray)
+        color = to_skia_plotcolor(band.color[], band)
+        model = band.model[]
+        space = band.space[]
+        xdir::Bool = band.direction[] === :x
+
+        upperpoints = xdir ? band[1][] : reverse.(band[1][])
+        lowerpoints = xdir ? band[2][] : reverse.(band[2][])
+
+        for rng in band_segment_ranges(lowerpoints, upperpoints)
+            points_segment = vcat(@view(lowerpoints[rng]), reverse(@view(upperpoints[rng])))
+            points = clip_poly(band.clip_planes[], points_segment, space, model)
+            points = project_position.(Ref(band), space, points, Ref(model))
+
+            path = points_to_path(points)
+            paint = new_paint(color = to_skia_color(color))
+            sk_canvas_draw_path(screen.canvas, path, paint)
+            sk_paint_delete(paint)
+            sk_path_delete(path)
+        end
+
+        for p in band.plots
+            p isa Mesh && continue
+            draw_plot(scene, screen, p)
+        end
+    else
+        for p in band.plots
+            draw_plot(scene, screen, p)
+        end
+    end
+    return nothing
+end
+
+function is_skiamakie_atomic_plot(plot::Band{<:Tuple{<:AbstractVector{<:Point2}, <:AbstractVector{<:Point2}}})
+    return true
+end
+
+function band_segment_ranges(lowerpoints, upperpoints)
+    ranges = UnitRange{Int}[]
+    start = nothing
+    for i in eachindex(lowerpoints, upperpoints)
+        if isnan(lowerpoints[i]) || isnan(upperpoints[i])
+            if start !== nothing && i - start > 1
+                push!(ranges, start:(i - 1))
+            end
+            start = nothing
+        elseif start === nothing
+            start = i
+        elseif i == lastindex(lowerpoints)
+            push!(ranges, start:i)
+        end
+    end
+    return ranges
+end
+
+################################################################################
+#                                  Tricontourf                                 #
+################################################################################
+
+function draw_plot(scene::Scene, screen::Screen, tric::Tricontourf)
+    pol = only(tric.plots)::Poly
+    colornumbers = pol.color[]
+    colors = to_skia_plotcolor(colornumbers, pol)
+    polygons = pol[1][]
+    model = pol.model[]
+    space = pol.space[]
+    projected_polys = project_polygon.(Ref(tric), space, polygons, Ref(tric.clip_planes[]), Ref(model))
+
+    paint = new_paint()
+    for (i, (po, col)) in enumerate(zip(projected_polys, colors))
+        path = polygon_to_skia_path(po)
+        if i == length(colornumbers) || colornumbers[i] != colornumbers[i + 1]
+            set_paint_color!(paint, col)
+            sk_canvas_draw_path(screen.canvas, path, paint)
+        end
+        sk_path_delete(path)
+    end
+    sk_paint_delete(paint)
+    return
+end
+
+is_skiamakie_atomic_plot(plot::Tricontourf) = true
+
+################################################################################
+#                                   Arrows2D                                   #
+################################################################################
+
+function draw_plot(scene::Scene, screen::Screen, arrow::Arrows2D)
+    poly = only(arrow.plots)
+    color = to_skia_plotcolor(poly.color[], poly)
+    model = Ref(poly.model[])
+    strokecolor = to_skia_plotcolor(poly.strokecolor[], poly)
+    strokestyle = Makie.convert_attribute(poly.linestyle[], key"linestyle"())
+    strokewidth = poly.strokewidth[]
+    miter_limit = to_skia_miter_limit(poly.miter_limit[])
+    joinstyle = to_skia_joinstyle(poly.joinstyle[])
+    linecap = to_skia_linecap(poly.linecap[])
+
+    broadcast_foreach(
+        poly.meshes[], color, model, strokecolor, strokestyle, strokewidth
+    ) do mesh, props...
+        points = [Point2(c[1], c[2]) for c in coordinates(mesh)]
+        draw_poly(scene, screen, poly, points, props..., miter_limit, joinstyle, linecap)
+    end
+    return nothing
+end
+
+is_skiamakie_atomic_plot(plot::Arrows2D) = true

--- a/SkiaMakie/src/plot-primitives.jl
+++ b/SkiaMakie/src/plot-primitives.jl
@@ -1,0 +1,119 @@
+####################################################################################################
+#                                          Infrastructure                                          #
+####################################################################################################
+
+########################################
+#           Drawing pipeline           #
+########################################
+
+function skia_draw(screen::Screen, scene::Scene)
+    sk_canvas_save(screen.canvas)
+    draw_background(screen, scene)
+
+    allplots = Makie.collect_atomic_plots(scene; is_atomic_plot = is_skiamakie_atomic_plot)
+    sort!(allplots; by = Makie.zvalue2d)
+
+    last_scene = scene
+
+    sk_canvas_save(screen.canvas)
+    for p in allplots
+        check_parent_plots(p) do plot
+            to_value(get(plot, :visible, true))
+        end || continue
+        pparent = Makie.parent_scene(p)::Scene
+        pparent.visible[]::Bool || continue
+        if pparent != last_scene
+            sk_canvas_restore(screen.canvas)
+            sk_canvas_save(screen.canvas)
+            prepare_for_scene(screen, pparent)
+            last_scene = pparent
+        end
+        sk_canvas_save(screen.canvas)
+
+        if to_value(get(p, :rasterize, false)) != false && is_vector_backend(screen)
+            # TODO: implement rasterize-on-vector
+            draw_plot(pparent, screen, p)
+        else
+            draw_plot(pparent, screen, p)
+        end
+        sk_canvas_restore(screen.canvas)
+    end
+    sk_canvas_restore(screen.canvas)
+    return
+end
+
+is_vector_backend(screen::Screen{RT}) where {RT} = is_vector_backend(RT)
+
+is_skiamakie_atomic_plot(plot::Plot) = Makie.is_atomic_plot(plot) || isempty(plot.plots) || to_value(get(plot, :rasterize, false)) != false
+
+function check_parent_plots(f, plot::Plot)
+    if f(plot)
+        check_parent_plots(f, parent(plot))
+    else
+        return false
+    end
+end
+check_parent_plots(f, scene::Scene) = true
+
+function prepare_for_scene(screen::Screen, scene::Scene)
+    root_area_height = widths(Makie.root(scene))[2]
+    scene_area = viewport(scene)[]
+    scene_height = widths(scene_area)[2]
+    scene_x_origin, scene_y_origin = scene_area.origin
+
+    top_offset = root_area_height - scene_height - scene_y_origin
+    sk_canvas_translate(screen.canvas, Float32(scene_x_origin), Float32(top_offset))
+
+    # clip to scene viewport
+    w, h = widths(scene_area)
+    clip_rect = Ref(sk_rect_t(0.0f0, 0.0f0, Float32(w), Float32(h)))
+    sk_canvas_clip_rect_with_operation(screen.canvas, clip_rect, SK_CLIP_OP_INTERSECT, false)
+    return
+end
+
+function draw_background(screen::Screen, scene::Scene)
+    w, h = Makie.widths(viewport(Makie.root(scene))[])
+    return draw_background(screen, scene, h)
+end
+
+function draw_background(screen::Screen, scene::Scene, root_h)
+    canvas = screen.canvas
+    sk_canvas_save(canvas)
+    if scene.clear[]
+        bg = scene.backgroundcolor[]
+        color = to_skia_color(bg)
+        r = viewport(scene)[]
+        x, y = origin(r); w, h = widths(r)
+        paint = new_paint(color = color)
+        rect = Ref(sk_rect_t(Float32(x), Float32(root_h - y - h), Float32(x + w), Float32(root_h - y)))
+        sk_canvas_draw_rect(canvas, rect, paint)
+        sk_paint_delete(paint)
+    end
+    sk_canvas_restore(canvas)
+    return foreach(child_scene -> draw_background(screen, child_scene, root_h), scene.children)
+end
+
+function draw_plot(scene::Scene, screen::Screen, primitive::Plot)
+    if to_value(get(primitive, :visible, true))
+        if is_skiamakie_atomic_plot(primitive)
+            sk_canvas_save(screen.canvas)
+            draw_atomic(scene, screen, primitive)
+            sk_canvas_restore(screen.canvas)
+        end
+        if !isempty(primitive.plots)
+            zvals = Makie.zvalue2d.(primitive.plots)
+            for idx in sortperm(zvals)
+                draw_plot(scene, screen, primitive.plots[idx])
+            end
+        end
+    end
+    return
+end
+
+function draw_atomic(::Scene, ::Screen, x::PlotList)
+    return nothing
+end
+
+function draw_atomic(::Scene, ::Screen, x)
+    return @warn "$(typeof(x)) is not supported by SkiaMakie right now"
+end

--- a/SkiaMakie/src/scatter.jl
+++ b/SkiaMakie/src/scatter.jl
@@ -1,0 +1,458 @@
+function draw_atomic(scene::Scene, screen::Screen, plot::Scatter)
+    attr = plot.attributes
+    isempty(attr.positions[]) && return
+    Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
+    skia_unclipped_indices!(attr)
+    Makie.compute_colors!(attr)
+    Makie.register_positions_projected!(
+        scene.compute, attr, Point3d;
+        input_name = :positions_transformed_f32c, output_name = :positions_in_markerspace,
+        input_space = :space, output_space = :markerspace, apply_clip_planes = false
+    )
+    map!(skia_scatter_marker, attr, :marker, :skia_marker)
+    size_model!(attr)
+    if !haskey(attr, :eye_to_clip)
+        add_input!(attr, :eye_to_clip, scene.compute.projection)
+        add_input!(attr, :cam_view, scene.compute.view)
+    end
+    inputs = [
+        :positions_in_markerspace, :projectionview, :eye_to_clip, :cam_view,
+        :markersize, :strokewidth, :skia_marker, :marker_offset,
+        :converted_rotation, :billboard, :transform_marker, :size_model, :markerspace,
+        :space, :clip_planes, :unclipped_indices, :font,
+        :strokecolor, :computed_color, :resolution,
+    ]
+    extract_attributes!(attr, inputs, :skia_attributes)
+    canvas = screen.canvas
+    return draw_atomic_scatter(canvas, attr[:skia_attributes][])
+end
+
+function draw_atomic(scene::Scene, screen::Screen, plot::Text)
+    attr = plot.attributes
+    skia_unclipped_indices!(attr, :per_char_positions_transformed_f32c)
+    Makie.register_positions_projected!(
+        scene.compute, attr, Point3d;
+        input_name = :positions_transformed_f32c, output_name = :positions_in_markerspace,
+        input_space = :space, output_space = :markerspace, apply_clip_planes = false
+    )
+    Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
+    size_model!(attr)
+    if !haskey(attr, :eye_to_clip)
+        add_input!(attr, :eye_to_clip, scene.compute.projection)
+        add_input!(attr, :cam_view, scene.compute.view)
+    end
+    inputs = [
+        :text_blocks, :font_per_char, :glyphindices, :marker_offset, :text_rotation,
+        :text_scales, :text_strokewidth, :text_strokecolor, :markerspace,
+        :text_color,
+        :positions_in_markerspace, :projectionview, :eye_to_clip, :cam_view, :resolution,
+        :transform_marker, :size_model, :unclipped_indices,
+    ]
+    extract_attributes!(attr, inputs, :skia_attributes)
+    canvas = screen.canvas
+    return draw_text(canvas, attr[:skia_attributes][])
+end
+
+function draw_atomic_scatter(canvas, attr::NamedTuple)
+    size_model = attr.size_model
+    font = attr.font
+    markerspace = attr.markerspace
+    billboard = attr.billboard
+    cam = (
+        resolution = attr.resolution,
+        projectionview = attr.projectionview,
+        eye_to_clip = attr.eye_to_clip,
+        view = attr.cam_view,
+    )
+    args = (
+        attr.unclipped_indices,
+        attr.positions_in_markerspace,
+        attr.computed_color,
+        attr.markersize,
+        attr.strokecolor,
+        attr.strokewidth,
+        attr.skia_marker,
+        attr.marker_offset,
+        attr.converted_rotation,
+    )
+
+    Makie.broadcast_foreach_index(args...) do position, col, markersize, strokecolor, strokewidth, marker, marker_offset, rot
+        isnan(position) && return
+        isnan(rot) && return
+        (isnan(markersize) || is_approx_zero(markersize)) && return
+        rotation = remove_billboard(rot)
+        origin = position .+ size_model * to_ndim(Vec3d, marker_offset, 0)
+
+        proj_pos, jl_mat = project_marker(
+            cam, markerspace, origin, markersize, rotation, size_model, billboard
+        )
+        is_degenerate(jl_mat) && return
+
+        sk_canvas_save(canvas)
+        if marker isa Char
+            draw_marker(canvas, marker, best_font(marker, font), proj_pos, col, strokecolor, strokewidth, jl_mat)
+        else
+            draw_marker(canvas, marker, proj_pos, col, strokecolor, strokewidth, jl_mat)
+        end
+        sk_canvas_restore(canvas)
+    end
+    return
+end
+
+function flush_glyph_batch!(canvas, glyph_ids, glyph_positions, ft_font, color, strokewidth, strokecolor, mat)
+    isempty(glyph_ids) && return
+
+    # Extract the actual font size from the transformation matrix so Skia
+    # rasterizes glyphs at the correct target size (not at size=1 then scaled).
+    # mat columns are the projected x/y basis vectors in screen space.
+    # The y-column magnitude gives the em-height in pixels.
+    yscale = norm(mat[:, 2])
+    yscale ≈ 0 && return
+    # Normalized matrix: only encodes rotation/shear, no scaling
+    norm_mat = mat * Mat2f(1/yscale, 0, 0, 1/yscale)
+
+    sk_font = make_skia_font(ft_font, yscale)
+
+    sk_canvas_save(canvas)
+
+    # Apply only the rotation/shear part to the canvas (scaling is in the font size)
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        norm_mat[1, 1], norm_mat[1, 2], 0.0f0,
+        norm_mat[2, 1], norm_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+
+    # Glyph positions are in screen space — transform them into the
+    # canvas coordinate system (which has norm_mat applied).
+    inv_norm = inv(norm_mat)
+    pos_flat = Float32[]
+    for (x, y) in glyph_positions
+        tp = inv_norm * Vec2f(x, y)
+        push!(pos_flat, Float32(tp[1]), Float32(tp[2]))
+    end
+
+    blob = make_positioned_glyph_blob(sk_font, glyph_ids, pos_flat)
+    if blob != C_NULL
+        # Fill
+        paint = new_paint(color = to_skia_color(color))
+        sk_canvas_draw_text_blob(canvas, blob, 0.0f0, 0.0f0, paint)
+
+        # Stroke
+        if strokewidth > 0 && strokecolor != RGBAf(0, 0, 0, 0)
+            sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+            set_paint_color!(paint, strokecolor)
+            sk_paint_set_stroke_width(paint, Float32(strokewidth))
+            sk_canvas_draw_text_blob(canvas, blob, 0.0f0, 0.0f0, paint)
+        end
+        sk_paint_delete(paint)
+    end
+
+    sk_canvas_restore(canvas)
+    sk_font_delete(sk_font)
+    empty!(glyph_ids)
+    empty!(glyph_positions)
+    return
+end
+
+function draw_text(canvas, attr::NamedTuple)
+    positions = attr.positions_in_markerspace
+    text_blocks = attr.text_blocks
+    font_per_char = attr.font_per_char
+    glyphindices = attr.glyphindices
+    marker_offset = attr.marker_offset
+    text_rotation = attr.text_rotation
+    text_scales = attr.text_scales
+    text_strokewidth = attr.text_strokewidth
+    text_strokecolor = attr.text_strokecolor
+    text_color = attr.text_color
+    markerspace = attr.markerspace
+    valid_indices = attr.unclipped_indices
+    size_model = attr.size_model
+    cam = (
+        resolution = attr.resolution,
+        projectionview = attr.projectionview,
+        eye_to_clip = attr.eye_to_clip,
+        view = attr.cam_view,
+    )
+
+    glyph_ids = UInt16[]
+    glyph_positions = Tuple{Float32, Float32}[]
+
+    for (block_idx, glyph_indices) in enumerate(text_blocks)
+        glyph_pos = positions[block_idx]
+        local batch_font, batch_color, batch_mat, batch_strokewidth, batch_strokecolor
+
+        for glyph_idx in glyph_indices
+            glyph_idx in valid_indices || continue
+
+            glyph = glyphindices[glyph_idx]
+            glyph == 0 && continue
+
+            offset = marker_offset[glyph_idx]
+            font = font_per_char[glyph_idx]
+            rotation = Makie.sv_getindex(text_rotation, glyph_idx)
+            color = Makie.sv_getindex(text_color, glyph_idx)
+            strokewidth = Makie.sv_getindex(text_strokewidth, glyph_idx)
+            strokecolor = Makie.sv_getindex(text_strokecolor, glyph_idx)
+            scale = Makie.sv_getindex(text_scales, glyph_idx)
+
+            gp3 = glyph_pos .+ size_model * offset
+            any(isnan, gp3) && continue
+
+            glyphpos, jl_mat = project_marker(cam, markerspace, Point3d(gp3), scale, rotation, size_model)
+
+            if !isempty(glyph_ids) && (
+                    font !== batch_font ||
+                    color != batch_color ||
+                    jl_mat != batch_mat ||
+                    strokewidth != batch_strokewidth ||
+                    strokecolor != batch_strokecolor
+                )
+                flush_glyph_batch!(canvas, glyph_ids, glyph_positions, batch_font, batch_color, batch_strokewidth, batch_strokecolor, batch_mat)
+            end
+
+            if isempty(glyph_ids)
+                batch_font = font
+                batch_color = color
+                batch_mat = jl_mat
+                batch_strokewidth = strokewidth
+                batch_strokecolor = strokecolor
+            end
+
+            # Glyph IDs from Makie are UInt64, Skia wants UInt16
+            push!(glyph_ids, UInt16(glyph & 0xFFFF))
+            push!(glyph_positions, (Float32(glyphpos[1]), Float32(glyphpos[2])))
+        end
+
+        if !isempty(glyph_ids)
+            flush_glyph_batch!(canvas, glyph_ids, glyph_positions, batch_font, batch_color, batch_strokewidth, batch_strokecolor, batch_mat)
+        end
+    end
+    return
+end
+
+function skia_unclipped_indices!(attr::Makie.ComputeGraph, position_name = :positions_transformed_f32c)
+    return Makie.register_computation!(
+        attr,
+        [position_name, :model_f32c, :space, :clip_planes],
+        [:unclipped_indices]
+    ) do (transformed, model, space, clip_planes), changed, outputs
+        return (unclipped_indices(to_model_space(model, clip_planes), transformed, space),)
+    end
+end
+
+function size_model!(attr)
+    return map!(attr, [:f32c_scale, :model, :markerspace, :transform_marker], :size_model) do f32c_scale, model, markerspace, transform_marker
+        size_model = transform_marker ? model[Vec(1, 2, 3), Vec(1, 2, 3)] : Mat3d(I)
+        return Mat3d(f32c_scale[1], 0, 0, 0, f32c_scale[2], 0, 0, 0, f32c_scale[3]) * size_model
+    end
+end
+
+function project_marker(cam, markerspace::Symbol, origin::Point3, scale::Vec, rotation, model33::Mat3, billboard = false)
+    xvec = rotation * (model33 * (scale[1] * Point3d(1, 0, 0)))
+    yvec = rotation * (model33 * (scale[2] * Point3d(0, -1, 0)))
+    pv = cam.projectionview
+    resolution = cam.resolution
+    proj_pos = project_flipped(pv, resolution, origin, true)
+    if billboard && Makie.is_data_space(markerspace)
+        p4d = cam.view * to_ndim(Point4d, origin, 1)
+        p4d_clip = p4d[Vec(1, 2, 3)] / p4d[4]
+        xproj = project_flipped(cam.eye_to_clip, resolution, p4d_clip + xvec, true)
+        yproj = project_flipped(cam.eye_to_clip, resolution, p4d_clip + yvec, true)
+    else
+        xproj = project_flipped(pv, resolution, origin + xvec, true)
+        yproj = project_flipped(pv, resolution, origin + yvec, true)
+    end
+
+    xdiff = xproj - proj_pos
+    ydiff = yproj - proj_pos
+
+    return proj_pos, Mat2f(xdiff..., ydiff...)
+end
+
+function project_flipped(trans::Mat4, res, point::Union{Point3, Vec3}, yflip::Bool)
+    p4d = to_ndim(Vec4d, to_ndim(Vec3d, point, 0.0), 1.0)
+    clip = trans * p4d
+    p = clip[Vec(1, 2)] ./ clip[4]
+    p_yflip = Vec2d(p[1], (1.0 - 2.0 * yflip) * p[2])
+    p_0_to_1 = (p_yflip .+ 1.0) ./ 2.0
+    return p_0_to_1 .* res
+end
+
+########################################
+#           Marker drawing             #
+########################################
+
+function draw_marker(canvas, marker::Char, font, pos, color, strokecolor, strokewidth, jl_mat)
+    # Get glyph index for this character
+    FT = Makie.FreeType
+    glyph_id = Base.@lock font.lock FT.FT_Get_Char_Index(font, UInt32(marker))
+
+    # Get character extent for centering
+    charextent = Makie.FreeTypeAbstraction.get_extent(font, marker)
+    inkbb = Makie.FreeTypeAbstraction.inkboundingbox(charextent)
+    centering_offset = Makie.origin(inkbb) .+ 0.5f0 .* widths(inkbb)
+    # Transform centering offset from marker space to screen space (yflip for Skia)
+    char_offset = Vec2f(jl_mat * ((1, -1) .* centering_offset))
+    charorigin = pos - char_offset
+
+    # Extract actual font size from mat and normalize (same as flush_glyph_batch!)
+    yscale = norm(jl_mat[:, 2])
+    yscale ≈ 0 && return
+    norm_mat = jl_mat * Mat2f(1/yscale, 0, 0, 1/yscale)
+    sk_font = make_skia_font(font, yscale)
+
+    sk_canvas_save(canvas)
+    sk_canvas_translate(canvas, Float32(charorigin[1]), Float32(charorigin[2]))
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        norm_mat[1, 1], norm_mat[1, 2], 0.0f0,
+        norm_mat[2, 1], norm_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+
+    # Build a single-glyph blob at origin
+    glyph_ids = UInt16[UInt16(glyph_id & 0xFFFF)]
+    pos_flat = Float32[0.0f0, 0.0f0]
+    blob = make_positioned_glyph_blob(sk_font, glyph_ids, pos_flat)
+
+    if blob != C_NULL
+        paint = new_paint(color = to_skia_color(color))
+        sk_canvas_draw_text_blob(canvas, blob, 0.0f0, 0.0f0, paint)
+
+        if strokewidth > 0
+            sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+            set_paint_color!(paint, strokecolor)
+            sk_paint_set_stroke_width(paint, Float32(strokewidth))
+            sk_canvas_draw_text_blob(canvas, blob, 0.0f0, 0.0f0, paint)
+        end
+        sk_paint_delete(paint)
+    end
+
+    sk_canvas_restore(canvas)
+    sk_font_delete(sk_font)
+    return
+end
+
+function draw_marker(canvas, ::Type{<:Circle}, pos, color, strokecolor, strokewidth, jl_mat)
+    sk_canvas_translate(canvas, Float32(pos[1]), Float32(pos[2]))
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        jl_mat[1, 1], jl_mat[1, 2], 0.0f0,
+        jl_mat[2, 1], jl_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+    paint = new_paint(color = to_skia_color(color))
+    sk_canvas_draw_circle(canvas, 0.0f0, 0.0f0, 0.5f0, paint)
+    if strokewidth > 0
+        sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, to_color(strokecolor))
+        sk_paint_set_stroke_width(paint, Float32(strokewidth))
+        sk_canvas_draw_circle(canvas, 0.0f0, 0.0f0, 0.5f0, paint)
+    end
+    sk_paint_delete(paint)
+    return
+end
+
+function draw_marker(canvas, ::Union{Makie.FastPixel, <:Type{<:Rect}}, pos, color, strokecolor, strokewidth, jl_mat)
+    sk_canvas_translate(canvas, Float32(pos[1]), Float32(pos[2]))
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        jl_mat[1, 1], jl_mat[1, 2], 0.0f0,
+        jl_mat[2, 1], jl_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+    rect = Ref(sk_rect_t(-0.5f0, -0.5f0, 0.5f0, 0.5f0))
+    paint = new_paint(color = to_skia_color(color))
+    sk_canvas_draw_rect(canvas, rect, paint)
+    if strokewidth > 0
+        sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, to_color(strokecolor))
+        sk_paint_set_stroke_width(paint, Float32(strokewidth))
+        sk_canvas_draw_rect(canvas, rect, paint)
+    end
+    sk_paint_delete(paint)
+    return
+end
+
+function draw_marker(canvas, beziermarker::BezierPath, pos, color, strokecolor, strokewidth, jl_mat)
+    sk_canvas_save(canvas)
+    sk_canvas_translate(canvas, Float32(pos[1]), Float32(pos[2]))
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        jl_mat[1, 1], jl_mat[1, 2], 0.0f0,
+        jl_mat[2, 1], jl_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+    sk_canvas_scale(canvas, 1.0f0, -1.0f0)
+
+    path = bezierpath_to_skia_path(beziermarker)
+    paint = new_paint(color = to_skia_color(color))
+    sk_canvas_draw_path(canvas, path, paint)
+    if strokewidth > 0
+        sk_paint_set_style(paint, SK_PAINT_STYLE_STROKE)
+        set_paint_color!(paint, to_color(strokecolor))
+        sk_paint_set_stroke_width(paint, Float32(strokewidth))
+        sk_canvas_draw_path(canvas, path, paint)
+    end
+    sk_paint_delete(paint)
+    sk_path_delete(path)
+    sk_canvas_restore(canvas)
+    return
+end
+
+function draw_marker(
+        canvas, marker::Matrix{T}, pos, color, strokecolor, strokewidth, jl_mat
+    ) where {T <: Colorant}
+    sk_canvas_save(canvas)
+    sk_canvas_translate(canvas, Float32(pos[1]), Float32(pos[2]))
+    concat_canvas_matrix!(canvas, sk_matrix_t(
+        jl_mat[1, 1], jl_mat[1, 2], 0.0f0,
+        jl_mat[2, 1], jl_mat[2, 2], 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    ))
+    w, h = size(marker)
+    sk_canvas_scale(canvas, 1.0f0 / w, 1.0f0 / h)
+
+    skia_img, _pixels = colormatrix_to_skia_image(permutedims(marker, (2, 1)))
+    src_rect = Ref(sk_rect_t(0.0f0, 0.0f0, Float32(w), Float32(h)))
+    dst_rect = Ref(sk_rect_t(Float32(-w / 2), Float32(-h / 2), Float32(w / 2), Float32(h / 2)))
+    paint = new_paint()
+    cubic = Skia.sk_cubic_resampler_t(0.0f0, 0.0f0)
+    sampling = Ref(sk_sampling_options_t(Int32(0), false, cubic, SK_FILTER_MODE_LINEAR, SK_MIPMAP_MODE_NONE))
+    sk_canvas_draw_image_rect(canvas, skia_img, src_rect, dst_rect, sampling, paint, SRC_RECT_CONSTRAINT_STRICT)
+    sk_paint_delete(paint)
+    sk_canvas_restore(canvas)
+    return
+end
+
+function bezierpath_to_skia_path(bp::BezierPath)
+    path = sk_path_new()
+    for cmd in bp.commands
+        if cmd isa MoveTo
+            sk_path_move_to(path, Float32(cmd.p[1]), Float32(cmd.p[2]))
+        elseif cmd isa LineTo
+            sk_path_line_to(path, Float32(cmd.p[1]), Float32(cmd.p[2]))
+        elseif cmd isa CurveTo
+            sk_path_cubic_to(path,
+                Float32(cmd.c1[1]), Float32(cmd.c1[2]),
+                Float32(cmd.c2[1]), Float32(cmd.c2[2]),
+                Float32(cmd.p[1]), Float32(cmd.p[2]))
+        elseif cmd isa ClosePath
+            sk_path_close(path)
+        elseif cmd isa EllipticalArc
+            beziers = Makie.elliptical_arc_to_beziers(cmd)
+            for b in beziers.commands
+                if b isa MoveTo
+                    sk_path_move_to(path, Float32(b.p[1]), Float32(b.p[2]))
+                elseif b isa LineTo
+                    sk_path_line_to(path, Float32(b.p[1]), Float32(b.p[2]))
+                elseif b isa CurveTo
+                    sk_path_cubic_to(path,
+                        Float32(b.c1[1]), Float32(b.c1[2]),
+                        Float32(b.c2[1]), Float32(b.c2[2]),
+                        Float32(b.p[1]), Float32(b.p[2]))
+                elseif b isa ClosePath
+                    sk_path_close(path)
+                end
+            end
+        end
+    end
+    return path
+end

--- a/SkiaMakie/src/screen.jl
+++ b/SkiaMakie/src/screen.jl
@@ -1,0 +1,239 @@
+using Base.Docs: doc
+
+@enum RenderType IMAGE SVG PDF
+
+function Base.convert(::Type{RenderType}, type::String)
+    type == "png" && return IMAGE
+    type == "svg" && return SVG
+    type == "pdf" && return PDF
+    error("Unsupported SkiaMakie render type: $type")
+end
+
+function to_mime(type::RenderType)
+    type == SVG && return MIME("image/svg+xml")
+    type == PDF && return MIME("application/pdf")
+    return MIME("image/png")
+end
+
+"""
+* `px_per_unit = 2.0`
+* `pt_per_unit = 0.75`
+* `antialias::Symbol = :best`
+* `visible::Bool`: if true, an image viewer will open to display rendered output.
+"""
+struct ScreenConfig
+    px_per_unit::Float64
+    pt_per_unit::Float64
+    antialias::Symbol
+    visible::Bool
+    start_renderloop::Bool
+
+    function ScreenConfig(
+            px_per_unit::Real, pt_per_unit::Real,
+            antialias::Symbol, visible::Bool, start_renderloop::Bool
+        )
+        return new(px_per_unit, pt_per_unit, antialias, visible, start_renderloop)
+    end
+end
+
+function device_scaling_factor(::Type{<:RenderType}, sc::ScreenConfig)
+    return sc.px_per_unit
+end
+function device_scaling_factor(rt::RenderType, sc::ScreenConfig)
+    rt === SVG && return sc.pt_per_unit / 0.75
+    rt === PDF && return sc.pt_per_unit
+    return sc.px_per_unit
+end
+
+const LAST_INLINE = Ref{Union{Makie.Automatic, Bool}}(Makie.automatic)
+
+"""
+    SkiaMakie.activate!(; screen_config...)
+
+Sets SkiaMakie as the currently active backend.
+"""
+function activate!(; inline = LAST_INLINE[], type = "png", screen_config...)
+    Makie.inline!(inline)
+    LAST_INLINE[] = inline
+    Makie.set_screen_config!(SkiaMakie, screen_config)
+    if type == "png"
+        disable_mime!("svg", "pdf")
+    elseif type == "svg"
+        disable_mime!("text/html", "application/vnd.webio.application+html",
+            "application/prs.juno.plotpane+html", "juliavscode/html")
+    else
+        enable_only_mime!(type)
+    end
+    Makie.set_active_backend!(SkiaMakie)
+    return
+end
+
+"""
+    Screen(; screen_config...)
+
+$(Base.doc(ScreenConfig))
+$(Base.doc(MakieScreen))
+"""
+mutable struct Screen{SurfaceRenderType} <: Makie.MakieScreen
+    scene::Scene
+    # Skia resources — surface may be C_NULL for SVG (canvas-only)
+    surface::Ptr{Skia.sk_surface_t}
+    canvas::Ptr{Skia.sk_canvas_t}
+    width::Int
+    height::Int
+    device_scaling_factor::Float64
+    visible::Bool
+    config::ScreenConfig
+
+    function Screen()
+        return new{IMAGE}()
+    end
+    function Screen{RT}(
+            scene, surface, canvas, w, h, dsf, visible, config
+        ) where {RT}
+        return new{RT}(scene, surface, canvas, w, h, dsf, visible, config)
+    end
+end
+
+function Base.empty!(screen::Screen)
+    isopen(screen) || return
+    bg = rgbatuple(screen.scene.backgroundcolor[])
+    sk_canvas_clear(screen.canvas, to_skia_color(bg...))
+    return
+end
+
+Base.close(screen::Screen) = empty!(screen)
+
+function destroy!(screen::Screen)
+    # Skia objects are ref-counted C pointers; we don't have explicit destroy
+    # for surfaces in the Julia wrapper, so we just null them out
+    screen.surface = Ptr{Skia.sk_surface_t}(C_NULL)
+    screen.canvas = Ptr{Skia.sk_canvas_t}(C_NULL)
+    return
+end
+
+function Base.isopen(screen::Screen)
+    return screen.canvas != C_NULL
+end
+
+function Base.size(screen::Screen)
+    isdefined(screen, :width) || return (0, 0)
+    return (screen.width, screen.height)
+end
+
+Base.insert!(screen::Screen, scene::Scene, plot) = nothing
+function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot) end
+
+function Base.show(io::IO, ::MIME"text/plain", screen::Screen{S}) where {S}
+    return println(io, "SkiaMakie.Screen{$S}")
+end
+
+function scaled_scene_resolution(typ::RenderType, config::ScreenConfig, scene::Scene)
+    dsf = device_scaling_factor(typ, config)
+    return round.(Int, Makie.size(scene) .* dsf)
+end
+
+function Screen(scene::Scene; screen_config...)
+    config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}(screen_config))
+    return Screen(scene, config)
+end
+
+Screen(scene::Scene, config::ScreenConfig) = Screen(scene, config, nothing, IMAGE)
+
+function Screen(scene::Scene, config::ScreenConfig, io_or_path::Union{Nothing, String, IO}, typ::Union{MIME, Symbol, RenderType})
+    rtype = typ isa RenderType ? typ : convert(RenderType, string(typ))
+    w, h = scaled_scene_resolution(rtype, config, scene)
+    return create_screen(scene, config, rtype, w, h, io_or_path)
+end
+
+function Screen(scene::Scene, config::ScreenConfig, ::Makie.ImageStorageFormat)
+    w, h = scaled_scene_resolution(IMAGE, config, scene)
+    return create_screen(scene, config, IMAGE, w, h, nothing)
+end
+
+function create_screen(scene, config, rtype::RenderType, w, h, io_or_path)
+    dsf = device_scaling_factor(rtype, config)
+
+    if rtype === IMAGE
+        surface, canvas = make_raster_surface(w, h)
+        # Apply device scale: the surface has w*dsf × h*dsf pixels but Makie
+        # draws in scene coordinates (w × h). This mirrors Cairo's
+        # surface_set_device_scale which applies a hidden base scaling.
+        sk_canvas_scale(canvas, Float32(dsf), Float32(dsf))
+        return Screen{IMAGE}(scene, surface, canvas, w, h, dsf, config.visible, config)
+    elseif rtype === SVG
+        # SVG: use file wstream → canvas (no surface)
+        error("SVG output not yet implemented in SkiaMakie")
+    elseif rtype === PDF
+        error("PDF output not yet implemented in SkiaMakie")
+    else
+        error("Unsupported render type: $rtype")
+    end
+end
+
+function Makie.apply_screen_config!(
+        screen::Screen{SCREEN_RT}, config::ScreenConfig, scene::Scene, io::Union{Nothing, IO}, m::MIME{SYM}
+    ) where {SYM, SCREEN_RT}
+    new_rendertype = convert(RenderType, string(SYM))
+    new_resolution = scaled_scene_resolution(new_rendertype, config, scene)
+    if SCREEN_RT !== new_rendertype || is_vector_backend(new_rendertype) || Base.size(screen) != new_resolution
+        old_screen = screen
+        screen = Screen(scene, config, io, new_rendertype)
+        destroy!(old_screen)
+    end
+    screen.scene = scene
+    screen.config = config
+    screen.device_scaling_factor = device_scaling_factor(new_rendertype, config)
+    return screen
+end
+
+function Makie.apply_screen_config!(screen::Screen, config::ScreenConfig, scene::Scene, args...)
+    return Makie.apply_screen_config!(screen, config, scene, nothing, MIME"image/png"())
+end
+
+function Makie.px_per_unit(s::Screen)::Float64
+    return s.config.px_per_unit
+end
+
+########################################
+#    Fast colorbuffer for recording    #
+########################################
+
+function Makie.colorbuffer(screen::Screen; figure = nothing)
+    scene = screen.scene
+    w, h = Base.size(screen)
+    scr = Screen(scene, screen.config, nothing, IMAGE)
+    return Makie.colorbuffer(scr)
+end
+
+function Makie.colorbuffer(screen::Screen{IMAGE}; figure = nothing)
+    Makie.push_screen!(screen.scene, screen)
+    empty!(screen)
+    skia_draw(screen, screen.scene)
+    w, h = Base.size(screen)
+    pixels = read_surface_pixels(screen.surface, w, h)
+    # Convert from Skia RGBA UInt32 to ARGB32 for Makie
+    # Skia RGBA_8888: R in low byte, A in high byte  → 0xAABBGGRR
+    # Makie ARGB32:   A in high byte, R next         → 0xAARRGGBB
+    result = Matrix{ARGB32}(undef, w, h)
+    for j in 1:h, i in 1:w
+        px = pixels[i, j]
+        r = (px >>  0) & 0xFF
+        g = (px >>  8) & 0xFF
+        b = (px >> 16) & 0xFF
+        a = (px >> 24) & 0xFF
+        # un-premultiply
+        if a > 0
+            r = min(UInt32(255), div(r * 255, a))
+            g = min(UInt32(255), div(g * 255, a))
+            b = min(UInt32(255), div(b * 255, a))
+        end
+        result[i, j] = ARGB32(reinterpret(N0f8, UInt8(r)), reinterpret(N0f8, UInt8(g)),
+            reinterpret(N0f8, UInt8(b)), reinterpret(N0f8, UInt8(a)))
+    end
+    return PermutedDimsArray(result, (2, 1))
+end
+
+is_vector_backend(rt::RenderType) = rt in (PDF, SVG)
+
+Base.resize!(screen::Screen, w, h) = nothing

--- a/SkiaMakie/src/skia-helpers.jl
+++ b/SkiaMakie/src/skia-helpers.jl
@@ -1,0 +1,374 @@
+################################################################################
+#                    Julia-friendly wrappers around Skia.jl                   #
+################################################################################
+
+# We wrap the low-level Skia C API in slightly more ergonomic Julia functions.
+# All Skia objects are opaque Ptr types — we manage their lifetime manually.
+
+"""
+Convert an RGBA colorant to Skia's packed UInt32 ARGB format (0xAARRGGBB).
+"""
+function to_skia_color(c::Colorant)
+    rgba = RGBA(c)
+    a = round(UInt32, clamp(alpha(rgba), 0, 1) * 255)
+    r = round(UInt32, clamp(red(rgba), 0, 1) * 255)
+    g = round(UInt32, clamp(green(rgba), 0, 1) * 255)
+    b = round(UInt32, clamp(blue(rgba), 0, 1) * 255)
+    return (a << 24) | (r << 16) | (g << 8) | b
+end
+
+to_skia_color(r, g, b, a) = to_skia_color(RGBAf(r, g, b, a))
+
+################################################################################
+#                         Font / typeface cache                                #
+################################################################################
+
+# Cache: FreeType FTFont → (Skia typeface ptr, font manager ptr)
+const _TYPEFACE_CACHE = Dict{UInt, Ptr{Skia.sk_typeface_t}}()
+const _FONTMGR = Ref{Ptr{Skia.sk_font_mgr_t}}(Ptr{Skia.sk_font_mgr_t}(C_NULL))
+
+function _get_fontmgr()
+    if _FONTMGR[] == C_NULL
+        _FONTMGR[] = sk_fontmgr_ref_default()
+    end
+    return _FONTMGR[]
+end
+
+"""
+Get or create a Skia typeface from a FreeType font.
+Caches by the objectid of the FTFont to avoid re-creating typefaces.
+"""
+function get_skia_typeface(ft_font::Makie.FreeTypeAbstraction.FTFont)
+    key = objectid(ft_font)
+    return get!(_TYPEFACE_CACHE, key) do
+        font_data = ft_font.mmapped
+        sk_data = sk_data_new_with_copy(pointer(font_data), Csize_t(length(font_data)))
+        typeface = sk_fontmgr_create_from_data(_get_fontmgr(), sk_data, Int32(0))
+        typeface == C_NULL && error("Failed to create Skia typeface from font data")
+        return typeface
+    end
+end
+
+"""
+Create a Skia font object at the given size from a FreeType font.
+The caller is responsible for the lifetime (no auto-cleanup).
+"""
+function make_skia_font(ft_font::Makie.FreeTypeAbstraction.FTFont, size::Real)
+    typeface = get_skia_typeface(ft_font)
+    font = sk_font_new_with_values(typeface, Float32(size), 1.0f0, 0.0f0)
+    # Disable hinting — we render at size=1 and scale via canvas transform,
+    # so hinting at the nominal size would distort glyph outlines.
+    sk_font_set_hinting(font, SK_FONT_HINTING_NONE)
+    sk_font_set_subpixel(font, true)
+    return font
+end
+
+"""
+Build a text blob from glyph IDs and per-glyph positions using Skia's text blob builder.
+`glyph_ids` is a Vector{UInt16}, `positions` is a Vector of (x::Float32, y::Float32) tuples
+packed as a flat Float32 vector [x1,y1, x2,y2, ...].
+"""
+function make_positioned_glyph_blob(sk_font, glyph_ids::Vector{UInt16}, pos_flat::Vector{Float32})
+    n = length(glyph_ids)
+    n == 0 && return Ptr{Skia.sk_text_blob_t}(C_NULL)
+    builder = sk_textblob_builder_new()
+    run_buf_ptr = sk_textblob_builder_alloc_run_pos(builder, sk_font, Int32(n), C_NULL)
+    run_buf = unsafe_load(run_buf_ptr)
+    unsafe_copyto!(run_buf.glyphs, pointer(glyph_ids), n)
+    unsafe_copyto!(run_buf.pos, pointer(pos_flat), 2 * n)
+    blob = sk_textblob_builder_make(builder)
+    sk_textblob_builder_delete(builder)
+    return blob
+end
+
+################################################################################
+#                         PDF document helpers                                 #
+################################################################################
+
+"""
+Create a PDF document writing to `path`, returning (document_ptr, canvas_ptr, file_wstream_ptr).
+The canvas is valid until `finish_pdf_document` is called.
+`w` and `h` are in points (1/72 inch).
+"""
+function make_pdf_document(path::String, w::Real, h::Real)
+    fileWstream = sk_file_wstream_new(path)
+    stream = sk_file_wstream_as_wstream(fileWstream)
+    dt = Skia.sk_date_time_t(Int16(0), UInt16(2026), UInt8(1), UInt8(0), UInt8(1), UInt8(0), UInt8(0), UInt8(0))
+    metadata = Ref(Skia.sk_metadata_t(
+        pointer(""), pointer(""), pointer(""),
+        pointer(""), pointer("SkiaMakie"), pointer("Skia.jl"),
+        dt, dt, 72.0f0, 0.0f0, Int32(1)
+    ))
+    document = sk_document_make_pdf(stream, metadata)
+    document == C_NULL && error("Failed to create Skia PDF document")
+    canvas = sk_document_begin_page(document, Float32(w), Float32(h))
+    return document, canvas, fileWstream
+end
+
+"""
+Finish and close a PDF document created with `make_pdf_document`.
+"""
+function finish_pdf_document(document, fileWstream)
+    sk_document_end_page(document)
+    sk_document_close(document)
+    sk_file_wstream_flush(fileWstream)
+    sk_file_wstream_delete(fileWstream)
+    return
+end
+
+"""
+Render a Makie scene to a PDF file using SkiaMakie.
+This is a convenience function that creates a temporary Screen{PDF}.
+"""
+function save_scene_to_pdf(scene::Scene, path::String; pt_per_unit=0.75)
+    w, h = Makie.size(scene)
+    pw, ph = w * pt_per_unit, h * pt_per_unit
+    document, canvas, fileWstream = make_pdf_document(path, pw, ph)
+
+    # Build a Screen with the PDF canvas
+    config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}())
+    dsf = pt_per_unit
+    screen = Screen{PDF}(scene, Ptr{Skia.sk_surface_t}(C_NULL), canvas, round(Int, pw), round(Int, ph), dsf, false, config)
+
+    # Apply device scaling so Makie scene coords map to PDF points
+    sk_canvas_scale(canvas, Float32(dsf), Float32(dsf))
+
+    skia_draw(screen, scene)
+
+    finish_pdf_document(document, fileWstream)
+    return path
+end
+
+"""
+Create a raster (CPU) surface of given dimensions, returning (surface_ptr, canvas_ptr, pixel_buffer).
+The pixel buffer is a Julia-owned Matrix{UInt32} in premultiplied ARGB format.
+"""
+function make_raster_surface(w::Integer, h::Integer)
+    colorspace = sk_colorspace_new_srgb()
+    info = Ref(sk_image_info_t(
+        colorspace,
+        SK_COLOR_TYPE_RGBA_8888,
+        SK_ALPHA_TYPE_PREMUL,
+        Int32(w),
+        Int32(h),
+    ))
+    surface = sk_surface_make_raster_n32_premul(info, C_NULL)
+    if surface == C_NULL
+        error("Failed to create Skia raster surface of size $w × $h")
+    end
+    canvas = sk_surface_get_canvas(surface)
+    return surface, canvas
+end
+
+"""
+Save a Skia surface snapshot to a PNG file. Returns nothing.
+Since there is no GPU context for raster surfaces, we read pixels and encode directly.
+"""
+function save_surface_to_png(surface, path::String)
+    snapshot = sk_surface_make_image_snapshot(surface)
+    # For raster surfaces, pass C_NULL as the graphics context
+    pngdata = sk_encode_png(C_NULL, snapshot, Int32(0))
+    sk_write_data_to_file(path, pngdata)
+    return
+end
+
+"""
+Read pixels from a Skia surface into a Julia Matrix{UInt32} (RGBA8888, premultiplied).
+Returns a (w, h) matrix where each element is a packed ARGB pixel.
+"""
+function read_surface_pixels(surface, w::Integer, h::Integer)
+    snapshot = sk_surface_make_image_snapshot(surface)
+    colorspace = sk_colorspace_new_srgb()
+    info = Ref(sk_image_info_t(
+        colorspace,
+        SK_COLOR_TYPE_RGBA_8888,
+        SK_ALPHA_TYPE_PREMUL,
+        Int32(w),
+        Int32(h),
+    ))
+    pixels = Matrix{UInt32}(undef, w, h)
+    rowBytes = Csize_t(w * 4)
+    sk_image_read_pixels(snapshot, info, pixels, rowBytes, Cint(0), Cint(0),
+        sk_image_caching_hint_t(0))
+    return pixels
+end
+
+"""
+Create a new Skia paint object with common defaults.
+"""
+function new_paint(; antialias=true, style=SK_PAINT_STYLE_FILL, color::UInt32=0xFF000000)
+    paint = sk_paint_new()
+    sk_paint_set_antialias(paint, antialias)
+    sk_paint_set_style(paint, style)
+    sk_paint_set_color(paint, color)
+    return paint
+end
+
+"""
+Set paint color from a Julia Colorant.
+"""
+function set_paint_color!(paint, c::Colorant)
+    sk_paint_set_color(paint, to_skia_color(c))
+    return paint
+end
+
+"""
+Create a Skia path from a series of Point2 vertices (closed polygon).
+"""
+function points_to_path(points::AbstractVector{<:VecTypes{2}})
+    path = sk_path_new()
+    isempty(points) && return path
+    sk_path_move_to(path, Float32(points[1][1]), Float32(points[1][2]))
+    for i in 2:length(points)
+        sk_path_line_to(path, Float32(points[i][1]), Float32(points[i][2]))
+    end
+    sk_path_close(path)
+    return path
+end
+
+"""
+Create an open Skia path from a series of Point2 vertices (not closed).
+"""
+function points_to_open_path(points::AbstractVector{<:VecTypes{2}})
+    path = sk_path_new()
+    isempty(points) && return path
+    sk_path_move_to(path, Float32(points[1][1]), Float32(points[1][2]))
+    for i in 2:length(points)
+        sk_path_line_to(path, Float32(points[i][1]), Float32(points[i][2]))
+    end
+    return path
+end
+
+# Skia linecap mapping
+function to_skia_linecap(linecap_symb::Symbol)
+    linecap = Makie.convert_attribute(linecap_symb, key"linecap"())
+    return to_skia_linecap(linecap)
+end
+function to_skia_linecap(linecap::Integer)
+    linecap == 0 && return SK_STROKE_CAP_BUTT
+    linecap == 1 && return SK_STROKE_CAP_SQUARE
+    linecap == 2 && return SK_STROKE_CAP_ROUND
+    error("Invalid linecap value: $linecap")
+end
+
+# Skia joinstyle mapping
+function to_skia_joinstyle(joinstyle_symb::Symbol)
+    joinstyle = Makie.convert_attribute(joinstyle_symb, key"joinstyle"())
+    return to_skia_joinstyle(joinstyle)
+end
+function to_skia_joinstyle(joinstyle::Integer)
+    joinstyle == 0 && return SK_STROKE_JOIN_MITER
+    joinstyle == 2 && return SK_STROKE_JOIN_ROUND
+    joinstyle == 3 && return SK_STROKE_JOIN_BEVEL
+    error("Invalid joinstyle value: $joinstyle")
+end
+
+"""
+Convert Makie's cumulative linestyle array to Skia's dash intervals.
+Returns a `sk_path_effect_t` pointer, or C_NULL if no dash.
+"""
+function to_skia_dash_effect(linestyle, linewidth)
+    isnothing(linestyle) && return C_NULL
+    linestyle isa AbstractVector || return C_NULL
+    linewidth isa AbstractArray && return C_NULL  # per-point linewidth: no global dash
+    pattern = diff(Float64.(linestyle)) .* linewidth
+    isodd(length(pattern)) && push!(pattern, 0.0)
+    intervals = Float32.(pattern)
+    return sk_path_effect_create_dash(intervals, Int32(length(intervals)), 0.0f0)
+end
+
+"""
+Apply a 2D affine transform to the Skia canvas via sk_matrix_t.
+The matrix is column-major:
+    | scaleX  skewX  transX |
+    | skewY   scaleY transY |
+    | persp0  persp1 persp2 |
+"""
+function set_canvas_matrix!(canvas, m::sk_matrix_t)
+    sk_canvas_set_matrix(canvas, Ref(m))
+    return
+end
+
+function concat_canvas_matrix!(canvas, m::sk_matrix_t)
+    sk_canvas_concat(canvas, Ref(m))
+    return
+end
+
+function sk_matrix_identity()
+    return sk_matrix_t(
+        1.0f0, 0.0f0, 0.0f0,
+        0.0f0, 1.0f0, 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    )
+end
+
+function sk_matrix_translate(tx, ty)
+    return sk_matrix_t(
+        1.0f0, 0.0f0, Float32(tx),
+        0.0f0, 1.0f0, Float32(ty),
+        0.0f0, 0.0f0, 1.0f0,
+    )
+end
+
+function sk_matrix_scale(sx, sy)
+    return sk_matrix_t(
+        Float32(sx), 0.0f0, 0.0f0,
+        0.0f0, Float32(sy), 0.0f0,
+        0.0f0, 0.0f0, 1.0f0,
+    )
+end
+
+function sk_matrix_from_2x3(m::Mat{2, 3, Float32})
+    # m is stored column-major as [m11 m21 m12 m22 m13 m23]
+    # Map to Skia's row-major:
+    # | m[1,1]  m[1,2]  m[1,3] |
+    # | m[2,1]  m[2,2]  m[2,3] |
+    # |   0       0       1    |
+    return sk_matrix_t(
+        m[1,1], m[1,2], m[1,3],
+        m[2,1], m[2,2], m[2,3],
+        0.0f0, 0.0f0, 1.0f0,
+    )
+end
+
+"""
+Create a Skia image from a Julia color matrix (for heatmaps/images).
+Returns a (sk_image_t pointer, pixel data reference to prevent GC).
+"""
+function colormatrix_to_skia_image(img::AbstractMatrix{<:Colorant})
+    # img has size (nx, ny) where nx = x-cells, ny = y-cells (Makie convention)
+    nx, ny = size(img)
+    # Skia image: width=nx pixels per row, height=ny rows
+    # Pixel data must be row-major (row 0 first, then row 1, etc.)
+    # Julia is column-major, so we store as (nx, ny) and pass row-by-row
+    # since Julia's memory layout for Matrix{UInt32}(undef, nx, ny) is
+    # column-major: pixels[1,1], pixels[2,1], ..., pixels[nx,1], pixels[1,2], ...
+    # That IS row-major when width=nx: row 0 = pixels[:,1], row 1 = pixels[:,2], etc.
+    pixels = Matrix{UInt32}(undef, nx, ny)
+    for j in 1:ny, i in 1:nx
+        c = img[i, j]
+        rgba = RGBA(c)
+        a = clamp(alpha(rgba), 0, 1)
+        r = clamp(red(rgba), 0, 1) * a  # premultiply
+        g = clamp(green(rgba), 0, 1) * a
+        b = clamp(blue(rgba), 0, 1) * a
+        # SK_COLOR_TYPE_RGBA_8888: bytes R,G,B,A in memory order
+        # On little-endian as UInt32: 0xAABBGGRR
+        pixels[i, j] = (round(UInt32, a * 255) << 24) |
+                        (round(UInt32, b * 255) << 16) |
+                        (round(UInt32, g * 255) << 8) |
+                        round(UInt32, r * 255)
+    end
+    colorspace = sk_colorspace_new_srgb()
+    info = Ref(sk_image_info_t(
+        colorspace,
+        SK_COLOR_TYPE_RGBA_8888,
+        SK_ALPHA_TYPE_PREMUL,
+        Int32(nx),
+        Int32(ny),
+    ))
+    rowbytes = Csize_t(nx * 4)
+    data = sk_data_new_with_copy(pointer(pixels), Csize_t(nx * ny * 4))
+    image = sk_image_new_raster_data(info, data, rowbytes)
+    return image, pixels  # return pixels to prevent GC
+end

--- a/SkiaMakie/src/utils.jl
+++ b/SkiaMakie/src/utils.jl
@@ -1,0 +1,381 @@
+function extract_attributes!(attr::ComputeGraph, inputs::Vector{Symbol}, output::Symbol)
+    return register_computation!(attr, inputs, [output]) do inputs, changed, outputs
+        return (inputs,)
+    end
+end
+
+################################################################################
+#                             Projection utilities                             #
+################################################################################
+
+using Makie: apply_transform, transform_func, unclipped_indices, to_model_space,
+    broadcast_foreach_index, is_clipped, is_visible
+
+function project_position(scene::Scene, transform_func::T, space::Symbol, point, model::Mat4, yflip::Bool = true) where {T}
+    point = Makie.apply_transform(transform_func, point)
+    return _project_position(scene, space, point, model, yflip)
+end
+
+function _project_position(scene::Scene, space, ps::AbstractArray{<:VecTypes{N, T1}}, model, yflip::Bool) where {N, T1}
+    return project_position(scene, space, ps, eachindex(ps), model, yflip)
+end
+
+function cairo_viewport_matrix(res::VecTypes{2}, yflip = true)
+    px_scale = Vec3d(0.5 * res[1], 0.5 * (yflip ? -res[2] : res[2]), 1)
+    px_offset = Vec3d(0.5 * res[1], 0.5 * res[2], 0)
+    return Makie.transformationmatrix(px_offset, px_scale)
+end
+
+function build_combined_transformation_matrix(
+        scene::Scene, space::Symbol, model::Mat4, yflip = true
+    )
+    f32convert = Makie.f32_convert_matrix(scene.float32convert, space)
+    M = Makie.get_space_to_space_matrix(scene, space, :clip) * f32convert * model
+    return cairo_viewport_matrix(scene.camera.resolution[], yflip) * M
+end
+
+function project_position(
+        scene::Scene, space::Symbol, ps::AbstractArray{<:VecTypes},
+        indices::Union{Vector{<:Integer}, Base.OneTo}, model::Mat4,
+        yflip::Bool = true
+    )
+    transform = build_combined_transformation_matrix(scene, space, model, yflip)
+    return project_position(Point2f, transform[Vec(1, 2, 4), Vec(1, 2, 3, 4)], ps, indices)
+end
+
+function project_position(
+        ::Type{PT}, transform::Mat{M, 4}, ps::AbstractVector{<:VecTypes},
+        indices::Vector{<:Integer}
+    ) where {N, PT <: VecTypes{N}, M}
+    output = Vector{PT}(undef, length(indices))
+    dims = Vec(ntuple(identity, N))
+    @inbounds for (i_out, i_in) in enumerate(indices)
+        p4d = to_ndim(Point4d, to_ndim(Point3d, ps[i_in], 0), 1)
+        px_pos = transform * p4d
+        output[i_out] = px_pos[dims] / px_pos[end]
+    end
+    return output
+end
+
+function project_position(
+        ::Type{PT}, transform::Mat{M, 4}, ps::AbstractArray{<:VecTypes},
+        indices::Base.OneTo
+    ) where {N, PT <: VecTypes{N}, M}
+    output = similar(ps, PT)
+    dims = Vec(ntuple(identity, N))
+    @inbounds for i in indices
+        p4d = to_ndim(Point4d, to_ndim(Point3d, ps[i], 0), 1)
+        px_pos = transform * p4d
+        output[i] = px_pos[dims] / px_pos[end]
+    end
+    return output
+end
+
+function _project_position(scene::Scene, space, point::VecTypes{N, T1}, model, yflip::Bool) where {N, T1 <: Real}
+    T = promote_type(Float32, T1)
+    res = scene.camera.resolution[]
+    p4d = to_ndim(Vec4{T}, to_ndim(Vec3{T}, point, 0), 1)
+    f32convert = Makie.f32_convert_matrix(scene.float32convert, space)
+    clip = Makie.space_to_clip(scene.camera, space) * f32convert * model * p4d
+    @inbounds begin
+        p = (clip ./ clip[4])[Vec(1, 2)]
+        p_yflip = Vec2f(p[1], (1.0f0 - 2.0f0 * yflip) * p[2])
+        p_0_to_1 = (p_yflip .+ 1.0f0) ./ 2.0f0
+    end
+    return p_0_to_1 .* res
+end
+
+function project_position(@nospecialize(scenelike), space, point, model, yflip::Bool = true)
+    scene = Makie.get_scene(scenelike)
+    return project_position(scene, Makie.transform_func(scenelike), space, point, model, yflip)
+end
+
+function project_shape(@nospecialize(scenelike), space, rect::Rect, model)
+    res = Makie.get_scene(scenelike).camera.resolution[]
+    mini = clamp.(project_position(scenelike, space, minimum(rect), model), -res, 2 .* res)
+    maxi = clamp.(project_position(scenelike, space, maximum(rect), model), -res, 2 .* res)
+    return Rect(mini, maxi .- mini)
+end
+
+function clip_poly(clip_planes::Vector{Plane3f}, ps::AbstractVector{PT}, space::Symbol, model::Mat4) where {PT <: VecTypes{2}}
+    if isempty(clip_planes) || !Makie.is_data_space(space)
+        return ps
+    end
+    planes = to_model_space(model, clip_planes)
+    last_distance = Makie.min_clip_distance(planes, first(ps))
+    last_point = first(ps)
+    output = sizehint!(PT[], length(ps))
+    for p in ps
+        d = Makie.min_clip_distance(planes, p)
+        if (last_distance < 0) && (d >= 0)
+            clip_point = - last_distance * (p - last_point) / (d - last_distance) + last_point
+            push!(output, clip_point, p)
+        elseif (last_distance >= 0) && (d < 0)
+            clip_point = - last_distance * (p - last_point) / (d - last_distance) + last_point
+            push!(output, clip_point)
+        elseif (last_distance >= 0) && (d >= 0)
+            push!(output, p)
+        end
+        last_point = p
+        last_distance = d
+    end
+    return output
+end
+
+function clip_shape(clip_planes::Vector{Plane3f}, shape::Rect2, space::Symbol, model::Mat4)
+    if !Makie.is_data_space(space) || isempty(clip_planes)
+        return shape
+    end
+    xy = origin(shape)
+    w, h = widths(shape)
+    ps = Point2d[xy, xy + Vec2d(w, 0), xy + Vec2d(w, h), xy + Vec2d(0, h)]
+    if any(p -> Makie.is_clipped(clip_planes, p), ps)
+        push!(ps, xy)
+        ps = clip_poly(clip_planes, ps, space, model)
+        commands = Makie.PathCommand[MoveTo(ps[1]), LineTo.(ps[2:end])..., ClosePath()]
+        return BezierPath(commands::Vector{Makie.PathCommand})
+    else
+        return shape
+    end
+end
+
+function clip_shape(clip_planes::Vector{Plane3f}, shape::BezierPath, space::Symbol, model::Mat4)
+    return shape
+end
+
+function project_polygon(@nospecialize(scenelike), space, poly::Polygon{N, T}, clip_planes, model) where {N, T}
+    PT = Point{N, Makie.float_type(T)}
+    ext = decompose(PT, poly.exterior)
+    project(p) = PT(project_position(scenelike, space, p, model))
+    ext_proj = PT[project(p) for p in clip_poly(clip_planes, ext, space, model)]
+    interiors_proj = Vector{PT}[
+        PT[project(p) for p in clip_poly(clip_planes, decompose(PT, points), space, model)]
+            for points in poly.interiors
+    ]
+    return Polygon(ext_proj, interiors_proj)
+end
+
+function project_multipolygon(@nospecialize(scenelike), space, multipoly::MP, clip_planes, model) where {MP <: MultiPolygon}
+    return MultiPolygon(project_polygon.(Ref(scenelike), Ref(space), multipoly.polygons, Ref(clip_planes), Ref(model)))
+end
+
+function clip2screen(p, res)
+    s = Vec2f(0.5f0, -0.5f0) .* p[Vec(1, 2)] / p[4] .+ 0.5f0
+    return res .* s
+end
+
+########################################
+#          Rotation handling           #
+########################################
+
+function to_2d_rotation(x)
+    quat = to_rotation(x)
+    return -Makie.quaternion_to_2d_angle(quat)
+end
+
+function to_2d_rotation(::Makie.Billboard)
+    @warn "This should not be reachable!"
+    return 0
+end
+
+remove_billboard(x) = x
+remove_billboard(b::Makie.Billboard) = b.rotation
+
+to_2d_rotation(quat::Makie.Quaternion) = -Makie.quaternion_to_2d_angle(quat)
+to_2d_rotation(vec::Vec2f) = atan(vec[1], vec[2])
+to_2d_rotation(n::Real) = n
+
+################################################################################
+#                                Color handling                                #
+################################################################################
+
+function rgbatuple(c::Colorant)
+    rgba = RGBA(c)
+    return red(rgba), green(rgba), blue(rgba), alpha(rgba)
+end
+
+function rgbatuple(c)
+    colorant = to_color(c)
+    if !(colorant isa Colorant)
+        error("Can't convert $(c) to a colorant")
+    end
+    return rgbatuple(colorant)
+end
+
+premultiplied_rgba(a::AbstractArray{<:ColorAlpha}) = map(premultiplied_rgba, a)
+premultiplied_rgba(a::AbstractArray{<:Color}) = RGBA.(a)
+premultiplied_rgba(r::RGBA) = RGBA(r.r * r.alpha, r.g * r.alpha, r.b * r.alpha, r.alpha)
+premultiplied_rgba(c::Colorant) = premultiplied_rgba(RGBA(c))
+
+to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, premultiplied_rgba(c)))
+
+########################################
+#        Common color utilities        #
+########################################
+
+function to_skia_plotcolor(colors::Union{AbstractVector, Number}, plot_object)
+    cmap = Makie.assemble_colors(colors, Observable(colors), plot_object)
+    return to_color(to_value(cmap))
+end
+
+function to_skia_plotcolor(color, plot_object)
+    return to_color((color, to_value(plot_object.alpha)))
+end
+
+#######################################
+#        Stroking properties          #
+#######################################
+
+to_skia_linestyle(::Nothing, ::Any) = nothing
+to_skia_linestyle(::AbstractVector, ::AbstractArray) = nothing
+function to_skia_linestyle(linestyle::AbstractVector, linewidth::Real)
+    pattern = diff(Float64.(linestyle)) .* linewidth
+    isodd(length(pattern)) && push!(pattern, 0)
+    return pattern
+end
+
+function to_skia_miter_limit(miter_limit)
+    return 2.0f0 * Makie.miter_angle_to_distance(miter_limit)
+end
+
+########################################
+#        Marker conversion API         #
+########################################
+
+skia_scatter_marker(marker) = Makie.to_spritemarker(marker)
+
+########################################
+#     Image/heatmap helpers            #
+########################################
+
+function to_skia_image(img::AbstractMatrix{<:Colorant})
+    return to_skia_image(to_uint32_color.(img))
+end
+
+function to_skia_image(img::AbstractMatrix{UInt32})
+    # Return permuted for row-major Skia layout
+    return convert(Matrix, permutedims(img))
+end
+
+################################################################################
+#                                Mesh handling                                 #
+################################################################################
+
+struct FaceIterator{Iteration, T, F, ET} <: AbstractVector{ET}
+    data::T
+    faces::F
+end
+
+function (::Type{FaceIterator{Typ}})(data::T, faces::F) where {Typ, T, F}
+    return FaceIterator{Typ, T, F}(data, faces)
+end
+function (::Type{FaceIterator{Typ, T, F}})(data::AbstractVector, faces::F) where {Typ, F, T}
+    return FaceIterator{Typ, T, F, NTuple{3, eltype(data)}}(data, faces)
+end
+function (::Type{FaceIterator{Typ, T, F}})(data::T, faces::F) where {Typ, T, F}
+    return FaceIterator{Typ, T, F, NTuple{3, T}}(data, faces)
+end
+function FaceIterator(data::AbstractVector, faces)
+    return if length(data) == length(faces)
+        FaceIterator{:PerFace}(data, faces)
+    else
+        FaceIterator{:PerVert}(data, faces)
+    end
+end
+
+Base.size(fi::FaceIterator) = size(fi.faces)
+Base.getindex(fi::FaceIterator{:PerFace}, i::Integer) = fi.data[i]
+Base.getindex(fi::FaceIterator{:PerVert}, i::Integer) = fi.data[fi.faces[i]]
+Base.getindex(fi::FaceIterator{:Const}, i::Integer) = ntuple(i -> fi.data, 3)
+
+color_or_nothing(c) = isnothing(c) ? nothing : to_color(c)
+function get_color_attr(attributes, attribute)::Union{Nothing, RGBAf}
+    return color_or_nothing(to_value(get(attributes, attribute, nothing)))
+end
+
+function per_face_colors(_color, matcap, faces, normals, uv)
+    color = to_color(_color)
+    if !isnothing(matcap)
+        wsize1 = reverse(size(matcap::Matrix{RGBAf}))
+        wh1 = wsize1 .- 1
+        cvec = map(normals) do n
+            muv = 0.5n[Vec(1, 2)] .+ Vec2f(0.5)
+            x, y = clamp.(round.(Int, Tuple(muv) .* wh1) .+ 1, 1, wh1)
+            return matcap[end - (y - 1), x]
+        end
+        return FaceIterator(cvec, faces)
+    elseif color isa Colorant
+        return FaceIterator{:Const}(color::RGBAf, faces)
+    elseif color isa AbstractVector{<:Colorant}
+        return FaceIterator{:PerVert}(color::Vector{RGBAf}, faces)
+    elseif color isa AbstractMatrix{<:Colorant} && !isnothing(uv)
+        wsize2 = size(color::Matrix{RGBAf})
+        wh2 = wsize2 .- 1
+        cvec = map(uv::Vector{Vec2f}) do uv
+            x, y = clamp.(round.(Int, uv .* wh2) .+ 1, 1, wsize2)
+            return color[x, y]::RGBAf
+        end
+        return FaceIterator(cvec, faces)
+    end
+    error("Unsupported Color type: $(typeof(color))")
+end
+
+################################################################################
+#                                Font handling                                 #
+################################################################################
+
+function best_font(c::Char, font = Makie.defaultfont())
+    if Base.@lock font.lock Makie.FreeType.FT_Get_Char_Index(font, c) == 0
+        for afont in Makie.alternativefonts()
+            if Base.@lock afont.lock Makie.FreeType.FT_Get_Char_Index(afont, c) != 0
+                return afont
+            end
+        end
+        return Makie.defaultfont()
+    end
+    return font
+end
+
+is_approx_zero(x) = isapprox(x, 0)
+is_approx_zero(v::VecTypes) = any(x -> isapprox(x, 0), v)
+
+function is_degenerate(M::Mat2f)
+    v1 = M[Vec(1, 2), 1]
+    v2 = M[Vec(1, 2), 2]
+    l1 = dot(v1, v1)
+    l2 = dot(v2, v2)
+    return any(isnan, M) || l1 ≈ 0 || l2 ≈ 0 || dot(v1, v2)^2 ≈ l1 * l2
+end
+
+zero_normalize(v::AbstractVector{T}) where {T} = v ./ (norm(v) + eps(zero(T)))
+
+########################################
+#     Screen-space projection for mesh #
+########################################
+
+function cairo_project_to_screen_impl(projectionview, resolution, model, pos, output_type = Point2f, yflip = true)
+    M = cairo_viewport_matrix(resolution, yflip) * projectionview * model
+    return project_position(output_type, M, pos, eachindex(pos))
+end
+
+function cairo_project_to_screen_impl(projectionview, resolution, model, pos::VecTypes, output_type = Point2f, yflip = true)
+    p4d = to_ndim(Point4d, to_ndim(Point3d, pos, 0), 1)
+    p4d = model * p4d
+    p4d = projectionview * p4d
+    p4d = cairo_viewport_matrix(resolution, yflip) * p4d
+    return output_type(p4d) / p4d[4]
+end
+
+function cairo_project_to_screen(
+        attr;
+        input_name = :positions_transformed_f32c, yflip = true, output_type = Point2f
+    )
+    Makie.register_computation!(
+        attr,
+        [:projectionview, :resolution, :model_f32c, input_name], [:cairo_screen_pos]
+    ) do inputs, changed, cached
+        output = cairo_project_to_screen_impl(values(inputs)..., output_type, yflip)
+        return (output,)
+    end
+    return attr[:cairo_screen_pos][]
+end

--- a/SkiaMakie/test/Project.toml
+++ b/SkiaMakie/test/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+ReferenceTests = "d37af2e0-5618-4e00-9939-d430db56ee94"
+SkiaMakie = "76793118-35c1-4747-aff5-edca4b36395e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+ReferenceTests = {path = "../../ReferenceTests"}
+SkiaMakie = {path = ".."}

--- a/SkiaMakie/test/runtests.jl
+++ b/SkiaMakie/test/runtests.jl
@@ -1,0 +1,47 @@
+ENV["ENABLE_COMPUTE_CHECKS"] = "true"
+
+using Test
+using SkiaMakie
+using Makie.FileIO
+using ReferenceTests
+
+# Same excludes as CairoMakie — these tests are known to not work on 2D raster backends
+excludes = Set([
+    "Streamplot animation",
+    "Axis + Surface",
+    "Streamplot 3D",
+    "Meshscatter Function",
+    "Record Video",
+    "Comparing contours, image, surfaces and heatmaps",
+    "Animated surface and wireframe",
+    "surface + contour3d",
+    "Orthographic Camera",
+    "3D Contour with 2D contour slices",
+    "Surface with image",
+    "FEM poly and mesh",
+    "Image on Surface Sphere",
+    "Arrows 3D",
+    "Connected Sphere",
+    "Depth Shift",
+    "Order Independent Transparency",
+    "scatter with glow",
+    "Textured meshscatter",
+    "Voxel - texture mapping",
+    "Voxel uvs",
+    "picking",
+    "MetaMesh (Sponza)",
+    "Mesh with 3d volume texture",
+    "Volume absorption",
+    "DataInspector", "DataInspector 2",
+])
+
+functions = [:volume, :volume!, :uv_mesh]
+
+@testset "refimages" begin
+    SkiaMakie.activate!(type = "png", px_per_unit = 1)
+    ReferenceTests.mark_broken_tests(excludes, functions = functions)
+    recorded_files, recording_dir = @include_reference_tests SkiaMakie "refimages.jl"
+    missing_images, scores = ReferenceTests.record_comparison(recording_dir, "SkiaMakie")
+    # Use a higher threshold than CairoMakie (0.05) since we expect small AA differences
+    ReferenceTests.test_comparison(scores; threshold = 0.1)
+end


### PR DESCRIPTION
## Summary
- New Makie backend using [Skia.jl](https://github.com/stensmo/Skia.jl) (via Skia_jll) as a potential CairoMakie alternative
- Implements all core 2D plot primitives: lines, scatter, text, heatmap, image, mesh, poly, band, contourf, errorbars, etc.
- Text rendering uses Skia's native text blob API with FreeType font data → selectable text in PDF output
- PNG raster and PDF output functional, SVG not yet implemented
- Reference tests compare against CairoMakie references via backend alias

## Perceptual comparison (PixelMatch) vs CairoMakie
| Plot type | Perceptual diff |
|-----------|----------------|
| scatter, barplot, histogram, errorbars, stairs | 0.01% |
| band, contourf, lines+legend | 0.01% |
| poly shapes | 0.02% |
| text (rotated, multi-size) | 0.02% |
| image (Makie logo) | 0.03% |
| heatmap (non-interpolated) | **0%** (pixel-perfect) |
| heatmap (interpolated) | 0.14% |

## Known limitations
- No SVG output yet
- Mesh uses flat per-triangle color (no gradient mesh patches like Cairo)
- No `AbstractPattern` support
- Text slightly heavier than Cairo (inherent Skia rasterizer difference)
- 3D features excluded (same as CairoMakie)

## How these changes were tested
- Side-by-side colorbuffer comparison of 12+ plot types using PixelMatch
- PDF output verified with selectable text
- Reference test infrastructure patched to compare SkiaMakie against CairoMakie references

Created with the help of [Claude Code](https://claude.com/claude-code)