### PR TITLE
Add argument-level `preferred_axis_attributes` hook

### DIFF
--- a/Makie/src/figureplotting.jl
+++ b/Makie/src/figureplotting.jl
@@ -154,6 +154,21 @@ NamedTuple).
 """
 preferred_axis_attributes(p::Plot, ::Type{<:Block}) = NamedTuple()
 
+"""
+    preferred_axis_attributes(arg)
+
+Returns axis attributes for a single plot argument. Data types that are passed
+as arguments to plot functions can define this method to provide default axis
+labels, scales, limits, etc.
+
+Analogous to `args_preferred_axis(arg)` which determines the axis *type* from
+arguments — this determines axis *attributes*.
+
+The return type should be a NamedTuple or other iterable of key-value pairs.
+The default returns an empty NamedTuple.
+"""
+preferred_axis_attributes(::Any) = NamedTuple()
+
 to_dict(dict::Dict) = convert(Dict{Symbol, Any}, dict)
 to_dict(nt::NamedTuple) = Dict{Symbol, Any}(pairs(nt))
 to_dict(attr::Attributes) = attributes(attr)
@@ -179,11 +194,20 @@ function create_axis_for_plot(figure::Figure, plot::AbstractPlot, attributes::Di
     bbox = pop!(axis_kw, :bbox, nothing)
     set_axis_attributes!(AxType, axis_kw, plot)
 
-    # Add defaults generated based on the plot creating the axis
+    # Add defaults generated based on the plot creating the axis.
+    # First from the plot type (recipe-level defaults):
     preferred_attr = preferred_axis_attributes(plot, AxType)
     attr = something(preferred_attr, NamedTuple())
     for (k, v) in pairs(attr)
         get!(axis_kw, k, v)
+    end
+
+    # Then from individual arguments (data-type-level defaults),
+    # mirroring args_preferred_axis(arg) for axis type selection:
+    for arg in plot.args[]
+        for (k, v) in pairs(preferred_axis_attributes(arg))
+            get!(axis_kw, k, v)
+        end
     end
 
     return _block(AxType, figure, [], axis_kw, bbox)

--- a/Makie/src/figureplotting.jl
+++ b/Makie/src/figureplotting.jl
@@ -142,32 +142,29 @@ args_preferred_axis(::AbstractVector{<:Point2}) = Axis
 # axis attributes
 
 """
-    preferred_axis_attributes(plot::Plot, ::Type{<:Block})
+    preferred_axis_attributes(::Type{<:Block}, plot::Plot)
 
 Sets the default axis attributes when a plot creates an axis. The axis may be
 created based on `args_preferred_axis()` or by the user setting
 `plot(..., axis = (type == axistype, ...))`. The latter may also overwrite
 attributes returned by this function.
 
