### PR TITLE
Track `transformation` keyword in plot.kw

### DIFF
--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -857,6 +857,7 @@ function connect_plot!(parent::SceneLike, plot::Plot{Func}) where {Func}
 
     documented_attr = plot_attributes(scene, Plot{Func})
     for (k, v) in plot.kw
+        k === :transformation && continue
         if !haskey(plot.attributes.outputs, k)
             if haskey(documented_attr, k)
                 error("User Attribute $k did not get registered.")

--- a/Makie/src/interfaces.jl
+++ b/Makie/src/interfaces.jl
@@ -136,7 +136,7 @@ function plot!(::Plot{F, Args}) where {F, Args}
 end
 
 function handle_transformation!(plot, parent)
-    t_user = to_value(pop!(plot.kw, :transformation, :automatic))
+    t_user = to_value(get!(plot.kw, :transformation, :automatic))
 
     # Handle passing transform!() inputs through transformation
     if t_user isa Tuple{Symbol, <:Real} || t_user isa Union{Attributes, AbstractDict, NamedTuple}

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -584,6 +584,12 @@ function initialize_block!(ax::Axis; palette = nothing)
     return ax
 end
 
+"""
+    add_axis_limits!(plot)
+
+Adds `axis_limits` and `axis_limits_transformed` as nodes to the plot graph.
+This is only available with `Axis`.
+"""
 function add_axis_limits!(plot)
     scene = parent_scene(plot)
     if !haskey(scene.compute, :axis_limits)


### PR DESCRIPTION
# Description

Small change to allow recipes to see what inheritance rules transformations followed. This would allow recipes to react to getting transformed data, if that is ever necessary.

This might be useful for an alternative solution to #5574 where plots are added with `plot!(ax, transformed_data...., transformation = :inherit_model)`. Though I don't believe h/vlines, h/vspan and ablines actually need this. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
