### PR TITLE
feat(axis): Add Pretransformed scale for pre-transformed data

### DIFF
--- a/Makie/src/layouting/transformation.jl
+++ b/Makie/src/layouting/transformation.jl
@@ -602,9 +602,8 @@ end
 inverse_transform(F::Tuple) = map(inverse_transform, F)
 inverse_transform(s::ReversibleScale) = s.inverse
 
-function is_identity_transform(t)
-    return t === identity || t isa Tuple && all(x -> x === identity, t)
-end
+is_identity_transform(t) = t === identity
+is_identity_transform(t::Tuple) = all(is_identity_transform, t)
 
 
 ################################################################################

--- a/Makie/src/makielayout/MakieLayout.jl
+++ b/Makie/src/makielayout/MakieLayout.jl
@@ -19,6 +19,7 @@ include("defaultattributes.jl")
 include("lineaxis.jl")
 include("interactions.jl")
 include("blocks/axis.jl")
+include("pretransformed.jl")
 include("blocks/axis3d.jl")
 include("blocks/polaraxis.jl")
 include("blocks/colorbar.jl")
@@ -55,7 +56,7 @@ export Textbox
 export linkxaxes!, linkyaxes!, linkaxes!
 export AxisAspect, DataAspect
 export autolimits!, limits!, reset_limits!, rlims!, thetalims!
-export LinearTicks, WilkinsonTicks, MultiplesTicks, IntervalsBetween, LogTicks, AngularTicks
+export LinearTicks, WilkinsonTicks, MultiplesTicks, IntervalsBetween, LogTicks, AngularTicks, Pretransformed
 export hidexdecorations!, hideydecorations!, hidezdecorations!, hidedecorations!, hidespines!
 export hiderdecorations!, hidethetadecorations!
 export tight_xticklabel_spacing!, tight_yticklabel_spacing!, tight_ticklabel_spacing!, tightlimits!

--- a/Makie/src/makielayout/pretransformed.jl
+++ b/Makie/src/makielayout/pretransformed.jl
@@ -1,0 +1,76 @@
+"""
+    Pretransformed(f)
+
+A scale for axes where data has already been transformed by `f` before plotting.
+
+The axis remains linear (so all plot types like `ablines!` work), but ticks are
+computed and labelled as if the original scale `f` were active.
+
+# Example
+
+```julia
+# Plot pre-transformed data with log-style ticks
+xs = range(0, 3, length=100)         # already in log10 space
+ys = xs .^ 2
+lines(xs, ys; axis = (xscale = Pretransformed(log10),))
+# x-axis ticks will read "10⁰", "10¹", "10²", "10³" at positions 0,1,2,3
+```
+"""
+struct Pretransformed{F} <: Function
+    f::F
+end
+
+# Acts as identity for data transformation — data is already in transformed space
+(::Pretransformed)(x) = x
+
+Makie.inverse_transform(::Pretransformed) = identity
+
+function Makie.defaultlimits(p::Pretransformed)
+    dl = Makie.defaultlimits(p.f)
+    return (p.f(dl[1]), p.f(dl[2]))
+end
+
+Makie.defined_interval(::Pretransformed) = OpenInterval(-Inf, Inf)
+
+Makie.is_identity_transform(::Pretransformed) = true
+
+# All tick specifications are in original (untransformed) data space.
+# Results are positioned in the pre-transformed axis space via p.f.
+
+function _pretransformed_ticks(p::Pretransformed, vmin, vmax)
+    inv = Makie.inverse_transform(p.f)
+    return inv(vmin), inv(vmax)
+end
+
+function Makie.get_ticks(::Makie.Automatic, p::Pretransformed, formatter, vmin, vmax)
+    vmin_orig, vmax_orig = _pretransformed_ticks(p, vmin, vmax)
+    tickvalues_orig, ticklabels = Makie.get_ticks(Makie.automatic, p.f, formatter, vmin_orig, vmax_orig)
+    return p.f.(tickvalues_orig), ticklabels
+end
+
+# Resolve ambiguity with get_ticks(::Tuple{Any,Any}, _, ::Automatic, ...)
+function Makie.get_ticks(ticks_and_labels::Tuple{Any, Any}, p::Pretransformed, ::Makie.Automatic, vmin, vmax)
+    tickvalues = p.f.(ticks_and_labels[1])
+    return tickvalues, ticks_and_labels[2]
+end
+
+# Resolve ambiguity with get_ticks(::Function, _, formatter, ...)
+function Makie.get_ticks(tickfunction::Function, p::Pretransformed, formatter, vmin, vmax)
+    vmin_orig, vmax_orig = _pretransformed_ticks(p, vmin, vmax)
+    result = tickfunction(vmin_orig, vmax_orig)
+    if result isa Tuple{Any, Any}
+        tickvalues_orig, ticklabels = result
+    else
+        tickvalues_orig = result
+        ticklabels = Makie.get_ticklabels(formatter, tickvalues_orig)
+    end
+    return p.f.(tickvalues_orig), ticklabels
+end
+
+# Generic: arrays, LinearTicks, WilkinsonTicks, etc.
+function Makie.get_ticks(ticks, p::Pretransformed, formatter, vmin, vmax)
+    vmin_orig, vmax_orig = _pretransformed_ticks(p, vmin, vmax)
+    tickvalues_orig = Makie.get_tickvalues(ticks, p.f, vmin_orig, vmax_orig)
+    ticklabels = Makie.get_ticklabels(formatter, tickvalues_orig)
+    return p.f.(tickvalues_orig), ticklabels
+end


