### PR TITLE
Remove unnecessary trailing comma

### DIFF
--- a/docs/fake_interaction.jl
+++ b/docs/fake_interaction.jl
@@ -265,7 +265,7 @@ function interaction_record(func, figlike, filepath, events::AbstractVector; fps
     return
 end
 
-interaction_record(figlike, filepath, events::AbstractVector; kwargs...) = interaction_record((args...,) -> nothing, figlike, filepath, events; kwargs...)
+interaction_record(figlike, filepath, events::AbstractVector; kwargs...) = interaction_record((args...) -> nothing, figlike, filepath, events; kwargs...)
 
 relative_pos(block, rel) = Point2f(block.layoutobservables.computedbbox[].origin .+ rel .* block.layoutobservables.computedbbox[].widths)
 


### PR DESCRIPTION
Before version 1.6.0 Runic left these alone but this was not consistent with how named functions were formatted.