+Recipe authors can override this to provide defaults for their plot type:
+
+    preferred_axis_attributes(::Type{<:Axis}, ::MyPlot) = (xlabel = "x", ...)
+
+The default unpacks `plot.args[]` and delegates to the args form, so data
+types used as plot arguments can provide axis defaults by dispatching on
+their type:
+
+    preferred_axis_attributes(::Type{<:Axis}, ::MyData, args...) = (xlabel = "x", ...)
+
 The return type is expected to be a Dict-like collection (e.g. Attributes, Dict,
 NamedTuple).
 """
-preferred_axis_attributes(p::Plot, ::Type{<:Block}) = NamedTuple()
-
-"""
-    preferred_axis_attributes(arg)
-
-Returns axis attributes for a single plot argument. Data types that are passed
-as arguments to plot functions can define this method to provide default axis
-labels, scales, limits, etc.
-
-Analogous to `args_preferred_axis(arg)` which determines the axis *type* from
-arguments — this determines axis *attributes*.
-
-The return type should be a NamedTuple or other iterable of key-value pairs.
-The default returns an empty NamedTuple.
-"""
-preferred_axis_attributes(::Any) = NamedTuple()
+preferred_axis_attributes(::Type{T}, plot::Plot) where {T <: Block} =
+    preferred_axis_attributes(T, plot.args[]...)
+preferred_axis_attributes(::Type{<:Block}, args...) = NamedTuple()
 
 to_dict(dict::Dict) = convert(Dict{Symbol, Any}, dict)
 to_dict(nt::NamedTuple) = Dict{Symbol, Any}(pairs(nt))
@@ -194,20 +191,11 @@ function create_axis_for_plot(figure::Figure, plot::AbstractPlot, attributes::Di
     bbox = pop!(axis_kw, :bbox, nothing)
     set_axis_attributes!(AxType, axis_kw, plot)
 
-    # Add defaults generated based on the plot creating the axis.
-    # First from the plot type (recipe-level defaults):
-    preferred_attr = preferred_axis_attributes(plot, AxType)
+    # Add defaults generated based on the plot creating the axis
+    preferred_attr = preferred_axis_attributes(AxType, plot)
     attr = something(preferred_attr, NamedTuple())
     for (k, v) in pairs(attr)
         get!(axis_kw, k, v)
-    end
-
-    # Then from individual arguments (data-type-level defaults),
-    # mirroring args_preferred_axis(arg) for axis type selection:
-    for arg in plot.args[]
-        for (k, v) in pairs(preferred_axis_attributes(arg))
-            get!(axis_kw, k, v)
-        end
     end
 
     return _block(AxType, figure, [], axis_kw, bbox)

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -26,13 +26,13 @@ end
 end
 
 @testset "Argument-level axis hints" begin
-    # Data types can define preferred_axis_attributes(arg) to provide
-    # axis defaults when used as plot arguments.
+    # Data types can define preferred_axis_attributes(AxisType, args...)
+    # to provide axis defaults when used as plot arguments.
     struct _AxisHintData
         xlabel::String
         ylabel::String
     end
-    function Makie.preferred_axis_attributes(d::_AxisHintData)
+    function Makie.preferred_axis_attributes(::Type{<:Axis}, d::_AxisHintData, args...)
         return (xlabel = d.xlabel, ylabel = d.ylabel)
     end
     function Makie.convert_arguments(::Type{<:Scatter}, d::_AxisHintData)

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -25,6 +25,42 @@ end
     @test p2 isa Scatter
 end
 
+@testset "Argument-level axis hints" begin
+    # Data types can define preferred_axis_attributes(arg) to provide
+    # axis defaults when used as plot arguments.
+    struct _AxisHintData
+        xlabel::String
+        ylabel::String
+    end
+    function Makie.preferred_axis_attributes(d::_AxisHintData)
+        return (xlabel = d.xlabel, ylabel = d.ylabel)
+    end
+    function Makie.convert_arguments(::Type{<:Scatter}, d::_AxisHintData)
+        return ([Point2f(i, sin(i)) for i in 1:5],)
+    end
+
+    fig = Figure()
+    ax, p = scatter(fig[1, 1], _AxisHintData("arg_x", "arg_y"))
+    @test ax.xlabel[] == "arg_x"
+    @test ax.ylabel[] == "arg_y"
+
+    # User axis keyword overrides argument-level hints
+    ax2, p2 = scatter(fig[1, 2], _AxisHintData("arg_x", "arg_y"), axis = (ylabel = "override",))
+    @test ax2.xlabel[] == "arg_x"
+    @test ax2.ylabel[] == "override"
+
+    # Non-hinting arguments are unaffected
+    fig2 = Figure()
+    ax3, p3 = scatter(fig2[1, 1], [1, 2, 3], [4, 5, 6])
+    @test ax3.xlabel[] == ""
+    @test ax3.ylabel[] == ""
+
+    # Auto-created Figure
+    fig3, ax4, p4 = scatter(_AxisHintData("auto_x", "auto_y"))
+    @test ax4.xlabel[] == "auto_x"
+    @test ax4.ylabel[] == "auto_y"
+end
+
 @testset "AxisPlot and Axes" begin
     fig = Figure()
     @test current_axis() === nothing

--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -322,14 +322,14 @@ Makie.conversion_trait(::Type{<:HintLines}) = PointBased()
 Makie.plot!(p::HintLines) = lines!(p, p.attributes, p[1])
 
 Makie.args_preferred_axis(::HintLines, ::AbstractVector{<:VecTypes{3}}) = Axis3
-function Makie.preferred_axis_attributes(::HintLines, ::Type{<:Axis})
+function Makie.preferred_axis_attributes(::Type{<:Axis}, ::HintLines)
     return (
         xlabel = "x", ylabel = "y label", title = "Title",
         xticklabelsize = 10, xticklabelrotation = 0.3,
         xgridvisible = false,
     )
 end
-function Makie.preferred_axis_attributes(::HintLines, ::Type{<:Axis3})
+function Makie.preferred_axis_attributes(::Type{<:Axis3}, ::HintLines)
     return (
         title = "3D", xticklabelsize = 10, zticklabelsize = 5,
         xypanelcolor = RGBf(0.7, 0.9, 1),

--- a/docs/src/explanations/recipes.md
+++ b/docs/src/explanations/recipes.md
@@ -191,11 +191,20 @@ Makie.args_preferred_axis(x, y, z) =  Makie.LScene
 These function are listed in decending priority.
 If none of them are defined for a given plot type or argument set, `Makie.Axis` will be used as the default.
 
-You can also control the attribute an axis is initialized with by implementing
+You can also control the attributes an axis is initialized with by implementing
 
 ```julia
-function Makie.preferred_axis_attributes(::MyPlot, ::Type{<:Axis})
+function Makie.preferred_axis_attributes(::Type{<:Axis}, ::MyPlot)
     return (xgridvisible = false, ygridvisible = false)
+end
+```
+
+Data types used as plot arguments can also provide axis defaults by dispatching
+on their type in the args form:
+
+```julia
+function Makie.preferred_axis_attributes(::Type{<:Axis}, ::MyData, args...)
+    return (xlabel = "x", ylabel = "y")
 end
 ```
 


### PR DESCRIPTION
This adds to the new `args_preferred_axis` feature a single-argument `preferred_axis_attributes(arg)` hook, so that data types passed as plot arguments can provide axis defaults.                                                        
                                           
Motivation: In MakieExtra.jl, `FPlot` is a data type (not a recipe) that carries axis metadata — labels derived from accessor functions, scales, limits. It participates in plotting via `convert_arguments`, not via `@recipe`. With the current PR, the only way for `FPlot` to influence axis attributes is either type piracy (overriding `preferred_axis_attributes(::Plot, ::Type{<:Block})` for all plots) or wrapping every plot call in a custom recipe.

The single-argument form lets MakieExtra define `Makie.preferred_axis_attributes(::FPlot)` — no    
  piracy, no wrapper:
         
```jl                                                                                                  
# MakieExtra side — one method on its own type
function Makie.preferred_axis_attributes(fplt::FPlot)
    # compute labels/scales from FPlot's accessor functions
end

# user code — just works
scatter(fig[1,1], fplt)  # axis labels set automatically
```                                                                                                   
  Implementation: Mirrors the existing `args_preferred_axis(arg)` pattern for axis type selection. In `create_axis_for_plot`, after applying recipe-level hints, iterate `plot.args[]` and call `preferred_axis_attributes(arg)` on each. Recipe-level hints and user axis keywords both take priority. The fallback `preferred_axis_attributes(::Any) = NamedTuple()` is a no-op.

NB: The names might be more intuitive as `axis_hint` and `attribute_hint` or something.
  
---

Note: Claude was used for this PR.

cc @aplavin 