### PR DESCRIPTION
Sometimes it's quite difficult to make a plot work with `scale = log10` because some plot types don't play well with these transformations, like ABLines. So I thought what might make sense is to make it easier to pretransform the data and then show it in a way that matches `scale = log10`. This is all about the ticks, but I've found it's a bit simpler to set up to work with other tick types if `Pretransformed` is a scale and not a tick object.

## Summary

- Add `Pretransformed(f)` scale type that displays ticks as if scale `f` were active, while keeping the axis linear
- Enables plot types like `ablines!` that require identity transforms, while still showing meaningful (e.g. log-spaced) tick labels
- Tick specifications (manual arrays, tuples, functions) are interpreted in the original data space and mapped to axis positions automatically
- Makes `is_identity_transform` recursive for tuples so `Pretransformed` is correctly recognized

## Example

```julia
using CairoMakie

fig = Figure(size=(700, 500))

ax1 = Axis(fig[1, 1], xscale=Pretransformed(log10), title="Pretransformed(log10)")
xs = range(0, 3, length=100)
lines!(ax1, xs, sin.(xs .* 2) .+ 2)
ablines!(ax1, 1.5, 0.3, color=:red, linewidth=2, label="ablines! works")
axislegend(ax1, position=:lt)

ax2 = Axis(fig[1, 2], xscale=Pretransformed(log10),
    xticks=[1, 5, 10, 50, 100, 500, 1000], title="Manual ticks in data space")
lines!(ax2, xs, xs .^ 2)

ax3 = Axis(fig[2, 1], xscale=Pretransformed(log2), title="Pretransformed(log2)")
xs2 = range(1, 10, length=100)
lines!(ax3, xs2, 2 .* xs2 .+ 1)

ax4 = Axis(fig[2, 2], xscale=Pretransformed(log10),
    xticks=([1, 10, 100, 1000], ["1", "10", "100", "1k"]), title="Tuple ticks")
lines!(ax4, xs, xs .^ 1.5)

fig
```

<img width="700" height="500" alt="Pretransformed scale examples showing log10, log2, manual ticks, and tuple ticks" src="https://github.com/user-attachments/assets/d63b0085-6f9b-4d7d-bac1-b5262be08604">

## Checks

- Verified automatic ticks produce correct positions and superscript labels for log10 and log2
- Verified manual tick arrays are interpreted in original data space (`[1, 10, 100, 1000]` → positions `[0, 1, 2, 3]`)
- Verified tuple ticks `([values], [labels])` transform values correctly and preserve labels
- Verified `ablines!` works (no identity transform error)
- Verified custom tick formatters work