### PR TITLE
Fixed `hspan`/`vspan` dim conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - CairoMakie now batches glyphs from the same text string into a single PDF/SVG text object, so that text can be selected and edited as a unit in vector editors like Inkscape and Illustrator [#5561](https://github.com/MakieOrg/Makie.jl/pull/5561)
 - Fixed `annotation` not showing lines/arrows when `text` is blank [#5560](https://github.com/MakieOrg/Makie.jl/pull/5560)
 - Fixed error/nan offsets in `annotation!()` when an annotation is perfectly centered [#5568](https://github.com/MakieOrg/Makie.jl/pull/5568)
+- Fixed `hspan`/`vspan` dim conversions so both span bounds are converted on the plotted axis instead of being split across x/y dimensions.
 
 ## [0.24.9] - 2026-03-04
 

--- a/Makie/src/basic_recipes/hvspan.jl
+++ b/Makie/src/basic_recipes/hvspan.jl
@@ -34,6 +34,9 @@ Both bounds can be passed together as an interval `xs_lowhigh`.
     documented_attributes(Poly)...
 end
 
+Makie.dim_convert_dimensions(::Type{<:HSpan}, low, high) = (2, 2)
+Makie.dim_convert_dimensions(::Type{<:VSpan}, low, high) = (1, 1)
+
 function Makie.plot!(p::Union{HSpan, VSpan})
     mi = p isa HSpan ? :xmin : :ymin
     ma = p isa HSpan ? :xmax : :ymax

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -448,7 +448,12 @@ function add_convert_kwargs!(attr, user_kw, P, args)
     end
 end
 
-function add_dim_converts!(attr::ComputeGraph, dim_converts, args, input = :args)
+dim_convert_dimensions(::Type{<:AbstractPlot}, args...) = ntuple(identity, length(args))
+
+function add_dim_converts!(attr::ComputeGraph, dim_converts, args, input = :args; dims = ntuple(identity, length(args)))
+    if length(args) != length(dims)
+        error("Expected one dim conversion mapping per argument, got $(length(args)) arguments and $(length(dims)) mappings.")
+    end
     if !(length(args) in (2, 3))
         # We only support plots with 2 or 3 dimensions right now
         map!(attr, :args, :dim_converted) do args
@@ -458,10 +463,10 @@ function add_dim_converts!(attr::ComputeGraph, dim_converts, args, input = :args
     end
 
     inputs = Symbol[]
-    for (i, arg) in enumerate(args)
-        update_dim_conversion!(dim_converts, i, arg)
-        obs = convert(Observable{Any}, needs_tick_update_observable(Observable{Any}(dim_converts[i])))
-        converts_updated = map!(x -> dim_converts[i], Observable{Any}(), obs)
+    for (i, (arg, dim)) in enumerate(zip(args, dims))
+        update_dim_conversion!(dim_converts, dim, arg)
+        obs = convert(Observable{Any}, needs_tick_update_observable(Observable{Any}(dim_converts[dim])))
+        converts_updated = map!(x -> dim_converts[dim], Observable{Any}(), obs)
         add_input!(attr, Symbol(:dim_convert_, i), converts_updated)
         push!(inputs, Symbol(:dim_convert_, i))
     end
@@ -495,6 +500,7 @@ end
 function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw) where {P}
     dim_converts = to_value(get!(() -> DimConversions(), user_kw, :dim_conversions))
     args = attr.args[]
+    dims = dim_convert_dimensions(P, args...)
     add_convert_kwargs!(attr, user_kw, P, args)
     kw = attr.convert_kwargs[]
     args_converted = convert_arguments(P, args...; kw...)
@@ -502,7 +508,7 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
     status = got_converted(P, conversion_trait(P, args...), args_converted)
     force_dimconverts = needs_dimconvert(dim_converts)
     if force_dimconverts
-        add_dim_converts!(attr, dim_converts, args)
+        add_dim_converts!(attr, dim_converts, args; dims = dims)
     elseif (status === true || status === SpecApi)
         # Nothing needs to be done, since we can just use convert_arguments without dim_converts
         # And just pass the arguments through
@@ -510,7 +516,7 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
             return Ref{Any}(args)
         end
     elseif isnothing(status) || status == true # we don't know (e.g. recipes)
-        add_dim_converts!(attr, dim_converts, args)
+        add_dim_converts!(attr, dim_converts, args; dims = dims)
     elseif status === false
         if args_converted !== args
             # Not at target conversion, but something got converted
@@ -518,9 +524,9 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
             map!(attr, :args, :recursive_convert) do args
                 return convert_arguments(P, args...)
             end
-            add_dim_converts!(attr, dim_converts, args_converted, :recursive_convert)
+            add_dim_converts!(attr, dim_converts, args_converted, :recursive_convert; dims = dim_convert_dimensions(P, args_converted...))
         else
-            add_dim_converts!(attr, dim_converts, args)
+            add_dim_converts!(attr, dim_converts, args; dims = dims)
         end
     end
     #  backwards compatibility for plot.converted (and not only compatibility, but it's just convenient to have)

--- a/Makie/test/conversions/dim-converts.jl
+++ b/Makie/test/conversions/dim-converts.jl
@@ -61,6 +61,26 @@ end
     @test pl[1][] == Point.(1:5, Float64.(Makie.date_to_number.(DateTime, DateTime.(1:5))))
 end
 
+@testset "datetime spans use the correct dimension" begin
+    low = DateTime(2025, 1, 1)
+    high = DateTime(2025, 1, 2)
+    converted = Float64.(Makie.date_to_number.(DateTime, (low, high)))
+
+    f, ax, pl = hspan(low, high)
+    pl_conversion = Makie.get_conversions(pl)
+    @test pl_conversion[1] isa Union{Nothing, Makie.NoDimConversion}
+    @test pl_conversion[2] isa Makie.DateTimeConversion
+    @test pl[1][] == converted[1]
+    @test pl[2][] == converted[2]
+
+    f, ax, pl = vspan(low, high)
+    pl_conversion = Makie.get_conversions(pl)
+    @test pl_conversion[1] isa Makie.DateTimeConversion
+    @test pl_conversion[2] isa Union{Nothing, Makie.NoDimConversion}
+    @test pl[1][] == converted[1]
+    @test pl[2][] == converted[2]
+end
+
 @testset "Categorical ylims!" begin
     f, ax, p = scatter(1:4, Categorical(["a", "b", "c", "a"]))
     scatter!(ax, 1:4, Categorical(["b", "d", "a", "c"]))


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

A minimal change to fix vspan and hspan DimConvert, https://github.com/MakieOrg/Makie.jl/issues/4412

```julia
using CairoMakie, Dates
import Makie

function date2num(x::T) where {T<:Union{DateTime,Date}}
    return Float32(Makie.date_to_number(T, x))
end

t = collect(DateTime(2019, 1, 1):Day(1):DateTime(2019, 12, 31))
n = length(t)
y = rand(n)

data = rand(2, n)
begin
    fig = Figure()
    ax = Axis(fig[1, 1])

    plt = series!(ax, t, data; labels=["ea", "es"])
    axislegend()

    vlines!(ax, date2num(t[5]); color=:red)
    # vlines!(ax, t[5]; color=:red) # not work
    hlines!(ax, 0.5; color=:blue)

    vspan!(ax, t[5], t[70]; color=:green, alpha=0.2)
    hspan!(ax, 0.2, 0.8; color=:orange, alpha=0.2)
    fig
    save("a.png", fig)
end
```

<img width="1200" height="900" alt="a" src="https://github.com/user-attachments/assets/ff7ae012-c918-4737-ba12-177ab5080b36" />



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
