### PR TITLE
Add pathtext recipe for text along a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `pathtext` recipe to place text along a path (`Vector{Point2}` with optional `NaN` separators or a `BezierPath`), with `:left`/`:center`/`:right` alignment, per-character colors, and `:data` or `:pixel` path space.
 - Added possibility to gather legend entries from multiple axes [#5551](https://github.com/MakieOrg/Makie.jl/pull/5551)
 - Added complete inverse transformation support to `register_projected_positions!` with `apply_inverse_transform`, `apply_inverse_transform_func`, `apply_inverse_float32convert`, and `apply_inverse_model` kwargs. These enable correct projection from non-data spaces back to data space. Includes early-exit optimization to skip redundant transform/inverse pairs when `input_space === output_space`. [#5485](https://github.com/MakieOrg/Makie.jl/pull/5485)
 - Fixed `bracket` not supporting `LaTeXString` text, which would render with dollar signs instead of mathematical notation [#5536](https://github.com/MakieOrg/Makie.jl/pull/5536)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added `pathtext` recipe for placing text along a path [#5596](https://github.com/MakieOrg/Makie.jl/pull/5596).
+- Added `pathtext` recipe for placing text along a path, plus `Ann.Styles.WithText` to layer path text onto any existing `annotation` style [#5596](https://github.com/MakieOrg/Makie.jl/pull/5596).
 - Added possibility to gather legend entries from multiple axes [#5551](https://github.com/MakieOrg/Makie.jl/pull/5551)
 - Added complete inverse transformation support to `register_projected_positions!` with `apply_inverse_transform`, `apply_inverse_transform_func`, `apply_inverse_float32convert`, and `apply_inverse_model` kwargs. These enable correct projection from non-data spaces back to data space. Includes early-exit optimization to skip redundant transform/inverse pairs when `input_space === output_space`. [#5485](https://github.com/MakieOrg/Makie.jl/pull/5485)
 - Fixed `bracket` not supporting `LaTeXString` text, which would render with dollar signs instead of mathematical notation [#5536](https://github.com/MakieOrg/Makie.jl/pull/5536)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added `pathtext` recipe to place text along a path (`Vector{Point2}` with optional `NaN` separators or a `BezierPath`), with `:left`/`:center`/`:right` alignment, per-character colors, and `:data` or `:pixel` path space.
+- Added `pathtext` recipe for placing text along a path [#5596](https://github.com/MakieOrg/Makie.jl/pull/5596).
 - Added possibility to gather legend entries from multiple axes [#5551](https://github.com/MakieOrg/Makie.jl/pull/5551)
 - Added complete inverse transformation support to `register_projected_positions!` with `apply_inverse_transform`, `apply_inverse_transform_func`, `apply_inverse_float32convert`, and `apply_inverse_model` kwargs. These enable correct projection from non-data spaces back to data space. Includes early-exit optimization to skip redundant transform/inverse pairs when `input_space === output_space`. [#5485](https://github.com/MakieOrg/Makie.jl/pull/5485)
 - Fixed `bracket` not supporting `LaTeXString` text, which would render with dollar signs instead of mathematical notation [#5536](https://github.com/MakieOrg/Makie.jl/pull/5536)

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -417,6 +417,7 @@ include("makielayout/MakieLayout.jl")
 include("figureplotting.jl")
 include("basic_recipes/series.jl")
 include("basic_recipes/text.jl")
+include("basic_recipes/pathtext.jl")
 include("basic_recipes/raincloud.jl")
 include("deprecated.jl")
 

--- a/Makie/src/basic_recipes/annotation.jl
+++ b/Makie/src/basic_recipes/annotation.jl
@@ -39,12 +39,39 @@ baremodule Ann # bare for cleanest tab-completion behavior
         using Base
 
         using ..Arrows: Arrows
+        using ...Makie: Makie
 
         struct Line end
 
         Base.@kwdef struct LineArrow
             head = Arrows.Line()
             tail = nothing
+        end
+
+        """
+            Ann.Styles.WithText(style; text, ...)
+
+        Wraps another annotation `style` and additionally draws `text` along the
+        connection path using `pathtext`. The inner `style` is rendered first,
+        then the text is layered on top so it follows the same curve.
+        """
+        struct WithText
+            style::Any
+            text::Any
+            fontsize::Float64
+            align::Any
+            offset::Float64
+            color::Any
+        end
+        function WithText(
+                style;
+                text = "",
+                fontsize = 12.0,
+                align = (:center, :bottom),
+                offset = 4.0,
+                color = Makie.automatic,
+            )
+            return WithText(style, text, Float64(fontsize), align, Float64(offset), color)
         end
 
     end
@@ -1023,6 +1050,20 @@ function annotation_style_plotspecs(::Ann.Styles.Line, path::BezierPath, p1, p2;
     ]
 end
 
+function annotation_style_plotspecs(s::Ann.Styles.WithText, path::BezierPath, p1, p2; color, linewidth)
+    specs = annotation_style_plotspecs(s.style, path, p1, p2; color, linewidth)
+    textcolor = s.color === automatic ? color : s.color
+    push!(
+        specs,
+        PlotSpec(
+            :PathText, path;
+            text = s.text, fontsize = s.fontsize, align = s.align,
+            offset = s.offset, color = textcolor, space = :pixel,
+        ),
+    )
+    return specs
+end
+
 _auto(x::Automatic, default) = default
 _auto(x, default) = x
 
@@ -1084,6 +1125,22 @@ function attribute_examples(::Type{Annotation})
                 annotation!(-200, 0, 0, -1, style = Ann.Styles.LineArrow())
                 annotation!(-200, 0, 0, -2, style = Ann.Styles.LineArrow(head = Ann.Arrows.Head()))
                 annotation!(-200, 0, 0, -3, style = Ann.Styles.LineArrow(tail = Ann.Arrows.Line(length = 20)))
+                fig
+                """
+            ),
+            Example(
+                code = raw"""
+                fig = Figure()
+                ax = Axis(fig[1, 1])
+                scatter!(ax, [1, 5], [2, 5], markersize = 10, color = :black)
+                annotation!(ax, [Point2f(1, 2)], [Point2f(5, 5)];
+                    text = [""],
+                    path = Ann.Paths.Arc(height = 0.4),
+                    style = Ann.Styles.WithText(Ann.Styles.LineArrow();
+                        text = rich("H", subscript("2"), "O → ",
+                            rich("products"; color = :crimson)),
+                        fontsize = 14),
+                    color = :steelblue, labelspace = :data, shrink = (5.0, 5.0))
                 fig
                 """
             ),

--- a/Makie/src/basic_recipes/annotation.jl
+++ b/Makie/src/basic_recipes/annotation.jl
@@ -1132,14 +1132,15 @@ function attribute_examples(::Type{Annotation})
                 code = raw"""
                 fig = Figure()
                 ax = Axis(fig[1, 1])
-                scatter!(ax, [1, 5], [2, 5], markersize = 10, color = :black)
-                annotation!(ax, [Point2f(1, 2)], [Point2f(5, 5)];
+                A, B = Point2f(1, 2), Point2f(5, 5)
+                scatter!(ax, [A, B], markersize = 10, color = :black)
+                text!(ax, [A, B], text = ["A", "B"],
+                    align = (:right, :top), offset = (-6, -4))
+                annotation!(ax, [A], [B];
                     text = [""],
                     path = Ann.Paths.Arc(height = 0.4),
                     style = Ann.Styles.WithText(Ann.Styles.LineArrow();
-                        text = rich("H", subscript("2"), "O → ",
-                            rich("products"; color = :crimson)),
-                        fontsize = 14),
+                        text = "from A to B", fontsize = 14),
                     color = :steelblue, labelspace = :data, shrink = (5.0, 5.0))
                 fig
                 """

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -506,143 +506,83 @@ const _PathtextGlyphStyles = @NamedTuple{
 
 _empty_layout() = (Point2f[], Quaternionf[], String[], nothing)
 
-# --- String on polyline -------------------------------------------------------
-
-function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::AbstractString, fontsize, font, fonts, align, offset)
-    (isempty(text) || length(pixel_path) < 2) && return _empty_layout()
-
-    _font = to_font(fonts, font)
-    _fontsize = Float32(to_fontsize(fontsize))
-    halign, valign = align
-    _offset = Float32(offset) + _valign_shift(valign, _fontsize, _font)
-
-    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
-
-    text_chars = collect(text)
-    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
-    total_text_len = sum(advances; init = 0.0f0)
-    total_path_len = _polyline_arc_length(working_path)
-
-    # x_positions: cumulative advance (start of each glyph)
+# Dispatch for the text side of layout. Returns per-glyph arrays and optional
+# per-glyph styles (or `nothing` for plain `AbstractString`).
+function _layout_glyphs(text::AbstractString, fontsize::Float32, font, fonts)
+    chars = collect(text)
+    advances = Float32[Float32(GlyphExtent(font, c).hadvance) * fontsize for c in chars]
     x_positions = cumsum(advances) .- advances
-    frac = _parse_halign(halign)
-    sample_fn = s -> _sample_polyline_at(working_path, s)
-    pos, rot, chars = _place_glyphs_on_path(x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len)
-    return (pos, rot, chars, nothing)
+    y_offsets = nothing
+    return (chars, x_positions, y_offsets, advances, nothing)
 end
 
-# --- String on BezierPath -----------------------------------------------------
-
-function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, font, fonts, align, offset)
-    isempty(text) && return _empty_layout()
-
-    _font = to_font(fonts, font)
-    _fontsize = Float32(to_fontsize(fontsize))
-    halign, valign = align
-    _offset = Float64(offset) + _valign_shift(valign, _fontsize, _font)
-
-    segs = _prepare_bezierpath(pixel_bp, _offset)
-    isempty(segs) && return _empty_layout()
-
-    text_chars = collect(text)
-    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
-    total_text_len = sum(advances; init = 0.0f0)
-    total_path_len = Float32(_total_arclen(segs))
-
-    x_positions = cumsum(advances) .- advances
-    frac = _parse_halign(halign)
-    sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
-    pos, rot, chars = _place_glyphs_on_path(x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len)
-    return (pos, rot, chars, nothing)
-end
-
-# --- RichText on polyline -----------------------------------------------------
-
-function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText, fontsize, font, fonts, align, offset)
-    length(pixel_path) < 2 && return _empty_layout()
-
-    _font = to_font(fonts, font)
-    _fontsize = Float32(to_fontsize(fontsize))
-    halign, valign = align
-    _offset = Float32(offset) + _valign_shift(valign, _fontsize, _font)
-
-    gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
+function _layout_glyphs(text::RichText, fontsize::Float32, font, fonts)
+    gc = _layout_richtext_for_path(text, fontsize, font, fonts)
     n = length(gc.glyphs)
-    n == 0 && return _empty_layout()
+    n == 0 && return (Char[], Float32[], Float32[], Float32[], nothing)
 
-    text_chars = _richtext_chars(text)
-    length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
+    chars = _richtext_chars(text)
+    length(chars) != n && error("RichText character count ($(length(chars))) does not match glyph count ($n).")
 
+    scales = collect_vector(gc.scales, n)
     x_positions = Float32[gc.origins[i][1] for i in 1:n]
     y_offsets = Float32[gc.origins[i][2] for i in 1:n]
-    scales = collect_vector(gc.scales, n)
     advances = Float32[gc.extents[i].hadvance * scales[i][1] for i in 1:n]
-    total_text_len = x_positions[end] + advances[end]
+    styles = (
+        colors = collect_vector(gc.colors, n),
+        fonts = collect_vector(gc.fonts, n),
+        fontsizes = Float32[s[1] for s in scales],
+    )::_PathtextGlyphStyles
+    return (chars, x_positions, y_offsets, advances, styles)
+end
 
-    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
-    total_path_len = _polyline_arc_length(working_path)
+# Dispatch for the path side of layout. Returns `(total_path_len, sample_fn)`
+# or `nothing` if the path is too short/empty.
+function _prepare_path_sampler(pixel_path::AbstractVector{<:VecTypes}, d::Real)
+    length(pixel_path) < 2 && return nothing
+    working = iszero(d) ? pixel_path : _offset_polyline(pixel_path, d)
+    total = _polyline_arc_length(working)
+    return (total, s -> _sample_polyline_at(working, s))
+end
 
+function _prepare_path_sampler(pixel_bp::BezierPath, d::Real)
+    segs = _prepare_bezierpath(pixel_bp, d)
+    isempty(segs) && return nothing
+    total = Float32(_total_arclen(segs))
+    return (total, s -> _sample_bezierpath_at(segs, s, d))
+end
+
+function _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset)
+    _font = to_font(fonts, font)
+    _fontsize = Float32(to_fontsize(fontsize))
+    halign, valign = align
+    perp_offset = Float64(offset) + _valign_shift(valign, _fontsize, _font)
+
+    chars, x_positions, y_offsets, advances, styles = _layout_glyphs(text, _fontsize, _font, fonts)
+    isempty(chars) && return _empty_layout()
+
+    prepared = _prepare_path_sampler(pixel_path, perp_offset)
+    prepared === nothing && return _empty_layout()
+    total_path_len, sample_fn = prepared
+
+    total_text_len = isempty(x_positions) ? 0.0f0 : x_positions[end] + advances[end]
     frac = _parse_halign(halign)
-    sample_fn = s -> _sample_polyline_at(working_path, s)
-    pos, rot, chars = _place_glyphs_on_path(
-        x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len;
+    pos, rot, placed = _place_glyphs_on_path(
+        x_positions, advances, chars, sample_fn, frac, total_text_len, total_path_len;
         y_offsets,
     )
 
-    m = length(pos)
-    colors_vec = collect_vector(gc.colors, n)
-    fonts_vec = collect_vector(gc.fonts, n)
-    scales_vec = collect_vector(gc.scales, n)
-    styles = (
-        colors = colors_vec[1:m],
-        fonts = fonts_vec[1:m],
-        fontsizes = Float32[s[1] for s in scales_vec[1:m]],
-    )::_PathtextGlyphStyles
-    return (pos, rot, chars, styles)
-end
-
-# --- RichText on BezierPath ---------------------------------------------------
-
-function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, fonts, align, offset)
-    _fontsize = Float32(to_fontsize(fontsize))
-    _font = to_font(fonts, font)
-    halign, valign = align
-    _offset = Float64(offset) + _valign_shift(valign, _fontsize, _font)
-
-    gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
-    n = length(gc.glyphs)
-    n == 0 && return _empty_layout()
-
-    text_chars = _richtext_chars(text)
-    length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
-
-    x_positions = Float32[gc.origins[i][1] for i in 1:n]
-    y_offsets = Float32[gc.origins[i][2] for i in 1:n]
-    scales = collect_vector(gc.scales, n)
-    advances = Float32[gc.extents[i].hadvance * scales[i][1] for i in 1:n]
-    total_text_len = x_positions[end] + advances[end]
-
-    segs = _prepare_bezierpath(pixel_bp, _offset)
-    isempty(segs) && return _empty_layout()
-    total_path_len = Float32(_total_arclen(segs))
-
-    frac = _parse_halign(halign)
-    sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
-    pos, rot, chars = _place_glyphs_on_path(
-        x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len;
-        y_offsets,
-    )
-
-    m = length(pos)
-    colors_vec = collect_vector(gc.colors, n)
-    fonts_vec = collect_vector(gc.fonts, n)
-    scales_vec = collect_vector(gc.scales, n)
-    styles = (
-        colors = colors_vec[1:m],
-        fonts = fonts_vec[1:m],
-        fontsizes = Float32[s[1] for s in scales_vec[1:m]],
-    )::_PathtextGlyphStyles
-    return (pos, rot, chars, styles)
+    truncated_styles = if styles === nothing
+        nothing
+    else
+        m = length(pos)
+        (
+            colors = styles.colors[1:m],
+            fonts = styles.fonts[1:m],
+            fontsizes = styles.fontsizes[1:m],
+        )::_PathtextGlyphStyles
+    end
+    return (pos, rot, placed, truncated_styles)
 end
 
 # ==============================================================================

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -4,6 +4,10 @@
 Draw `text` along a path. `path` can be a `Vector{<: Point2}` (with optional
 `NaN` separators between sub-paths) or a `BezierPath`.
 
+When a `BezierPath` is provided, glyphs are positioned and oriented using exact
+cubic-Bézier evaluation, giving smooth tangent rotations. A polyline input is
+sampled piecewise-linearly.
+
 Text is always rendered at pixel size (`fontsize` is in pixels) because the glyphs
 are placed visually along the path. The path itself may be given in `:data` or
 `:pixel` space, controlled by the `space` attribute.
@@ -18,7 +22,8 @@ Newlines in `text` are not supported.
 - `color`: Text color. May be a single value or a vector with one entry per
   character.
 - `strokecolor`, `strokewidth`: Stroke styling; may be per-character.
-- `align = :left`: Alignment along the path. One of `:left`, `:center`, `:right`.
+- `align = :left`: Alignment along the path. One of `:left`, `:center`, `:right`,
+  or a `Real` fraction (0 = start, 1 = end).
 - `offset = 0.0`: Perpendicular offset from the path in pixels. Positive values
   shift the text to the left of the path's direction of travel.
 - `space = :data`: Coordinate space of the path; `:data` or `:pixel`.
@@ -38,7 +43,7 @@ Newlines in `text` are not supported.
     strokewidth = 0
     "Font size in pixels."
     fontsize = @inherit fontsize
-    "Alignment of the text along the path. One of `:left`, `:center`, `:right`, or a `Real` fraction between 0 (start) and 1 (end) controlling the start position of the text relative to the slack between path and text length."
+    "Alignment of the text along the path. One of `:left`, `:center`, `:right`, or a `Real` fraction between 0 (start) and 1 (end)."
     align = :left
     "Perpendicular offset (in pixels) from the path. Positive values shift the text to the left of the path's direction of travel."
     offset = 0.0f0
@@ -46,9 +51,201 @@ Newlines in `text` are not supported.
     mixin_colormap_attributes()...
 end
 
-conversion_trait(::Type{<:PathText}) = PointBased()
+# -- convert_arguments ---------------------------------------------------------
 
-# -- arc-length utilities for polylines with NaN separators -------------------
+function convert_arguments(::Type{<:PathText}, path::AbstractVector{<:VecTypes{2}})
+    return (convert(Vector{Point2d}, path),)
+end
+
+function convert_arguments(::Type{<:PathText}, path::BezierPath)
+    return (path,)
+end
+
+# ==============================================================================
+# Cubic Bézier math
+# ==============================================================================
+
+# 8-point Gauss-Legendre nodes and weights on [0, 1]  (transformed from [-1, 1])
+const _GL8 = (
+    weights = (
+        0.181341891689181, 0.181341891689181,
+        0.15685332293894365, 0.15685332293894365,
+        0.11119051722668723, 0.11119051722668723,
+        0.05061426814518813, 0.05061426814518813,
+    ),
+    nodes = (
+        0.4082826787521751, 0.5917173212478249,
+        0.2372337950418355, 0.7627662049581645,
+        0.10166676130026867, 0.8983332386997313,
+        0.01985507175123188, 0.9801449282487681,
+    ),
+)
+
+# p(t) = (1-t)³p0 + 3(1-t)²t·p1 + 3(1-t)t²·p2 + t³·p3
+function _cubic_eval(p0, p1, p2, p3, t)
+    mt = 1.0 - t
+    return mt^3 .* p0 .+ (3 * mt^2 * t) .* p1 .+ (3 * mt * t^2) .* p2 .+ t^3 .* p3
+end
+
+# p'(t) = 3[(1-t)²(p1-p0) + 2(1-t)t(p2-p1) + t²(p3-p2)]
+function _cubic_deriv(p0, p1, p2, p3, t)
+    mt = 1.0 - t
+    d01 = p1 .- p0
+    d12 = p2 .- p1
+    d23 = p3 .- p2
+    return 3.0 .* (mt^2 .* d01 .+ (2 * mt * t) .* d12 .+ t^2 .* d23)
+end
+
+# p''(t) = 6[(1-t)(p2-2p1+p0) + t(p3-2p2+p1)]
+function _cubic_second_deriv(p0, p1, p2, p3, t)
+    mt = 1.0 - t
+    a = p2 .- 2.0 .* p1 .+ p0
+    b = p3 .- 2.0 .* p2 .+ p1
+    return 6.0 .* (mt .* a .+ t .* b)
+end
+
+# Arc length of a cubic Bézier on [t0, t1] via 8-point GL quadrature.
+function _cubic_arclen(p0, p1, p2, p3, t0 = 0.0, t1 = 1.0)
+    dt = t1 - t0
+    total = 0.0
+    for (w, x) in zip(_GL8.weights, _GL8.nodes)
+        t = t0 + x * dt
+        d = _cubic_deriv(p0, p1, p2, p3, t)
+        total += w * sqrt(d[1]^2 + d[2]^2)
+    end
+    return total * dt
+end
+
+# Arc length of the offset curve  p(t) + d·n(t)  on [t0, t1].
+# Speed of offset curve = |p'(t)| · |1 - d·κ(t)|  where κ is signed curvature.
+function _cubic_offset_arclen(p0, p1, p2, p3, d, t0 = 0.0, t1 = 1.0)
+    iszero(d) && return _cubic_arclen(p0, p1, p2, p3, t0, t1)
+    dt = t1 - t0
+    total = 0.0
+    for (w, x) in zip(_GL8.weights, _GL8.nodes)
+        t = t0 + x * dt
+        dp = _cubic_deriv(p0, p1, p2, p3, t)
+        speed = sqrt(dp[1]^2 + dp[2]^2)
+        if speed > 1.0e-12
+            ddp = _cubic_second_deriv(p0, p1, p2, p3, t)
+            kappa = (dp[1] * ddp[2] - dp[2] * ddp[1]) / speed^3
+            total += w * speed * abs(1.0 - d * kappa)
+        end
+    end
+    return total * dt
+end
+
+# Find parameter t ∈ [0,1] such that the (offset) arc length from 0 to t equals `target`.
+function _cubic_inv_arclen(p0, p1, p2, p3, target, total_len, d = 0.0)
+    target <= 0 && return 0.0
+    target >= total_len && return 1.0
+    lo, hi = 0.0, 1.0
+    for _ in 1:30
+        mid = 0.5 * (lo + hi)
+        s = iszero(d) ? _cubic_arclen(p0, p1, p2, p3, 0.0, mid) :
+            _cubic_offset_arclen(p0, p1, p2, p3, d, 0.0, mid)
+        if s < target
+            lo = mid
+        else
+            hi = mid
+        end
+    end
+    return 0.5 * (lo + hi)
+end
+
+# Point on the offset curve at parameter t.
+function _cubic_offset_point(p0, p1, p2, p3, t, d)
+    pt = _cubic_eval(p0, p1, p2, p3, t)
+    dp = _cubic_deriv(p0, p1, p2, p3, t)
+    speed = sqrt(dp[1]^2 + dp[2]^2)
+    speed < 1.0e-12 && return Point2f(pt[1], pt[2])
+    nx, ny = -dp[2] / speed, dp[1] / speed
+    return Point2f(pt[1] + d * nx, pt[2] + d * ny)
+end
+
+# Unit tangent of a cubic at parameter t.
+function _cubic_unit_tangent(p0, p1, p2, p3, t)
+    dp = _cubic_deriv(p0, p1, p2, p3, t)
+    speed = sqrt(dp[1]^2 + dp[2]^2)
+    speed < 1.0e-12 && return Point2f(1, 0)
+    return Point2f(dp[1] / speed, dp[2] / speed)
+end
+
+# ==============================================================================
+# Prepared BezierPath: precomputed per-segment (offset) arc lengths
+# ==============================================================================
+
+struct _PreparedSegment
+    kind::Symbol          # :line or :cubic
+    p0::Point2d           # start
+    p1::Point2d           # end (line) / control 1 (cubic)
+    p2::Point2d           # control 2 (cubic)
+    p3::Point2d           # end (cubic)
+    arclen::Float64       # (offset) arc length
+end
+
+function _prepare_bezierpath(bp::BezierPath, d::Real = 0.0)
+    bp2 = replace_nonfreetype_commands(bp)
+    segs = _PreparedSegment[]
+    last_pt = Point2d(0, 0)
+    for cmd in bp2.commands
+        if cmd isa MoveTo
+            last_pt = cmd.p
+        elseif cmd isa LineTo
+            len = norm(cmd.p - last_pt)
+            push!(segs, _PreparedSegment(:line, last_pt, cmd.p, Point2d(0), Point2d(0), len))
+            last_pt = cmd.p
+        elseif cmd isa CurveTo
+            len = iszero(d) ? _cubic_arclen(last_pt, cmd.c1, cmd.c2, cmd.p) :
+                _cubic_offset_arclen(last_pt, cmd.c1, cmd.c2, cmd.p, d)
+            push!(segs, _PreparedSegment(:cubic, last_pt, cmd.c1, cmd.c2, cmd.p, len))
+            last_pt = cmd.p
+        end
+    end
+    return segs
+end
+
+function _total_arclen(segs::Vector{_PreparedSegment})
+    return sum(s.arclen for s in segs; init = 0.0)
+end
+
+"""
+Sample a prepared BezierPath at arc-length `s`. Returns `(point, tangent)` or
+`nothing` if past the end. When `d ≠ 0`, positions are offset perpendicularly.
+"""
+function _sample_bezierpath_at(segs::Vector{_PreparedSegment}, s::Real, d::Real = 0.0)
+    s < 0 && return nothing
+    accum = 0.0
+    for seg in segs
+        if accum + seg.arclen >= s
+            local_s = s - accum
+            if seg.kind === :line
+                frac = seg.arclen > 0 ? local_s / seg.arclen : 0.0
+                v = seg.p1 - seg.p0
+                len = norm(v)
+                tangent = len > 0 ? Point2f(v[1] / len, v[2] / len) : Point2f(1, 0)
+                pt = Point2f(seg.p0[1] + frac * v[1], seg.p0[2] + frac * v[2])
+                if !iszero(d)
+                    nx, ny = -tangent[2], tangent[1]
+                    pt = pt + Float32(d) * Point2f(nx, ny)
+                end
+                return (pt, tangent)
+            else # :cubic
+                t = _cubic_inv_arclen(seg.p0, seg.p1, seg.p2, seg.p3, local_s, seg.arclen, d)
+                tangent = _cubic_unit_tangent(seg.p0, seg.p1, seg.p2, seg.p3, t)
+                pt = iszero(d) ? Point2f(_cubic_eval(seg.p0, seg.p1, seg.p2, seg.p3, t)...) :
+                    _cubic_offset_point(seg.p0, seg.p1, seg.p2, seg.p3, t, d)
+                return (pt, tangent)
+            end
+        end
+        accum += seg.arclen
+    end
+    return nothing
+end
+
+# ==============================================================================
+# Polyline utilities (for Vector{Point} input)
+# ==============================================================================
 
 function _polyline_arc_length(points::AbstractVector{<:VecTypes})
     total = 0.0
@@ -61,7 +258,6 @@ function _polyline_arc_length(points::AbstractVector{<:VecTypes})
     return Float32(total)
 end
 
-# Perpendicular normal (90° CCW) of the segment p1->p2, or `nothing` if invalid.
 function _seg_normal(p1, p2)
     (any(isnan, p1) || any(isnan, p2)) && return nothing
     v = p2 - p1
@@ -70,12 +266,6 @@ function _seg_normal(p1, p2)
     return Vec2f(-v[2] / len, v[1] / len)
 end
 
-"""
-Offset a polyline perpendicularly by `d` pixels (positive = left of path
-direction). Uses the angle-bisector at interior vertices to keep the offset
-polyline roughly at distance `d` from both incident segments. `NaN` separators
-are preserved as separators between sub-paths, each offset independently.
-"""
 function _offset_polyline(points::AbstractVector{<:VecTypes}, d::Real)
     n = length(points)
     result = Vector{Point2f}(undef, n)
@@ -99,7 +289,6 @@ function _offset_polyline(points::AbstractVector{<:VecTypes}, d::Real)
         else
             denom = 1 + dot(n_in, n_out)
             if denom < 1.0f-3
-                # near reversal; avoid huge miter
                 result[i] = Point2f(p) + d * Point2f(n_in)
             else
                 avg = n_in + n_out
@@ -110,11 +299,6 @@ function _offset_polyline(points::AbstractVector{<:VecTypes}, d::Real)
     return result
 end
 
-"""
-Sample a polyline at arc-length `s`, skipping over `NaN` separators between
-sub-paths. Returns `(point, unit_tangent)` as `Point2f`, or `nothing` if `s` is
-beyond the end of the path.
-"""
 function _sample_polyline_at(points::AbstractVector{<:VecTypes}, s::Real)
     s < 0 && return nothing
     accum = 0.0
@@ -136,29 +320,57 @@ function _sample_polyline_at(points::AbstractVector{<:VecTypes}, s::Real)
     return nothing
 end
 
-# -- layout --------------------------------------------------------------------
+# ==============================================================================
+# Control-point extraction / reassembly (for projecting BezierPath to pixel)
+# ==============================================================================
 
-function _pathtext_layout(pixel_path, text::AbstractString, fontsize, font, fonts, align, offset)
-    positions = Point2f[]
-    rotations = Quaternionf[]
-    chars = String[]
+function _extract_control_points(path::AbstractVector{<:VecTypes})
+    return path
+end
 
-    (isempty(text) || length(pixel_path) < 2) && return (positions, rotations, chars)
+function _extract_control_points(bp::BezierPath)
+    bp2 = replace_nonfreetype_commands(bp)
+    points = Point2d[]
+    for cmd in bp2.commands
+        if cmd isa MoveTo
+            push!(points, cmd.p)
+        elseif cmd isa LineTo
+            push!(points, cmd.p)
+        elseif cmd isa CurveTo
+            push!(points, cmd.c1, cmd.c2, cmd.p)
+        end
+    end
+    return points
+end
 
-    _font = to_font(fonts, font)
-    _fontsize = Float32(to_fontsize(fontsize))
-    _offset = Float32(offset)
+function _reassemble_path(px_pts::AbstractVector, ::AbstractVector{<:VecTypes})
+    return px_pts
+end
 
-    # Offset the polyline first so the text is laid out along the already-offset
-    # path. This keeps glyph spacing uniform on curves (without this the convex
-    # side would stretch characters apart and the concave side would crowd them).
-    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
+function _reassemble_path(px_pts::AbstractVector, bp::BezierPath)
+    bp2 = replace_nonfreetype_commands(bp)
+    cmds = PathCommand[]
+    i = 1
+    for cmd in bp2.commands
+        if cmd isa MoveTo
+            push!(cmds, MoveTo(Point2d(px_pts[i])))
+            i += 1
+        elseif cmd isa LineTo
+            push!(cmds, LineTo(Point2d(px_pts[i])))
+            i += 1
+        elseif cmd isa CurveTo
+            push!(cmds, CurveTo(Point2d(px_pts[i]), Point2d(px_pts[i + 1]), Point2d(px_pts[i + 2])))
+            i += 3
+        end
+    end
+    return BezierPath(cmds)
+end
 
-    text_chars = collect(text)
-    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
-    total_text_len = sum(advances; init = 0.0f0)
-    total_path_len = _polyline_arc_length(working_path)
+# ==============================================================================
+# Layout
+# ==============================================================================
 
+function _parse_align(align)
     frac = if align === :left
         0.0f0
     elseif align === :center
@@ -170,6 +382,29 @@ function _pathtext_layout(pixel_path, text::AbstractString, fontsize, font, font
     else
         throw(ArgumentError("Invalid `align = $(repr(align))` for `pathtext`. Expected `:left`, `:center`, `:right`, or a `Real`."))
     end
+    return frac
+end
+
+# Layout on a polyline
+function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::AbstractString, fontsize, font, fonts, align, offset)
+    positions = Point2f[]
+    rotations = Quaternionf[]
+    chars = String[]
+
+    (isempty(text) || length(pixel_path) < 2) && return (positions, rotations, chars)
+
+    _font = to_font(fonts, font)
+    _fontsize = Float32(to_fontsize(fontsize))
+    _offset = Float32(offset)
+
+    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
+
+    text_chars = collect(text)
+    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
+    total_text_len = sum(advances; init = 0.0f0)
+    total_path_len = _polyline_arc_length(working_path)
+
+    frac = _parse_align(align)
     start_s = frac * (total_path_len - total_text_len)
 
     s = start_s
@@ -177,7 +412,6 @@ function _pathtext_layout(pixel_path, text::AbstractString, fontsize, font, font
         sample = _sample_polyline_at(working_path, s)
         sample === nothing && break
         pt, tangent = sample
-        # "up" of the text is perpendicular to tangent, rotated 90° CCW.
         normal = Point2f(-tangent[2], tangent[1])
         push!(positions, pt)
         push!(rotations, to_rotation(Vec2f(normal)))
@@ -188,7 +422,47 @@ function _pathtext_layout(pixel_path, text::AbstractString, fontsize, font, font
     return (positions, rotations, chars)
 end
 
-# -- plot! ---------------------------------------------------------------------
+# Layout on a BezierPath (native cubic evaluation)
+function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, font, fonts, align, offset)
+    positions = Point2f[]
+    rotations = Quaternionf[]
+    chars = String[]
+
+    isempty(text) && return (positions, rotations, chars)
+
+    _font = to_font(fonts, font)
+    _fontsize = Float32(to_fontsize(fontsize))
+    _offset = Float64(offset)
+
+    segs = _prepare_bezierpath(pixel_bp, _offset)
+    isempty(segs) && return (positions, rotations, chars)
+
+    text_chars = collect(text)
+    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
+    total_text_len = sum(advances; init = 0.0f0)
+    total_path_len = Float32(_total_arclen(segs))
+
+    frac = _parse_align(align)
+    start_s = frac * (total_path_len - total_text_len)
+
+    s = start_s
+    for (c, adv) in zip(text_chars, advances)
+        sample = _sample_bezierpath_at(segs, s, _offset)
+        sample === nothing && break
+        pt, tangent = sample
+        normal = Point2f(-tangent[2], tangent[1])
+        push!(positions, pt)
+        push!(rotations, to_rotation(Vec2f(normal)))
+        push!(chars, string(c))
+        s += adv
+    end
+
+    return (positions, rotations, chars)
+end
+
+# ==============================================================================
+# plot!
+# ==============================================================================
 
 function plot!(p::PathText)
     map!(p.attributes, [:text], :_pathtext_validated_text) do text
@@ -196,19 +470,29 @@ function plot!(p::PathText)
         return String(text)
     end
 
-    # Project the path from its input space (plot.space = :data or :pixel) to pixel space.
-    # The result is reactive on camera / transform changes so text stays aligned on zoom/pan.
+    # Extract geometric control points from whatever path type we have.
+    map!(p.attributes, [:path], :_pathtext_control_points) do path
+        return _extract_control_points(path)
+    end
+
+    # Project control points from input space to pixel space.
     register_projected_positions!(
         p, Point2f;
-        input_name = :path,
-        output_name = :_pathtext_path_pixel,
+        input_name = :_pathtext_control_points,
+        output_name = :_pathtext_control_points_pixel,
         input_space = :space,
         output_space = :pixel,
     )
 
+    # Reassemble projected path (BezierPath or polyline).
+    map!(p.attributes, [:_pathtext_control_points_pixel, :path], :_pathtext_pixel_path) do px_pts, orig_path
+        return _reassemble_path(px_pts, orig_path)
+    end
+
+    # Compute per-character positions and rotations.
     map!(
         p.attributes,
-        [:_pathtext_path_pixel, :_pathtext_validated_text, :fontsize, :font, :fonts, :align, :offset],
+        [:_pathtext_pixel_path, :_pathtext_validated_text, :fontsize, :font, :fonts, :align, :offset],
         [:_pathtext_positions, :_pathtext_rotations, :_pathtext_chars]
     ) do pixel_path, text, fontsize, font, fonts, align, offset
         return _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset)
@@ -246,11 +530,14 @@ function plot!(p::PathText)
 end
 
 function data_limits(p::PathText)
-    return if p.space[] === :data
-        pts = p.path[]
-        isempty(pts) ? Rect3d(Point3d(NaN), Vec3d(NaN)) : Rect3d(Rect2d(pts))
-    else
-        Rect3d(Point3d(NaN), Vec3d(NaN))
+    if p.space[] === :data
+        path = p.path[]
+        if path isa BezierPath
+            return Rect3d(bbox(path))
+        elseif path isa AbstractVector && !isempty(path)
+            return Rect3d(Rect2d(path))
+        end
     end
+    return Rect3d(Point3d(NaN), Vec3d(NaN))
 end
 boundingbox(p::PathText, space::Symbol = :data) = apply_transform_and_model(p, data_limits(p))

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -61,6 +61,29 @@ function convert_arguments(::Type{<:PathText}, path::BezierPath)
     return (path,)
 end
 
+# -- RichText helpers ----------------------------------------------------------
+
+function _richtext_chars(rt::RichText)
+    chars = Char[]
+    _collect_richtext_chars!(chars, rt)
+    return chars
+end
+
+function _collect_richtext_chars!(chars, rt::RichText)
+    for child in rt.children
+        _collect_richtext_chars!(chars, child)
+    end
+    return
+end
+
+function _collect_richtext_chars!(chars, s::String)
+    for c in s
+        c == '\n' && throw(ArgumentError("`pathtext` does not support newlines in `text`."))
+        push!(chars, c)
+    end
+    return
+end
+
 # ==============================================================================
 # Cubic Bézier math
 # ==============================================================================
@@ -370,6 +393,28 @@ end
 # Layout
 # ==============================================================================
 
+# Common helper: place glyphs along a path given their arc-length positions.
+# `sample_fn(s)` returns `(point, tangent)` or `nothing`.
+function _place_glyphs_on_path(x_positions, chars, sample_fn, frac, total_text_len, total_path_len)
+    positions = Point2f[]
+    rotations = Quaternionf[]
+    placed_chars = String[]
+
+    start_s = frac * (total_path_len - total_text_len)
+
+    for (x, c) in zip(x_positions, chars)
+        sample = sample_fn(start_s + x)
+        sample === nothing && break
+        pt, tangent = sample
+        normal = Point2f(-tangent[2], tangent[1])
+        push!(positions, pt)
+        push!(rotations, to_rotation(Vec2f(normal)))
+        push!(placed_chars, string(c))
+    end
+
+    return (positions, rotations, placed_chars)
+end
+
 function _parse_align(align)
     frac = if align === :left
         0.0f0
@@ -385,13 +430,12 @@ function _parse_align(align)
     return frac
 end
 
-# Layout on a polyline
-function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::AbstractString, fontsize, font, fonts, align, offset)
-    positions = Point2f[]
-    rotations = Quaternionf[]
-    chars = String[]
+_empty_layout() = (Point2f[], Quaternionf[], String[], nothing)
 
-    (isempty(text) || length(pixel_path) < 2) && return (positions, rotations, chars)
+# --- String on polyline -------------------------------------------------------
+
+function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::AbstractString, fontsize, font, fonts, align, offset)
+    (isempty(text) || length(pixel_path) < 2) && return _empty_layout()
 
     _font = to_font(fonts, font)
     _fontsize = Float32(to_fontsize(fontsize))
@@ -404,70 +448,132 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::Abstract
     total_text_len = sum(advances; init = 0.0f0)
     total_path_len = _polyline_arc_length(working_path)
 
+    # x_positions: cumulative advance (start of each glyph)
+    x_positions = cumsum(advances) .- advances
     frac = _parse_align(align)
-    start_s = frac * (total_path_len - total_text_len)
-
-    s = start_s
-    for (c, adv) in zip(text_chars, advances)
-        sample = _sample_polyline_at(working_path, s)
-        sample === nothing && break
-        pt, tangent = sample
-        normal = Point2f(-tangent[2], tangent[1])
-        push!(positions, pt)
-        push!(rotations, to_rotation(Vec2f(normal)))
-        push!(chars, string(c))
-        s += adv
-    end
-
-    return (positions, rotations, chars)
+    sample_fn = s -> _sample_polyline_at(working_path, s)
+    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    return (pos, rot, chars, nothing)
 end
 
-# Layout on a BezierPath (native cubic evaluation)
-function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, font, fonts, align, offset)
-    positions = Point2f[]
-    rotations = Quaternionf[]
-    chars = String[]
+# --- String on BezierPath -----------------------------------------------------
 
-    isempty(text) && return (positions, rotations, chars)
+function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, font, fonts, align, offset)
+    isempty(text) && return _empty_layout()
 
     _font = to_font(fonts, font)
     _fontsize = Float32(to_fontsize(fontsize))
     _offset = Float64(offset)
 
     segs = _prepare_bezierpath(pixel_bp, _offset)
-    isempty(segs) && return (positions, rotations, chars)
+    isempty(segs) && return _empty_layout()
 
     text_chars = collect(text)
     advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
     total_text_len = sum(advances; init = 0.0f0)
     total_path_len = Float32(_total_arclen(segs))
 
+    x_positions = cumsum(advances) .- advances
     frac = _parse_align(align)
-    start_s = frac * (total_path_len - total_text_len)
+    sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
+    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    return (pos, rot, chars, nothing)
+end
 
-    s = start_s
-    for (c, adv) in zip(text_chars, advances)
-        sample = _sample_bezierpath_at(segs, s, _offset)
-        sample === nothing && break
-        pt, tangent = sample
-        normal = Point2f(-tangent[2], tangent[1])
-        push!(positions, pt)
-        push!(rotations, to_rotation(Vec2f(normal)))
-        push!(chars, string(c))
-        s += adv
-    end
+# --- RichText on polyline -----------------------------------------------------
 
-    return (positions, rotations, chars)
+function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText, fontsize, font, fonts, align, offset)
+    length(pixel_path) < 2 && return _empty_layout()
+
+    _fontsize = Float32(to_fontsize(fontsize))
+    _font = to_font(fonts, font)
+    _offset = Float32(offset)
+
+    gc = layout_text(text, _fontsize, _font, fonts, (:left, :baseline), to_rotation(0), :left, 1.0, RGBAf(0, 0, 0, 1))
+    n = length(gc.glyphs)
+    n == 0 && return _empty_layout()
+
+    text_chars = _richtext_chars(text)
+    length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
+
+    x_positions = Float32[gc.origins[i][1] for i in 1:n]
+    scales = collect_vector(gc.scales, n)
+    total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
+
+    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
+    total_path_len = _polyline_arc_length(working_path)
+
+    frac = _parse_align(align)
+    sample_fn = s -> _sample_polyline_at(working_path, s)
+    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+
+    # Wrap each placed glyph as a single-char RichText with its per-glyph style.
+    # This lets the child text! handle font/color/size natively per block.
+    m = length(pos)
+    colors_vec = collect_vector(gc.colors, n)
+    fonts_vec = collect_vector(gc.fonts, n)
+    scales_vec = collect_vector(gc.scales, n)
+    rt_chars = Union{String, RichText}[
+        rich(string(placed_chars[j]); color = colors_vec[j], font = fonts_vec[j], fontsize = scales_vec[j][1])
+            for j in 1:m
+    ]
+    return (pos, rot, rt_chars, nothing)
+end
+
+# --- RichText on BezierPath ---------------------------------------------------
+
+function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, fonts, align, offset)
+    _fontsize = Float32(to_fontsize(fontsize))
+    _font = to_font(fonts, font)
+    _offset = Float64(offset)
+
+    gc = layout_text(text, _fontsize, _font, fonts, (:left, :baseline), to_rotation(0), :left, 1.0, RGBAf(0, 0, 0, 1))
+    n = length(gc.glyphs)
+    n == 0 && return _empty_layout()
+
+    text_chars = _richtext_chars(text)
+    length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
+
+    x_positions = Float32[gc.origins[i][1] for i in 1:n]
+    scales = collect_vector(gc.scales, n)
+    total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
+
+    segs = _prepare_bezierpath(pixel_bp, _offset)
+    isempty(segs) && return _empty_layout()
+    total_path_len = Float32(_total_arclen(segs))
+
+    frac = _parse_align(align)
+    sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
+    pos, rot, placed_chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+
+    m = length(pos)
+    colors_vec = collect_vector(gc.colors, n)
+    fonts_vec = collect_vector(gc.fonts, n)
+    scales_vec = collect_vector(gc.scales, n)
+    rt_chars = Union{String, RichText}[
+        rich(string(placed_chars[j]); color = colors_vec[j], font = fonts_vec[j], fontsize = scales_vec[j][1])
+            for j in 1:m
+    ]
+    return (pos, rot, rt_chars, nothing)
 end
 
 # ==============================================================================
 # plot!
 # ==============================================================================
 
+function _validate_pathtext(text::AbstractString)
+    occursin('\n', text) && throw(ArgumentError("`pathtext` does not support newlines in `text`."))
+    return text
+end
+
+function _validate_pathtext(text::RichText)
+    _richtext_chars(text) # walks the tree; throws if newline found
+    return text
+end
+
 function plot!(p::PathText)
     map!(p.attributes, [:text], :_pathtext_validated_text) do text
-        occursin('\n', text) && throw(ArgumentError("`pathtext` does not support newlines in `text`."))
-        return String(text)
+        return _validate_pathtext(text)
     end
 
     # Extract geometric control points from whatever path type we have.
@@ -489,11 +595,11 @@ function plot!(p::PathText)
         return _reassemble_path(px_pts, orig_path)
     end
 
-    # Compute per-character positions and rotations.
+    # Compute per-character positions, rotations, chars, and optional per-glyph styles.
     map!(
         p.attributes,
         [:_pathtext_pixel_path, :_pathtext_validated_text, :fontsize, :font, :fonts, :align, :offset],
-        [:_pathtext_positions, :_pathtext_rotations, :_pathtext_chars]
+        [:_pathtext_positions, :_pathtext_rotations, :_pathtext_chars, :_pathtext_glyph_styles]
     ) do pixel_path, text, fontsize, font, fonts, align, offset
         return _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset)
     end

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -769,7 +769,7 @@ function attribute_examples(::Type{PathText})
         ],
         :align => [
             Example(;
-                code = """
+                code = raw"""
                 bp = BezierPath([
                     MoveTo(Point2(0, 0)),
                     CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
@@ -777,7 +777,7 @@ function attribute_examples(::Type{PathText})
                 fig = Figure(size = (800, 600))
                 for (i, va) in enumerate((:top, :center, :baseline, :bottom))
                     r, c = fldmod1(i, 2)
-                    ax = Axis(fig[r, c], aspect = DataAspect(), title = "valign = \\$(repr(va))",
+                    ax = Axis(fig[r, c], aspect = DataAspect(), title = "valign = $(repr(va))",
                         limits = (nothing, (-0.5, 3)))
                     lines!(ax, bp, color = (:steelblue, 0.5), linewidth = 2)
                     pathtext!(ax, bp, text = "Text along a path", fontsize = 22,
@@ -789,7 +789,7 @@ function attribute_examples(::Type{PathText})
         ],
         :offset => [
             Example(;
-                code = """
+                code = raw"""
                 bp = BezierPath([
                     MoveTo(Point2(0, 0)),
                     CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
@@ -798,7 +798,7 @@ function attribute_examples(::Type{PathText})
                 ax = Axis(fig[1, 1], aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
                 lines!(ax, bp, color = (:gray, 0.4), linewidth = 2)
                 for (off, col) in zip((-15, 0, 15), (:red, :black, :blue))
-                    pathtext!(ax, bp, text = "offset = \\$off", fontsize = 14,
+                    pathtext!(ax, bp, text = "offset = $off", fontsize = 14,
                         align = (:center, :baseline), offset = off, color = col)
                 end
                 fig

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -22,10 +22,12 @@ Newlines in `text` are not supported.
 - `color`: Text color. May be a single value or a vector with one entry per
   character.
 - `strokecolor`, `strokewidth`: Stroke styling; may be per-character.
-- `align = :left`: Alignment along the path. One of `:left`, `:center`, `:right`,
-  or a `Real` fraction (0 = start, 1 = end).
-- `offset = 0.0`: Perpendicular offset from the path in pixels. Positive values
-  shift the text to the left of the path's direction of travel.
+- `align = (:left, :baseline)`: Alignment as `(halign, valign)`. `halign` controls
+  position along the path (`:left`, `:center`, `:right`, or a `Real` 0–1).
+  `valign` controls perpendicular placement relative to font metrics
+  (`:baseline`, `:bottom`, `:center`, `:top`).
+- `offset = 0.0`: Additional perpendicular offset in pixels, applied on top of
+  `valign`. Positive values shift to the left of the path's travel direction.
 - `space = :data`: Coordinate space of the path; `:data` or `:pixel`.
 """
 @recipe PathText (path,) begin
@@ -43,9 +45,9 @@ Newlines in `text` are not supported.
     strokewidth = 0
     "Font size in pixels."
     fontsize = @inherit fontsize
-    "Alignment of the text along the path. One of `:left`, `:center`, `:right`, or a `Real` fraction between 0 (start) and 1 (end)."
-    align = :left
-    "Perpendicular offset (in pixels) from the path. Positive values shift the text to the left of the path's direction of travel."
+    "Alignment of the text relative to the path, as a `(halign, valign)` tuple. `halign` controls position along the path (`:left`, `:center`, `:right`, or a `Real` fraction 0–1). `valign` controls perpendicular placement (`:baseline`, `:bottom`, `:center`, `:top`)."
+    align = (:left, :baseline)
+    "Additional perpendicular offset (in pixels) from the path, applied on top of `valign`. Positive values shift the text to the left of the path's direction of travel."
     offset = 0.0f0
     mixin_generic_plot_attributes()...
     mixin_colormap_attributes()...
@@ -432,19 +434,35 @@ function _place_glyphs_on_path(
     return (positions, rotations, placed_chars)
 end
 
-function _parse_align(align)
-    frac = if align === :left
+function _parse_halign(ha)
+    return if ha === :left
         0.0f0
-    elseif align === :center
+    elseif ha === :center
         0.5f0
-    elseif align === :right
+    elseif ha === :right
         1.0f0
-    elseif align isa Real
-        Float32(align)
+    elseif ha isa Real
+        Float32(ha)
     else
-        throw(ArgumentError("Invalid `align = $(repr(align))` for `pathtext`. Expected `:left`, `:center`, `:right`, or a `Real`."))
+        throw(ArgumentError("Invalid halign $(repr(ha)) for `pathtext`. Expected `:left`, `:center`, `:right`, or a `Real`."))
     end
-    return frac
+end
+
+# Compute perpendicular baseline shift from valign and font metrics (ascender/descender in pixels).
+# Positive result shifts text in the +normal direction (left of path travel).
+function _valign_shift(va, fontsize, font)
+    va === :baseline && return 0.0f0
+    asc = Float32(FreeTypeAbstraction.ascender(font)) * fontsize
+    desc = Float32(FreeTypeAbstraction.descender(font)) * fontsize  # negative
+    return if va === :bottom
+        -desc    # shift up so descender sits on path
+    elseif va === :top
+        -asc     # shift down so ascender sits on path
+    elseif va === :center
+        -(asc + desc) / 2   # center of typographic extent on path
+    else
+        throw(ArgumentError("Invalid valign $(repr(va)) for `pathtext`. Expected `:baseline`, `:bottom`, `:center`, or `:top`."))
+    end
 end
 
 # Per-glyph style overrides from RichText layout (or `nothing` for plain strings
@@ -464,7 +482,8 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::Abstract
 
     _font = to_font(fonts, font)
     _fontsize = Float32(to_fontsize(fontsize))
-    _offset = Float32(offset)
+    halign, valign = align
+    _offset = Float32(offset) + _valign_shift(valign, _fontsize, _font)
 
     working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
 
@@ -475,7 +494,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::Abstract
 
     # x_positions: cumulative advance (start of each glyph)
     x_positions = cumsum(advances) .- advances
-    frac = _parse_align(align)
+    frac = _parse_halign(halign)
     sample_fn = s -> _sample_polyline_at(working_path, s)
     pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
     return (pos, rot, chars, nothing)
@@ -488,7 +507,8 @@ function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, 
 
     _font = to_font(fonts, font)
     _fontsize = Float32(to_fontsize(fontsize))
-    _offset = Float64(offset)
+    halign, valign = align
+    _offset = Float64(offset) + _valign_shift(valign, _fontsize, _font)
 
     segs = _prepare_bezierpath(pixel_bp, _offset)
     isempty(segs) && return _empty_layout()
@@ -499,7 +519,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, 
     total_path_len = Float32(_total_arclen(segs))
 
     x_positions = cumsum(advances) .- advances
-    frac = _parse_align(align)
+    frac = _parse_halign(halign)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
     pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
     return (pos, rot, chars, nothing)
@@ -510,9 +530,10 @@ end
 function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText, fontsize, font, fonts, align, offset)
     length(pixel_path) < 2 && return _empty_layout()
 
-    _fontsize = Float32(to_fontsize(fontsize))
     _font = to_font(fonts, font)
-    _offset = Float32(offset)
+    _fontsize = Float32(to_fontsize(fontsize))
+    halign, valign = align
+    _offset = Float32(offset) + _valign_shift(valign, _fontsize, _font)
 
     gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
     n = length(gc.glyphs)
@@ -529,7 +550,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
     working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
     total_path_len = _polyline_arc_length(working_path)
 
-    frac = _parse_align(align)
+    frac = _parse_halign(halign)
     sample_fn = s -> _sample_polyline_at(working_path, s)
     pos, rot, chars = _place_glyphs_on_path(
         x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
@@ -553,7 +574,8 @@ end
 function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, fonts, align, offset)
     _fontsize = Float32(to_fontsize(fontsize))
     _font = to_font(fonts, font)
-    _offset = Float64(offset)
+    halign, valign = align
+    _offset = Float64(offset) + _valign_shift(valign, _fontsize, _font)
 
     gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
     n = length(gc.glyphs)
@@ -571,7 +593,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     isempty(segs) && return _empty_layout()
     total_path_len = Float32(_total_arclen(segs))
 
-    frac = _parse_align(align)
+    frac = _parse_halign(halign)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
     pos, rot, chars = _place_glyphs_on_path(
         x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -395,18 +395,25 @@ end
 
 # Common helper: place glyphs along a path given their arc-length positions.
 # `sample_fn(s)` returns `(point, tangent)` or `nothing`.
-function _place_glyphs_on_path(x_positions, chars, sample_fn, frac, total_text_len, total_path_len)
+# `y_offsets` (optional) are per-glyph perpendicular shifts (e.g. from sub/superscript baseline).
+function _place_glyphs_on_path(
+        x_positions, chars, sample_fn, frac, total_text_len, total_path_len;
+        y_offsets = nothing,
+    )
     positions = Point2f[]
     rotations = Quaternionf[]
     placed_chars = String[]
 
     start_s = frac * (total_path_len - total_text_len)
 
-    for (x, c) in zip(x_positions, chars)
+    for (i, (x, c)) in enumerate(zip(x_positions, chars))
         sample = sample_fn(start_s + x)
         sample === nothing && break
         pt, tangent = sample
         normal = Point2f(-tangent[2], tangent[1])
+        if y_offsets !== nothing && !iszero(y_offsets[i])
+            pt = pt + y_offsets[i] * normal
+        end
         push!(positions, pt)
         push!(rotations, to_rotation(Vec2f(normal)))
         push!(placed_chars, string(c))
@@ -497,6 +504,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
     length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
 
     x_positions = Float32[gc.origins[i][1] for i in 1:n]
+    y_offsets = Float32[gc.origins[i][2] for i in 1:n]
     scales = collect_vector(gc.scales, n)
     total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
 
@@ -505,7 +513,10 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
 
     frac = _parse_align(align)
     sample_fn = s -> _sample_polyline_at(working_path, s)
-    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    pos, rot, chars = _place_glyphs_on_path(
+        x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
+        y_offsets,
+    )
 
     # Wrap each placed glyph as a single-char RichText with its per-glyph style.
     # This lets the child text! handle font/color/size natively per block.
@@ -535,6 +546,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     length(text_chars) != n && error("RichText character count ($(length(text_chars))) does not match glyph count ($n).")
 
     x_positions = Float32[gc.origins[i][1] for i in 1:n]
+    y_offsets = Float32[gc.origins[i][2] for i in 1:n]
     scales = collect_vector(gc.scales, n)
     total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
 
@@ -544,7 +556,10 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
 
     frac = _parse_align(align)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
-    pos, rot, placed_chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    pos, rot, placed_chars = _place_glyphs_on_path(
+        x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
+        y_offsets,
+    )
 
     m = length(pos)
     colors_vec = collect_vector(gc.colors, n)

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -8,30 +8,12 @@ When a `BezierPath` is provided, glyphs are positioned and oriented using exact
 cubic-Bézier evaluation, giving smooth tangent rotations. A polyline input is
 sampled piecewise-linearly.
 
-Text is always rendered at pixel size (`fontsize` is in pixels) because the glyphs
-are placed visually along the path. The path itself may be given in `:data` or
-`:pixel` space, controlled by the `space` attribute.
+The path itself may be given in `:data` or `:pixel` space, controlled by the `space` attribute.
 
-Newlines in `text` are not supported.
-
-# Attributes
-
-- `text = ""`: The text to place along the path. Must not contain newlines.
-- `fontsize`: The font size in pixels.
-- `font`, `fonts`: Font settings (as for `text`).
-- `color`: Text color. May be a single value or a vector with one entry per
-  character.
-- `strokecolor`, `strokewidth`: Stroke styling; may be per-character.
-- `align = (:left, :baseline)`: Alignment as `(halign, valign)`. `halign` controls
-  position along the path (`:left`, `:center`, `:right`, or a `Real` 0–1).
-  `valign` controls perpendicular placement relative to font metrics
-  (`:baseline`, `:bottom`, `:center`, `:top`).
-- `offset = 0.0`: Additional perpendicular offset in pixels, applied on top of
-  `valign`. Positive values shift to the left of the path's travel direction.
-- `space = :data`: Coordinate space of the path; `:data` or `:pixel`.
+Newlines in `text` are currently not supported.
 """
 @recipe PathText (path,) begin
-    "The text to place along the path. Must not contain newlines."
+    "The text to place along the path. May be `String` or `RichText`. Must not contain newlines."
     text = ""
     "The color of the text. May be a single value or a vector with one entry per character."
     color = @inherit textcolor
@@ -40,7 +22,7 @@ Newlines in `text` are not supported.
     "Dictionary of fonts that can be referenced by `Symbol`."
     fonts = @inherit fonts
     "Color of the text stroke. May be per-character."
-    strokecolor = (:black, 0.0)
+    strokecolor = :black
     "Width of the text stroke in pixels. May be per-character."
     strokewidth = 0
     "Font size in pixels."
@@ -212,23 +194,32 @@ struct _PreparedSegment
     p2::Point2d           # control 2 (cubic)
     p3::Point2d           # end (cubic)
     arclen::Float64       # (offset) arc length
+    subpath_id::Int       # incremented on each MoveTo (to detect sub-path gaps)
 end
 
 function _prepare_bezierpath(bp::BezierPath, d::Real = 0.0)
     bp2 = replace_nonfreetype_commands(bp)
     segs = _PreparedSegment[]
     last_pt = Point2d(0, 0)
+    subpath_id = 0
+    started = false
     for cmd in bp2.commands
         if cmd isa MoveTo
             last_pt = cmd.p
+            if started
+                subpath_id += 1
+            end
+            started = true
         elseif cmd isa LineTo
+            started || (subpath_id += 1; started = true)
             len = norm(cmd.p - last_pt)
-            push!(segs, _PreparedSegment(:line, last_pt, cmd.p, Point2d(0), Point2d(0), len))
+            push!(segs, _PreparedSegment(:line, last_pt, cmd.p, Point2d(0), Point2d(0), len, subpath_id))
             last_pt = cmd.p
         elseif cmd isa CurveTo
+            started || (subpath_id += 1; started = true)
             len = iszero(d) ? _cubic_arclen(last_pt, cmd.c1, cmd.c2, cmd.p) :
                 _cubic_offset_arclen(last_pt, cmd.c1, cmd.c2, cmd.p, d)
-            push!(segs, _PreparedSegment(:cubic, last_pt, cmd.c1, cmd.c2, cmd.p, len))
+            push!(segs, _PreparedSegment(:cubic, last_pt, cmd.c1, cmd.c2, cmd.p, len, subpath_id))
             last_pt = cmd.p
         end
     end
@@ -259,13 +250,13 @@ function _sample_bezierpath_at(segs::Vector{_PreparedSegment}, s::Real, d::Real 
                     nx, ny = -tangent[2], tangent[1]
                     pt = pt + Float32(d) * Point2f(nx, ny)
                 end
-                return (pt, tangent)
+                return (pt, tangent, seg.subpath_id)
             else # :cubic
                 t = _cubic_inv_arclen(seg.p0, seg.p1, seg.p2, seg.p3, local_s, seg.arclen, d)
                 tangent = _cubic_unit_tangent(seg.p0, seg.p1, seg.p2, seg.p3, t)
                 pt = iszero(d) ? Point2f(_cubic_eval(seg.p0, seg.p1, seg.p2, seg.p3, t)...) :
                     _cubic_offset_point(seg.p0, seg.p1, seg.p2, seg.p3, t, d)
-                return (pt, tangent)
+                return (pt, tangent, seg.subpath_id)
             end
         end
         accum += seg.arclen
@@ -332,10 +323,19 @@ end
 function _sample_polyline_at(points::AbstractVector{<:VecTypes}, s::Real)
     s < 0 && return nothing
     accum = 0.0
+    subpath_id = 0
+    prev_was_nan = true   # so the very first valid segment starts sub-path 0
     @inbounds for i in 1:(length(points) - 1)
         p1 = points[i]
         p2 = points[i + 1]
-        (any(isnan, p1) || any(isnan, p2)) && continue
+        if any(isnan, p1) || any(isnan, p2)
+            prev_was_nan = true
+            continue
+        end
+        if prev_was_nan
+            subpath_id += 1
+            prev_was_nan = false
+        end
         v = p2 - p1
         seglen = norm(v)
         iszero(seglen) && continue
@@ -343,7 +343,7 @@ function _sample_polyline_at(points::AbstractVector{<:VecTypes}, s::Real)
             t = (s - accum) / seglen
             unit_tangent = Point2f(v[1] / seglen, v[2] / seglen)
             pt = Point2f(p1[1] + t * v[1], p1[2] + t * v[2])
-            return (pt, unit_tangent)
+            return (pt, unit_tangent, subpath_id)
         end
         accum += seglen
     end
@@ -429,22 +429,23 @@ function _place_glyphs_on_path(
         s0 = start_s + x
         sample_start = sample_fn(s0)
         sample_start === nothing && break
-        pt, _ = sample_start
+        pt, start_tangent, start_subpath = sample_start
 
         # Rotation from the chord spanning the character's advance width.
-        # Falls back to the tangent at the start if the end sample is unavailable.
+        # Falls back to the tangent at the start if the end sample is unavailable
+        # or lands on a different sub-path (avoids bridging NaN gaps).
         sample_end = sample_fn(s0 + adv)
-        if sample_end !== nothing
-            pt_end, _ = sample_end
-            chord = pt_end - pt
-            chord_len = norm(chord)
-            if chord_len > 1.0f-6
-                tangent = Point2f(chord[1] / chord_len, chord[2] / chord_len)
+        tangent = if sample_end !== nothing
+            pt_end, _, end_subpath = sample_end
+            if end_subpath != start_subpath
+                start_tangent
             else
-                tangent = sample_start[2]
+                chord = pt_end - pt
+                chord_len = norm(chord)
+                chord_len > 1.0f-6 ? Point2f(chord[1] / chord_len, chord[2] / chord_len) : start_tangent
             end
         else
-            tangent = sample_start[2]
+            start_tangent
         end
 
         normal = Point2f(-tangent[2], tangent[1])

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -393,6 +393,16 @@ end
 # Layout
 # ==============================================================================
 
+# Layout a single-line RichText into a GlyphCollection with the baseline at y=0.
+# We call the layout sub-steps directly, skipping apply_alignment_and_justification!
+# which would shift all origins by the descender height.
+function _layout_richtext_for_path(text::RichText, fontsize, font, fonts)
+    lines = [GlyphInfo[]]
+    gs = GlyphState(0, 0, Vec2f(fontsize), font, RGBAf(0, 0, 0, 1))
+    process_rt_node!(lines, gs, text, fonts)
+    return GlyphCollection(reduce(vcat, lines))
+end
+
 # Common helper: place glyphs along a path given their arc-length positions.
 # `sample_fn(s)` returns `(point, tangent)` or `nothing`.
 # `y_offsets` (optional) are per-glyph perpendicular shifts (e.g. from sub/superscript baseline).
@@ -436,6 +446,14 @@ function _parse_align(align)
     end
     return frac
 end
+
+# Per-glyph style overrides from RichText layout (or `nothing` for plain strings
+# where the recipe's own color/font/fontsize attributes are used as-is).
+const _PathtextGlyphStyles = @NamedTuple{
+    colors::Vector{RGBAf},
+    fonts::Vector{NativeFont},
+    fontsizes::Vector{Float32},
+}
 
 _empty_layout() = (Point2f[], Quaternionf[], String[], nothing)
 
@@ -496,7 +514,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
     _font = to_font(fonts, font)
     _offset = Float32(offset)
 
-    gc = layout_text(text, _fontsize, _font, fonts, (:left, :baseline), to_rotation(0), :left, 1.0, RGBAf(0, 0, 0, 1))
+    gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
     n = length(gc.glyphs)
     n == 0 && return _empty_layout()
 
@@ -518,17 +536,16 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
         y_offsets,
     )
 
-    # Wrap each placed glyph as a single-char RichText with its per-glyph style.
-    # This lets the child text! handle font/color/size natively per block.
     m = length(pos)
     colors_vec = collect_vector(gc.colors, n)
     fonts_vec = collect_vector(gc.fonts, n)
     scales_vec = collect_vector(gc.scales, n)
-    rt_chars = Union{String, RichText}[
-        rich(string(placed_chars[j]); color = colors_vec[j], font = fonts_vec[j], fontsize = scales_vec[j][1])
-            for j in 1:m
-    ]
-    return (pos, rot, rt_chars, nothing)
+    styles = (
+        colors = colors_vec[1:m],
+        fonts = fonts_vec[1:m],
+        fontsizes = Float32[s[1] for s in scales_vec[1:m]],
+    )::_PathtextGlyphStyles
+    return (pos, rot, chars, styles)
 end
 
 # --- RichText on BezierPath ---------------------------------------------------
@@ -538,7 +555,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     _font = to_font(fonts, font)
     _offset = Float64(offset)
 
-    gc = layout_text(text, _fontsize, _font, fonts, (:left, :baseline), to_rotation(0), :left, 1.0, RGBAf(0, 0, 0, 1))
+    gc = _layout_richtext_for_path(text, _fontsize, _font, fonts)
     n = length(gc.glyphs)
     n == 0 && return _empty_layout()
 
@@ -556,7 +573,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
 
     frac = _parse_align(align)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
-    pos, rot, placed_chars = _place_glyphs_on_path(
+    pos, rot, chars = _place_glyphs_on_path(
         x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
         y_offsets,
     )
@@ -565,11 +582,12 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     colors_vec = collect_vector(gc.colors, n)
     fonts_vec = collect_vector(gc.fonts, n)
     scales_vec = collect_vector(gc.scales, n)
-    rt_chars = Union{String, RichText}[
-        rich(string(placed_chars[j]); color = colors_vec[j], font = fonts_vec[j], fontsize = scales_vec[j][1])
-            for j in 1:m
-    ]
-    return (pos, rot, rt_chars, nothing)
+    styles = (
+        colors = colors_vec[1:m],
+        fonts = fonts_vec[1:m],
+        fontsizes = Float32[s[1] for s in scales_vec[1:m]],
+    )::_PathtextGlyphStyles
+    return (pos, rot, chars, styles)
 end
 
 # ==============================================================================
@@ -619,15 +637,27 @@ function plot!(p::PathText)
         return _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset)
     end
 
+    # For RichText, per-glyph color/font/fontsize come from the layout.
+    # For plain strings, fall through to the recipe's own attributes.
+    map!(p.attributes, [:_pathtext_glyph_styles, :color], :_pathtext_color) do styles, user_color
+        styles !== nothing ? styles.colors : user_color
+    end
+    map!(p.attributes, [:_pathtext_glyph_styles, :font], :_pathtext_font) do styles, user_font
+        styles !== nothing ? styles.fonts : user_font
+    end
+    map!(p.attributes, [:_pathtext_glyph_styles, :fontsize], :_pathtext_fontsize) do styles, user_fs
+        styles !== nothing ? styles.fontsizes : user_fs
+    end
+
     text!(
         p,
         p._pathtext_positions;
         text = p._pathtext_chars,
         rotation = p._pathtext_rotations,
-        fontsize = p.fontsize,
-        font = p.font,
+        fontsize = p._pathtext_fontsize,
+        font = p._pathtext_font,
         fonts = p.fonts,
-        color = p.color,
+        color = p._pathtext_color,
         strokecolor = p.strokecolor,
         strokewidth = p.strokewidth,
         colormap = p.colormap,

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -88,6 +88,11 @@ end
 
 # ==============================================================================
 # Cubic Bézier math
+#
+# Arc-length (Gauss-Legendre quadrature) and inverse arc-length (binary search)
+# techniques are adapted from the `kurbo` Rust crate (MIT-licensed), specifically
+# its `cubicbez.rs` and `param_curve.rs` modules.
+# See https://github.com/linebender/kurbo
 # ==============================================================================
 
 # 8-point Gauss-Legendre nodes and weights on [0, 1]  (transformed from [-1, 1])

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -35,6 +35,11 @@ Newlines in `text` are currently not supported.
     mixin_colormap_attributes()...
 end
 
+# Preserve `align` as-is. The default numeric conversion used for `text`/`scatter`
+# is not appropriate for `pathtext`, whose `halign` accepts a `Real` fraction
+# (0–1) along the path and whose `valign` accepts symbolic values.
+convert_attribute(align, ::key"align", ::key"PathText") = Ref{Any}(align)
+
 # -- convert_arguments ---------------------------------------------------------
 
 function convert_arguments(::Type{<:PathText}, path::AbstractVector{<:VecTypes{2}})

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -157,7 +157,9 @@ function _cubic_inv_arclen(p0, p1, p2, p3, target, total_len, d = 0.0)
     target <= 0 && return 0.0
     target >= total_len && return 1.0
     lo, hi = 0.0, 1.0
-    for _ in 1:30
+    # 20 iterations of bisection → ≈ 1e-6 precision on the parameter, which is
+    # below sub-pixel accuracy for any realistic font size.
+    for _ in 1:20
         mid = 0.5 * (lo + hi)
         s = iszero(d) ? _cubic_arclen(p0, p1, p2, p3, 0.0, mid) :
             _cubic_offset_arclen(p0, p1, p2, p3, d, 0.0, mid)
@@ -199,6 +201,7 @@ struct _PreparedSegment
     p2::Point2d           # control 2 (cubic)
     p3::Point2d           # end (cubic)
     arclen::Float64       # (offset) arc length
+    cum_end::Float64      # cumulative arc length at the end of this segment
     subpath_id::Int       # incremented on each MoveTo (to detect sub-path gaps)
 end
 
@@ -207,6 +210,7 @@ function _prepare_bezierpath(bp::BezierPath, d::Real = 0.0)
     segs = _PreparedSegment[]
     last_pt = Point2d(0, 0)
     subpath_id = 0
+    cum = 0.0
     started = false
     for cmd in bp2.commands
         if cmd isa MoveTo
@@ -218,22 +222,22 @@ function _prepare_bezierpath(bp::BezierPath, d::Real = 0.0)
         elseif cmd isa LineTo
             started || (subpath_id += 1; started = true)
             len = norm(cmd.p - last_pt)
-            push!(segs, _PreparedSegment(:line, last_pt, cmd.p, Point2d(0), Point2d(0), len, subpath_id))
+            cum += len
+            push!(segs, _PreparedSegment(:line, last_pt, cmd.p, Point2d(0), Point2d(0), len, cum, subpath_id))
             last_pt = cmd.p
         elseif cmd isa CurveTo
             started || (subpath_id += 1; started = true)
             len = iszero(d) ? _cubic_arclen(last_pt, cmd.c1, cmd.c2, cmd.p) :
                 _cubic_offset_arclen(last_pt, cmd.c1, cmd.c2, cmd.p, d)
-            push!(segs, _PreparedSegment(:cubic, last_pt, cmd.c1, cmd.c2, cmd.p, len, subpath_id))
+            cum += len
+            push!(segs, _PreparedSegment(:cubic, last_pt, cmd.c1, cmd.c2, cmd.p, len, cum, subpath_id))
             last_pt = cmd.p
         end
     end
     return segs
 end
 
-function _total_arclen(segs::Vector{_PreparedSegment})
-    return sum(s.arclen for s in segs; init = 0.0)
-end
+_total_arclen(segs::Vector{_PreparedSegment}) = isempty(segs) ? 0.0 : segs[end].cum_end
 
 """
 Sample a prepared BezierPath at arc-length `s`. Returns `(point, tangent)` or
@@ -241,32 +245,40 @@ Sample a prepared BezierPath at arc-length `s`. Returns `(point, tangent)` or
 """
 function _sample_bezierpath_at(segs::Vector{_PreparedSegment}, s::Real, d::Real = 0.0)
     s < 0 && return nothing
-    accum = 0.0
-    for seg in segs
-        if accum + seg.arclen >= s
-            local_s = s - accum
-            if seg.kind === :line
-                frac = seg.arclen > 0 ? local_s / seg.arclen : 0.0
-                v = seg.p1 - seg.p0
-                len = norm(v)
-                tangent = len > 0 ? Point2f(v[1] / len, v[2] / len) : Point2f(1, 0)
-                pt = Point2f(seg.p0[1] + frac * v[1], seg.p0[2] + frac * v[2])
-                if !iszero(d)
-                    nx, ny = -tangent[2], tangent[1]
-                    pt = pt + Float32(d) * Point2f(nx, ny)
-                end
-                return (pt, tangent, seg.subpath_id)
-            else # :cubic
-                t = _cubic_inv_arclen(seg.p0, seg.p1, seg.p2, seg.p3, local_s, seg.arclen, d)
-                tangent = _cubic_unit_tangent(seg.p0, seg.p1, seg.p2, seg.p3, t)
-                pt = iszero(d) ? Point2f(_cubic_eval(seg.p0, seg.p1, seg.p2, seg.p3, t)...) :
-                    _cubic_offset_point(seg.p0, seg.p1, seg.p2, seg.p3, t, d)
-                return (pt, tangent, seg.subpath_id)
-            end
+
+    # Binary search the segment whose cumulative arc-length range contains `s`.
+    lo, hi = 1, length(segs)
+    hi == 0 && return nothing
+    while lo < hi
+        mid = (lo + hi) >> 1
+        if segs[mid].cum_end < s
+            lo = mid + 1
+        else
+            hi = mid
         end
-        accum += seg.arclen
     end
-    return nothing
+    seg = segs[lo]
+    seg.cum_end < s && return nothing
+    local_s = s - (seg.cum_end - seg.arclen)
+
+    if seg.kind === :line
+        frac = seg.arclen > 0 ? local_s / seg.arclen : 0.0
+        v = seg.p1 - seg.p0
+        len = norm(v)
+        tangent = len > 0 ? Point2f(v[1] / len, v[2] / len) : Point2f(1, 0)
+        pt = Point2f(seg.p0[1] + frac * v[1], seg.p0[2] + frac * v[2])
+        if !iszero(d)
+            nx, ny = -tangent[2], tangent[1]
+            pt = pt + Float32(d) * Point2f(nx, ny)
+        end
+        return (pt, tangent, seg.subpath_id)
+    else # :cubic
+        t = _cubic_inv_arclen(seg.p0, seg.p1, seg.p2, seg.p3, local_s, seg.arclen, d)
+        tangent = _cubic_unit_tangent(seg.p0, seg.p1, seg.p2, seg.p3, t)
+        pt = iszero(d) ? Point2f(_cubic_eval(seg.p0, seg.p1, seg.p2, seg.p3, t)...) :
+            _cubic_offset_point(seg.p0, seg.p1, seg.p2, seg.p3, t, d)
+        return (pt, tangent, seg.subpath_id)
+    end
 end
 
 # ==============================================================================
@@ -415,19 +427,21 @@ function _layout_richtext_for_path(text::RichText, fontsize, font, fonts)
     return GlyphCollection(reduce(vcat, lines))
 end
 
-# Common helper: place glyphs along a path given their arc-length positions.
-# `sample_fn(s)` returns `(point, tangent)` or `nothing`.
-# `advances` are the horizontal advance widths per glyph (used to compute the
-#   chord across each character for its rotation).
-# `y_offsets` (optional) are per-glyph perpendicular shifts (e.g. from sub/superscript baseline).
+# `sample_fn(s)` returns `(point, tangent, subpath_id)` or `nothing`.
+# `advances` are the horizontal advance widths per glyph; the chord between
+# arc-length `s` and `s + adv` determines the glyph's rotation (so wide letters
+# span the curvature naturally).
+# `y_offsets` (optional) are per-glyph perpendicular shifts from the path
+# baseline (e.g. sub/superscript displacement in RichText).
 function _place_glyphs_on_path(
-        x_positions, advances, chars, sample_fn, frac, total_text_len, total_path_len;
+        x_positions, advances, chars, sample_fn, frac, total_path_len;
         y_offsets = nothing,
     )
     positions = Point2f[]
     rotations = Quaternionf[]
     placed_chars = String[]
 
+    total_text_len = isempty(x_positions) ? 0.0f0 : x_positions[end] + advances[end]
     start_s = frac * (total_path_len - total_text_len)
 
     for (i, (x, adv, c)) in enumerate(zip(x_positions, advances, chars))
@@ -436,9 +450,8 @@ function _place_glyphs_on_path(
         sample_start === nothing && break
         pt, start_tangent, start_subpath = sample_start
 
-        # Rotation from the chord spanning the character's advance width.
-        # Falls back to the tangent at the start if the end sample is unavailable
-        # or lands on a different sub-path (avoids bridging NaN gaps).
+        # Fall back to the start tangent when the chord would bridge a NaN or
+        # MoveTo gap between two sub-paths.
         sample_end = sample_fn(s0 + adv)
         tangent = if sample_end !== nothing
             pt_end, _, end_subpath = sample_end
@@ -479,18 +492,18 @@ function _parse_halign(ha)
     end
 end
 
-# Compute perpendicular baseline shift from valign and font metrics (ascender/descender in pixels).
-# Positive result shifts text in the +normal direction (left of path travel).
+# Perpendicular baseline shift (in pixels) from valign and font metrics.
+# Positive result shifts to the left of the path's travel direction.
 function _valign_shift(va, fontsize, font)
     va === :baseline && return 0.0f0
     asc = Float32(FreeTypeAbstraction.ascender(font)) * fontsize
     desc = Float32(FreeTypeAbstraction.descender(font)) * fontsize  # negative
     return if va === :bottom
-        -desc    # shift up so descender sits on path
+        -desc
     elseif va === :top
-        -asc     # shift down so ascender sits on path
+        -asc
     elseif va === :center
-        -(asc + desc) / 2   # center of typographic extent on path
+        -(asc + desc) / 2
     else
         throw(ArgumentError("Invalid valign $(repr(va)) for `pathtext`. Expected `:baseline`, `:bottom`, `:center`, or `:top`."))
     end
@@ -511,9 +524,13 @@ _empty_layout() = (Point2f[], Quaternionf[], String[], nothing)
 function _layout_glyphs(text::AbstractString, fontsize::Float32, font, fonts)
     chars = collect(text)
     advances = Float32[Float32(GlyphExtent(font, c).hadvance) * fontsize for c in chars]
-    x_positions = cumsum(advances) .- advances
-    y_offsets = nothing
-    return (chars, x_positions, y_offsets, advances, nothing)
+    x_positions = similar(advances)
+    acc = 0.0f0
+    @inbounds for i in eachindex(advances)
+        x_positions[i] = acc
+        acc += advances[i]
+    end
+    return (chars, x_positions, nothing, advances, nothing)
 end
 
 function _layout_glyphs(text::RichText, fontsize::Float32, font, fonts)
@@ -565,10 +582,9 @@ function _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset
     prepared === nothing && return _empty_layout()
     total_path_len, sample_fn = prepared
 
-    total_text_len = isempty(x_positions) ? 0.0f0 : x_positions[end] + advances[end]
     frac = _parse_halign(halign)
     pos, rot, placed = _place_glyphs_on_path(
-        x_positions, advances, chars, sample_fn, frac, total_text_len, total_path_len;
+        x_positions, advances, chars, sample_fn, frac, total_path_len;
         y_offsets,
     )
 

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -1,0 +1,256 @@
+"""
+    pathtext(path; text = "", kwargs...)
+
+Draw `text` along a path. `path` can be a `Vector{<: Point2}` (with optional
+`NaN` separators between sub-paths) or a `BezierPath`.
+
+Text is always rendered at pixel size (`fontsize` is in pixels) because the glyphs
+are placed visually along the path. The path itself may be given in `:data` or
+`:pixel` space, controlled by the `space` attribute.
+
+Newlines in `text` are not supported.
+
+# Attributes
+
+- `text = ""`: The text to place along the path. Must not contain newlines.
+- `fontsize`: The font size in pixels.
+- `font`, `fonts`: Font settings (as for `text`).
+- `color`: Text color. May be a single value or a vector with one entry per
+  character.
+- `strokecolor`, `strokewidth`: Stroke styling; may be per-character.
+- `align = :left`: Alignment along the path. One of `:left`, `:center`, `:right`.
+- `offset = 0.0`: Perpendicular offset from the path in pixels. Positive values
+  shift the text to the left of the path's direction of travel.
+- `space = :data`: Coordinate space of the path; `:data` or `:pixel`.
+"""
+@recipe PathText (path,) begin
+    "The text to place along the path. Must not contain newlines."
+    text = ""
+    "The color of the text. May be a single value or a vector with one entry per character."
+    color = @inherit textcolor
+    "Sets the font. Can be a `Symbol` that is looked up in `fonts` or a font path/name."
+    font = @inherit font
+    "Dictionary of fonts that can be referenced by `Symbol`."
+    fonts = @inherit fonts
+    "Color of the text stroke. May be per-character."
+    strokecolor = (:black, 0.0)
+    "Width of the text stroke in pixels. May be per-character."
+    strokewidth = 0
+    "Font size in pixels."
+    fontsize = @inherit fontsize
+    "Alignment of the text along the path. One of `:left`, `:center`, `:right`, or a `Real` fraction between 0 (start) and 1 (end) controlling the start position of the text relative to the slack between path and text length."
+    align = :left
+    "Perpendicular offset (in pixels) from the path. Positive values shift the text to the left of the path's direction of travel."
+    offset = 0.0f0
+    mixin_generic_plot_attributes()...
+    mixin_colormap_attributes()...
+end
+
+conversion_trait(::Type{<:PathText}) = PointBased()
+
+# -- arc-length utilities for polylines with NaN separators -------------------
+
+function _polyline_arc_length(points::AbstractVector{<:VecTypes})
+    total = 0.0
+    @inbounds for i in 1:(length(points) - 1)
+        p1 = points[i]
+        p2 = points[i + 1]
+        (any(isnan, p1) || any(isnan, p2)) && continue
+        total += norm(p2 - p1)
+    end
+    return Float32(total)
+end
+
+# Perpendicular normal (90° CCW) of the segment p1->p2, or `nothing` if invalid.
+function _seg_normal(p1, p2)
+    (any(isnan, p1) || any(isnan, p2)) && return nothing
+    v = p2 - p1
+    len = norm(v)
+    iszero(len) && return nothing
+    return Vec2f(-v[2] / len, v[1] / len)
+end
+
+"""
+Offset a polyline perpendicularly by `d` pixels (positive = left of path
+direction). Uses the angle-bisector at interior vertices to keep the offset
+polyline roughly at distance `d` from both incident segments. `NaN` separators
+are preserved as separators between sub-paths, each offset independently.
+"""
+function _offset_polyline(points::AbstractVector{<:VecTypes}, d::Real)
+    n = length(points)
+    result = Vector{Point2f}(undef, n)
+    iszero(d) && return Point2f[Point2f(p) for p in points]
+    d = Float32(d)
+
+    for i in 1:n
+        p = points[i]
+        if any(isnan, p)
+            result[i] = Point2f(NaN, NaN)
+            continue
+        end
+        n_in = i > 1 ? _seg_normal(points[i - 1], p) : nothing
+        n_out = i < n ? _seg_normal(p, points[i + 1]) : nothing
+        if n_in === nothing && n_out === nothing
+            result[i] = Point2f(p)
+        elseif n_in === nothing
+            result[i] = Point2f(p) + d * Point2f(n_out)
+        elseif n_out === nothing
+            result[i] = Point2f(p) + d * Point2f(n_in)
+        else
+            denom = 1 + dot(n_in, n_out)
+            if denom < 1.0f-3
+                # near reversal; avoid huge miter
+                result[i] = Point2f(p) + d * Point2f(n_in)
+            else
+                avg = n_in + n_out
+                result[i] = Point2f(p) + (d / denom) * Point2f(avg)
+            end
+        end
+    end
+    return result
+end
+
+"""
+Sample a polyline at arc-length `s`, skipping over `NaN` separators between
+sub-paths. Returns `(point, unit_tangent)` as `Point2f`, or `nothing` if `s` is
+beyond the end of the path.
+"""
+function _sample_polyline_at(points::AbstractVector{<:VecTypes}, s::Real)
+    s < 0 && return nothing
+    accum = 0.0
+    @inbounds for i in 1:(length(points) - 1)
+        p1 = points[i]
+        p2 = points[i + 1]
+        (any(isnan, p1) || any(isnan, p2)) && continue
+        v = p2 - p1
+        seglen = norm(v)
+        iszero(seglen) && continue
+        if accum + seglen >= s
+            t = (s - accum) / seglen
+            unit_tangent = Point2f(v[1] / seglen, v[2] / seglen)
+            pt = Point2f(p1[1] + t * v[1], p1[2] + t * v[2])
+            return (pt, unit_tangent)
+        end
+        accum += seglen
+    end
+    return nothing
+end
+
+# -- layout --------------------------------------------------------------------
+
+function _pathtext_layout(pixel_path, text::AbstractString, fontsize, font, fonts, align, offset)
+    positions = Point2f[]
+    rotations = Quaternionf[]
+    chars = String[]
+
+    (isempty(text) || length(pixel_path) < 2) && return (positions, rotations, chars)
+
+    _font = to_font(fonts, font)
+    _fontsize = Float32(to_fontsize(fontsize))
+    _offset = Float32(offset)
+
+    # Offset the polyline first so the text is laid out along the already-offset
+    # path. This keeps glyph spacing uniform on curves (without this the convex
+    # side would stretch characters apart and the concave side would crowd them).
+    working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
+
+    text_chars = collect(text)
+    advances = Float32[Float32(GlyphExtent(_font, c).hadvance) * _fontsize for c in text_chars]
+    total_text_len = sum(advances; init = 0.0f0)
+    total_path_len = _polyline_arc_length(working_path)
+
+    frac = if align === :left
+        0.0f0
+    elseif align === :center
+        0.5f0
+    elseif align === :right
+        1.0f0
+    elseif align isa Real
+        Float32(align)
+    else
+        throw(ArgumentError("Invalid `align = $(repr(align))` for `pathtext`. Expected `:left`, `:center`, `:right`, or a `Real`."))
+    end
+    start_s = frac * (total_path_len - total_text_len)
+
+    s = start_s
+    for (c, adv) in zip(text_chars, advances)
+        sample = _sample_polyline_at(working_path, s)
+        sample === nothing && break
+        pt, tangent = sample
+        # "up" of the text is perpendicular to tangent, rotated 90° CCW.
+        normal = Point2f(-tangent[2], tangent[1])
+        push!(positions, pt)
+        push!(rotations, to_rotation(Vec2f(normal)))
+        push!(chars, string(c))
+        s += adv
+    end
+
+    return (positions, rotations, chars)
+end
+
+# -- plot! ---------------------------------------------------------------------
+
+function plot!(p::PathText)
+    map!(p.attributes, [:text], :_pathtext_validated_text) do text
+        occursin('\n', text) && throw(ArgumentError("`pathtext` does not support newlines in `text`."))
+        return String(text)
+    end
+
+    # Project the path from its input space (plot.space = :data or :pixel) to pixel space.
+    # The result is reactive on camera / transform changes so text stays aligned on zoom/pan.
+    register_projected_positions!(
+        p, Point2f;
+        input_name = :path,
+        output_name = :_pathtext_path_pixel,
+        input_space = :space,
+        output_space = :pixel,
+    )
+
+    map!(
+        p.attributes,
+        [:_pathtext_path_pixel, :_pathtext_validated_text, :fontsize, :font, :fonts, :align, :offset],
+        [:_pathtext_positions, :_pathtext_rotations, :_pathtext_chars]
+    ) do pixel_path, text, fontsize, font, fonts, align, offset
+        return _pathtext_layout(pixel_path, text, fontsize, font, fonts, align, offset)
+    end
+
+    text!(
+        p,
+        p._pathtext_positions;
+        text = p._pathtext_chars,
+        rotation = p._pathtext_rotations,
+        fontsize = p.fontsize,
+        font = p.font,
+        fonts = p.fonts,
+        color = p.color,
+        strokecolor = p.strokecolor,
+        strokewidth = p.strokewidth,
+        colormap = p.colormap,
+        colorscale = p.colorscale,
+        colorrange = p.colorrange,
+        lowclip = p.lowclip,
+        highclip = p.highclip,
+        nan_color = p.nan_color,
+        alpha = p.alpha,
+        visible = p.visible,
+        transparency = p.transparency,
+        overdraw = p.overdraw,
+        inspectable = p.inspectable,
+        align = (:left, :baseline),
+        space = :pixel,
+        markerspace = :pixel,
+        transformation = :nothing,
+    )
+
+    return p
+end
+
+function data_limits(p::PathText)
+    return if p.space[] === :data
+        pts = p.path[]
+        isempty(pts) ? Rect3d(Point3d(NaN), Vec3d(NaN)) : Rect3d(Rect2d(pts))
+    else
+        Rect3d(Point3d(NaN), Vec3d(NaN))
+    end
+end
+boundingbox(p::PathText, space::Symbol = :data) = apply_transform_and_model(p, data_limits(p))

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -736,3 +736,63 @@ function data_limits(p::PathText)
     return Rect3d(Point3d(NaN), Vec3d(NaN))
 end
 boundingbox(p::PathText, space::Symbol = :data) = apply_transform_and_model(p, data_limits(p))
+
+function attribute_examples(::Type{PathText})
+    return Dict(
+        :text => [
+            Example(;
+                code = """
+                bp = BezierPath([
+                    MoveTo(Point2(0, 0)),
+                    CurveTo(Point2(1, 2), Point2(3, 2), Point2(4, 0)),
+                ])
+                fig = Figure()
+                ax = Axis(fig[1, 1], aspect = DataAspect())
+                lines!(ax, bp, color = (:gray, 0.4))
+                pathtext!(ax, bp, text = "plain string", fontsize = 20, align = (:left, :bottom))
+                pathtext!(ax, bp, text = rich("Rich", rich("Text"; color = :red, font = :bold)),
+                    fontsize = 20, align = (:right, :bottom))
+                fig
+                """
+            ),
+        ],
+        :align => [
+            Example(;
+                code = """
+                bp = BezierPath([
+                    MoveTo(Point2(0, 0)),
+                    CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+                ])
+                fig = Figure(size = (800, 600))
+                for (i, va) in enumerate((:top, :center, :baseline, :bottom))
+                    r, c = fldmod1(i, 2)
+                    ax = Axis(fig[r, c], aspect = DataAspect(), title = "valign = \\$(repr(va))",
+                        limits = (nothing, (-0.5, 3)))
+                    lines!(ax, bp, color = (:steelblue, 0.5), linewidth = 2)
+                    pathtext!(ax, bp, text = "Text along a path", fontsize = 22,
+                        align = (:center, va))
+                end
+                fig
+                """
+            ),
+        ],
+        :offset => [
+            Example(;
+                code = """
+                bp = BezierPath([
+                    MoveTo(Point2(0, 0)),
+                    CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+                ])
+                fig = Figure()
+                ax = Axis(fig[1, 1], aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
+                lines!(ax, bp, color = (:gray, 0.4), linewidth = 2)
+                for (off, col) in zip((-15, 0, 15), (:red, :black, :blue))
+                    pathtext!(ax, bp, text = "offset = \\$off", fontsize = 14,
+                        align = (:center, :baseline), offset = off, color = col)
+                end
+                fig
+                """
+            ),
+        ],
+    )
+end

--- a/Makie/src/basic_recipes/pathtext.jl
+++ b/Makie/src/basic_recipes/pathtext.jl
@@ -407,9 +407,11 @@ end
 
 # Common helper: place glyphs along a path given their arc-length positions.
 # `sample_fn(s)` returns `(point, tangent)` or `nothing`.
+# `advances` are the horizontal advance widths per glyph (used to compute the
+#   chord across each character for its rotation).
 # `y_offsets` (optional) are per-glyph perpendicular shifts (e.g. from sub/superscript baseline).
 function _place_glyphs_on_path(
-        x_positions, chars, sample_fn, frac, total_text_len, total_path_len;
+        x_positions, advances, chars, sample_fn, frac, total_text_len, total_path_len;
         y_offsets = nothing,
     )
     positions = Point2f[]
@@ -418,10 +420,28 @@ function _place_glyphs_on_path(
 
     start_s = frac * (total_path_len - total_text_len)
 
-    for (i, (x, c)) in enumerate(zip(x_positions, chars))
-        sample = sample_fn(start_s + x)
-        sample === nothing && break
-        pt, tangent = sample
+    for (i, (x, adv, c)) in enumerate(zip(x_positions, advances, chars))
+        s0 = start_s + x
+        sample_start = sample_fn(s0)
+        sample_start === nothing && break
+        pt, _ = sample_start
+
+        # Rotation from the chord spanning the character's advance width.
+        # Falls back to the tangent at the start if the end sample is unavailable.
+        sample_end = sample_fn(s0 + adv)
+        if sample_end !== nothing
+            pt_end, _ = sample_end
+            chord = pt_end - pt
+            chord_len = norm(chord)
+            if chord_len > 1.0f-6
+                tangent = Point2f(chord[1] / chord_len, chord[2] / chord_len)
+            else
+                tangent = sample_start[2]
+            end
+        else
+            tangent = sample_start[2]
+        end
+
         normal = Point2f(-tangent[2], tangent[1])
         if y_offsets !== nothing && !iszero(y_offsets[i])
             pt = pt + y_offsets[i] * normal
@@ -496,7 +516,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::Abstract
     x_positions = cumsum(advances) .- advances
     frac = _parse_halign(halign)
     sample_fn = s -> _sample_polyline_at(working_path, s)
-    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    pos, rot, chars = _place_glyphs_on_path(x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len)
     return (pos, rot, chars, nothing)
 end
 
@@ -521,7 +541,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::AbstractString, fontsize, 
     x_positions = cumsum(advances) .- advances
     frac = _parse_halign(halign)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
-    pos, rot, chars = _place_glyphs_on_path(x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len)
+    pos, rot, chars = _place_glyphs_on_path(x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len)
     return (pos, rot, chars, nothing)
 end
 
@@ -545,7 +565,8 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
     x_positions = Float32[gc.origins[i][1] for i in 1:n]
     y_offsets = Float32[gc.origins[i][2] for i in 1:n]
     scales = collect_vector(gc.scales, n)
-    total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
+    advances = Float32[gc.extents[i].hadvance * scales[i][1] for i in 1:n]
+    total_text_len = x_positions[end] + advances[end]
 
     working_path = iszero(_offset) ? pixel_path : _offset_polyline(pixel_path, _offset)
     total_path_len = _polyline_arc_length(working_path)
@@ -553,7 +574,7 @@ function _pathtext_layout(pixel_path::AbstractVector{<:VecTypes}, text::RichText
     frac = _parse_halign(halign)
     sample_fn = s -> _sample_polyline_at(working_path, s)
     pos, rot, chars = _place_glyphs_on_path(
-        x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
+        x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len;
         y_offsets,
     )
 
@@ -587,7 +608,8 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     x_positions = Float32[gc.origins[i][1] for i in 1:n]
     y_offsets = Float32[gc.origins[i][2] for i in 1:n]
     scales = collect_vector(gc.scales, n)
-    total_text_len = x_positions[end] + gc.extents[end].hadvance * scales[end][1]
+    advances = Float32[gc.extents[i].hadvance * scales[i][1] for i in 1:n]
+    total_text_len = x_positions[end] + advances[end]
 
     segs = _prepare_bezierpath(pixel_bp, _offset)
     isempty(segs) && return _empty_layout()
@@ -596,7 +618,7 @@ function _pathtext_layout(pixel_bp::BezierPath, text::RichText, fontsize, font, 
     frac = _parse_halign(halign)
     sample_fn = s -> _sample_bezierpath_at(segs, s, _offset)
     pos, rot, chars = _place_glyphs_on_path(
-        x_positions, text_chars, sample_fn, frac, total_text_len, total_path_len;
+        x_positions, advances, text_chars, sample_fn, frac, total_text_len, total_path_len;
         y_offsets,
     )
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -2466,6 +2466,16 @@ end
         ax, 0, -100, 10, sin(10),
         style = Ann.Styles.LineArrow(),
     )
+    ylims!(ax, -1.5, 1.8)
+    annotation!(
+        ax, pi / 2, 1.0, 5pi / 2, 1.0,
+        text = "", style = Ann.Styles.WithText(
+            Ann.Styles.LineArrow();
+            text = "one period", fontsize = 12
+        ),
+        path = Ann.Paths.Arc(0.3), labelspace = :data,
+        color = :purple, shrink = (5.0, 5.0),
+    )
 
     f
 end

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -593,7 +593,7 @@ end
             MoveTo(Point2(0.0, 0.0)),
             LineTo(Point2(1.5, 0.0)),
             CurveTo(Point2(2.5, 1.5), Point2(3.5, -1.5), Point2(4.5, 0.0)),
-            EllipticalArc(Point2(5.5, 0.0), 1.0, 0.6, 0.0, π, 0.0),
+            Makie.EllipticalArc(Point2(5.5, 0.0), 1.0, 0.6, 0.0, π, 0.0),
         ]
     )
     pts = Makie.convert_arguments(Makie.PointBased(), bp)[1]

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -606,6 +606,29 @@ end
     f
 end
 
+@reference_test "pathtext as annotation style" begin
+    f = Figure(size = (500, 300))
+    ax = Axis(f[1, 1]; limits = ((0, 6), (1, 6)))
+    hidedecorations!(ax); hidespines!(ax)
+    scatter!(ax, [1, 5], [2, 5]; markersize = 10, color = :black)
+    annotation!(
+        ax, [Point2f(1, 2)], [Point2f(5, 5)];
+        text = [""],
+        path = Ann.Paths.Arc(height = 0.4),
+        style = Ann.Styles.WithText(
+            Ann.Styles.LineArrow();
+            text = rich(
+                "H", subscript("2"), "O → ",
+                rich("products"; color = :crimson),
+            ),
+            fontsize = 14,
+        ),
+        color = :steelblue, linewidth = 1.5,
+        labelspace = :data, shrink = (5.0, 5.0),
+    )
+    f
+end
+
 @reference_test "pathtext data vs pixel space" begin
     f = Figure(size = (500, 250))
 

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -528,87 +528,66 @@ end
             CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
         ]
     )
-    f = Figure(size = (800, 800))
-    # halign variants along the path
+    f = Figure(size = (600, 400))
     for (i, ha) in enumerate((:left, :center, :right))
-        ax = Axis(
-            f[1, i]; aspect = DataAspect(), title = "halign = $(repr(ha))",
-            limits = (nothing, (-0.5, 3))
-        )
+        ax = Axis(f[1, i]; title = "halign = $(repr(ha))", limits = ((-0.2, 4.2), (-0.2, 3)))
+        hidedecorations!(ax); hidespines!(ax)
         lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
-        pathtext!(ax, bp; text = "Text along a path", fontsize = 16, align = (ha, :baseline))
+        pathtext!(ax, bp; text = "Text along a path", fontsize = 14, align = (ha, :baseline))
     end
-    # valign variants perpendicular to the path
     for (i, va) in enumerate((:top, :center, :bottom))
-        ax = Axis(
-            f[2, i]; aspect = DataAspect(), title = "valign = $(repr(va))",
-            limits = (nothing, (-0.5, 3))
-        )
+        ax = Axis(f[2, i]; title = "valign = $(repr(va))", limits = ((-0.2, 4.2), (-0.2, 3)))
+        hidedecorations!(ax); hidespines!(ax)
         lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
-        pathtext!(ax, bp; text = "Text along a path", fontsize = 16, align = (:center, va))
+        pathtext!(ax, bp; text = "Text along a path", fontsize = 14, align = (:center, va))
     end
     f
 end
 
-@reference_test "pathtext string and richtext" begin
+@reference_test "pathtext richtext and offset" begin
     bp = BezierPath(
         [
             MoveTo(Point2(0, 0)),
             CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
         ]
     )
-    f = Figure(size = (800, 500))
-    ax = Axis(f[1, 1]; aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
+    f = Figure(size = (500, 350))
+    ax = Axis(f[1, 1]; limits = ((-0.2, 4.2), (-0.2, 3)))
+    hidedecorations!(ax); hidespines!(ax)
     lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
-    # plain string with per-char color vector
+    # Plain string with per-char color vector, offset above the curve.
     cols = resample_cmap(:viridis, 17)
     pathtext!(
-        ax, bp; text = "Text along a path", fontsize = 18,
-        align = (:center, :top), color = cols
+        ax, bp; text = "Text along a path", fontsize = 14,
+        align = (:center, :bottom), offset = 8, color = cols,
     )
-    # RichText with bold, color, sub/superscript
+    # RichText with bold, color, sub/superscript, offset below the curve.
     rt = rich(
         "H", subscript("2"), "O → H", superscript("+"),
-        " + ", rich("OH"; font = :bold, color = :crimson), superscript("−")
+        " + ", rich("OH"; font = :bold, color = :crimson), superscript("−"),
     )
-    pathtext!(ax, bp; text = rt, fontsize = 18, align = (:center, :bottom))
-    f
-end
-
-@reference_test "pathtext offset" begin
-    bp = BezierPath(
-        [
-            MoveTo(Point2(0, 0)),
-            CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
-        ]
-    )
-    f = Figure(size = (800, 500))
-    ax = Axis(f[1, 1]; aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
-    lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
-    for (off, col) in zip((-20, 0, 20), (:crimson, :black, :steelblue))
-        pathtext!(
-            ax, bp; text = "offset = $off", fontsize = 14,
-            align = (:center, :baseline), offset = off, color = col
-        )
-    end
+    pathtext!(ax, bp; text = rt, fontsize = 14, align = (:center, :top), offset = -8)
     f
 end
 
 @reference_test "pathtext polyline vs BezierPath" begin
-    f = Figure(size = (800, 600))
+    f = Figure(size = (500, 400))
 
-    # Polyline (LineTo-only) with NaN gap
     ax1 = Axis(f[1, 1]; title = "polyline with NaN sub-path gap")
+    hidedecorations!(ax1); hidespines!(ax1)
     poly_path = Point2f[(0, 0), (1.5, 1), (3, 0), (NaN, NaN), (4, 1), (6, 0)]
     lines!(ax1, poly_path; color = (:gray, 0.4), linewidth = 2)
     pathtext!(
         ax1, poly_path;
-        text = "text flows up the first hill, over its peak, skips across the NaN gap, climbs the second hill, and descends",
-        fontsize = 14,
+        text = "up the first hill and down, across the NaN gap to the second, up and down again until the end of the polyline",
+        fontsize = 11,
     )
 
-    # BezierPath with MoveTo / LineTo / CurveTo / EllipticalArc
-    ax2 = Axis(f[2, 1]; aspect = DataAspect(), title = "BezierPath (LineTo, CurveTo, EllipticalArc)")
+    ax2 = Axis(
+        f[2, 1]; aspect = DataAspect(), title = "LineTo, CurveTo, EllipticalArc",
+        limits = (nothing, (-0.7, 1.3)),
+    )
+    hidedecorations!(ax2); hidespines!(ax2)
     bp = BezierPath(
         [
             MoveTo(Point2(0.0, 0.0)),
@@ -621,20 +600,20 @@ end
     lines!(ax2, pts; color = (:gray, 0.4), linewidth = 2)
     pathtext!(
         ax2, bp;
-        text = "straight line · cubic curve with inflection · elliptical arc",
-        fontsize = 14, align = (:center, :bottom),
+        text = "a straight LineTo, a curving CurveTo with inflection, and an EllipticalArc",
+        fontsize = 11, align = (:center, :bottom),
     )
     f
 end
 
 @reference_test "pathtext data vs pixel space" begin
-    f = Figure(size = (800, 400))
+    f = Figure(size = (500, 250))
 
-    # :data space — path coordinates in axis data units
     ax1 = Axis(
         f[1, 1]; aspect = DataAspect(), title = "space = :data",
-        limits = (nothing, (-0.5, 2))
+        limits = (nothing, (-0.3, 2)),
     )
+    hidedecorations!(ax1); hidespines!(ax1)
     bp_data = BezierPath(
         [
             MoveTo(Point2(0.0, 0.0)),
@@ -644,23 +623,23 @@ end
     pts_data = Makie.convert_arguments(Makie.PointBased(), bp_data)[1]
     lines!(ax1, pts_data; color = (:gray, 0.4))
     pathtext!(
-        ax1, bp_data; text = "path in data space", fontsize = 16,
-        align = (:center, :bottom), space = :data
+        ax1, bp_data; text = "data space", fontsize = 12,
+        align = (:center, :bottom), space = :data,
     )
 
-    # :pixel space — path coordinates in pixels of the axis scene
     ax2 = Axis(f[1, 2]; title = "space = :pixel", limits = ((0, 1), (0, 1)))
+    hidedecorations!(ax2); hidespines!(ax2)
     bp_pixel = BezierPath(
         [
-            MoveTo(Point2(30.0, 30.0)),
-            CurveTo(Point2(100.0, 250.0), Point2(200.0, 250.0), Point2(280.0, 30.0)),
+            MoveTo(Point2(20.0, 20.0)),
+            CurveTo(Point2(60.0, 150.0), Point2(120.0, 150.0), Point2(170.0, 20.0)),
         ]
     )
     pts_pixel = Makie.convert_arguments(Makie.PointBased(), bp_pixel)[1]
     lines!(ax2, pts_pixel; color = (:gray, 0.4), space = :pixel)
     pathtext!(
-        ax2, bp_pixel; text = "path in pixel space", fontsize = 16,
-        align = (:center, :bottom), space = :pixel, color = :crimson
+        ax2, bp_pixel; text = "pixel space", fontsize = 12,
+        align = (:center, :bottom), space = :pixel, color = :crimson,
     )
     f
 end

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -520,3 +520,147 @@ end
     Makie.step!(st)
     st
 end
+
+@reference_test "pathtext align" begin
+    bp = BezierPath(
+        [
+            MoveTo(Point2(0, 0)),
+            CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+        ]
+    )
+    f = Figure(size = (800, 800))
+    # halign variants along the path
+    for (i, ha) in enumerate((:left, :center, :right))
+        ax = Axis(
+            f[1, i]; aspect = DataAspect(), title = "halign = $(repr(ha))",
+            limits = (nothing, (-0.5, 3))
+        )
+        lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
+        pathtext!(ax, bp; text = "Text along a path", fontsize = 16, align = (ha, :baseline))
+    end
+    # valign variants perpendicular to the path
+    for (i, va) in enumerate((:top, :center, :bottom))
+        ax = Axis(
+            f[2, i]; aspect = DataAspect(), title = "valign = $(repr(va))",
+            limits = (nothing, (-0.5, 3))
+        )
+        lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
+        pathtext!(ax, bp; text = "Text along a path", fontsize = 16, align = (:center, va))
+    end
+    f
+end
+
+@reference_test "pathtext string and richtext" begin
+    bp = BezierPath(
+        [
+            MoveTo(Point2(0, 0)),
+            CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+        ]
+    )
+    f = Figure(size = (800, 500))
+    ax = Axis(f[1, 1]; aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
+    lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
+    # plain string with per-char color vector
+    cols = resample_cmap(:viridis, 17)
+    pathtext!(
+        ax, bp; text = "Text along a path", fontsize = 18,
+        align = (:center, :top), color = cols
+    )
+    # RichText with bold, color, sub/superscript
+    rt = rich(
+        "H", subscript("2"), "O → H", superscript("+"),
+        " + ", rich("OH"; font = :bold, color = :crimson), superscript("−")
+    )
+    pathtext!(ax, bp; text = rt, fontsize = 18, align = (:center, :bottom))
+    f
+end
+
+@reference_test "pathtext offset" begin
+    bp = BezierPath(
+        [
+            MoveTo(Point2(0, 0)),
+            CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+        ]
+    )
+    f = Figure(size = (800, 500))
+    ax = Axis(f[1, 1]; aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
+    lines!(ax, bp; color = (:gray, 0.4), linewidth = 2)
+    for (off, col) in zip((-20, 0, 20), (:crimson, :black, :steelblue))
+        pathtext!(
+            ax, bp; text = "offset = $off", fontsize = 14,
+            align = (:center, :baseline), offset = off, color = col
+        )
+    end
+    f
+end
+
+@reference_test "pathtext polyline vs BezierPath" begin
+    f = Figure(size = (800, 600))
+
+    # Polyline (LineTo-only) with NaN gap
+    ax1 = Axis(f[1, 1]; title = "polyline with NaN sub-path gap")
+    poly_path = Point2f[(0, 0), (1.5, 1), (3, 0), (NaN, NaN), (4, 1), (6, 0)]
+    lines!(ax1, poly_path; color = (:gray, 0.4), linewidth = 2)
+    pathtext!(
+        ax1, poly_path;
+        text = "text flows up the first hill, over its peak, skips across the NaN gap, climbs the second hill, and descends",
+        fontsize = 14,
+    )
+
+    # BezierPath with MoveTo / LineTo / CurveTo / EllipticalArc
+    ax2 = Axis(f[2, 1]; aspect = DataAspect(), title = "BezierPath (LineTo, CurveTo, EllipticalArc)")
+    bp = BezierPath(
+        [
+            MoveTo(Point2(0.0, 0.0)),
+            LineTo(Point2(1.5, 0.0)),
+            CurveTo(Point2(2.5, 1.5), Point2(3.5, -1.5), Point2(4.5, 0.0)),
+            EllipticalArc(Point2(5.5, 0.0), 1.0, 0.6, 0.0, π, 0.0),
+        ]
+    )
+    pts = Makie.convert_arguments(Makie.PointBased(), bp)[1]
+    lines!(ax2, pts; color = (:gray, 0.4), linewidth = 2)
+    pathtext!(
+        ax2, bp;
+        text = "straight line · cubic curve with inflection · elliptical arc",
+        fontsize = 14, align = (:center, :bottom),
+    )
+    f
+end
+
+@reference_test "pathtext data vs pixel space" begin
+    f = Figure(size = (800, 400))
+
+    # :data space — path coordinates in axis data units
+    ax1 = Axis(
+        f[1, 1]; aspect = DataAspect(), title = "space = :data",
+        limits = (nothing, (-0.5, 2))
+    )
+    bp_data = BezierPath(
+        [
+            MoveTo(Point2(0.0, 0.0)),
+            CurveTo(Point2(1.0, 1.5), Point2(3.0, 1.5), Point2(4.0, 0.0)),
+        ]
+    )
+    pts_data = Makie.convert_arguments(Makie.PointBased(), bp_data)[1]
+    lines!(ax1, pts_data; color = (:gray, 0.4))
+    pathtext!(
+        ax1, bp_data; text = "path in data space", fontsize = 16,
+        align = (:center, :bottom), space = :data
+    )
+
+    # :pixel space — path coordinates in pixels of the axis scene
+    ax2 = Axis(f[1, 2]; title = "space = :pixel", limits = ((0, 1), (0, 1)))
+    bp_pixel = BezierPath(
+        [
+            MoveTo(Point2(30.0, 30.0)),
+            CurveTo(Point2(100.0, 250.0), Point2(200.0, 250.0), Point2(280.0, 30.0)),
+        ]
+    )
+    pts_pixel = Makie.convert_arguments(Makie.PointBased(), bp_pixel)[1]
+    lines!(ax2, pts_pixel; color = (:gray, 0.4), space = :pixel)
+    pathtext!(
+        ax2, bp_pixel; text = "path in pixel space", fontsize = 16,
+        align = (:center, :bottom), space = :pixel, color = :crimson
+    )
+    f
+end

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -96,6 +96,7 @@ pages = [
                 "linesegments.md",
                 "mesh.md",
                 "meshscatter.md",
+                "pathtext.md",
                 "pie.md",
                 "poly.md",
                 "qqnorm.md",

--- a/docs/src/reference/plots/annotation.md
+++ b/docs/src/reference/plots/annotation.md
@@ -35,6 +35,25 @@ hidedecorations!.([ax1, ax2])
 f
 ```
 
+### Text along the connection path
+
+`Ann.Styles.WithText` wraps another annotation style and additionally draws text along the connection path using [`pathtext`](@ref).
+
+```@figure
+f = Figure()
+ax = Axis(f[1, 1])
+A, B = Point2f(1, 2), Point2f(5, 5)
+scatter!(ax, [A, B], markersize = 10, color = :black)
+text!(ax, [A, B], text = ["A", "B"], align = (:right, :top), offset = (-6, -4))
+annotation!(ax, [A], [B];
+    text = [""],
+    path = Ann.Paths.Arc(height = 0.4),
+    style = Ann.Styles.WithText(Ann.Styles.LineArrow();
+        text = "from A to B", fontsize = 14),
+    color = :steelblue, labelspace = :data, shrink = (5.0, 5.0))
+f
+```
+
 ## Attributes
 
 ```@attrdocs

--- a/docs/src/reference/plots/annotation.md
+++ b/docs/src/reference/plots/annotation.md
@@ -35,25 +35,6 @@ hidedecorations!.([ax1, ax2])
 f
 ```
 
-### Text along the connection path
-
-`Ann.Styles.WithText` wraps another annotation style and additionally draws text along the connection path using [`pathtext`](@ref).
-
-```@figure
-f = Figure()
-ax = Axis(f[1, 1])
-A, B = Point2f(1, 2), Point2f(5, 5)
-scatter!(ax, [A, B], markersize = 10, color = :black)
-text!(ax, [A, B], text = ["A", "B"], align = (:right, :top), offset = (-6, -4))
-annotation!(ax, [A], [B];
-    text = [""],
-    path = Ann.Paths.Arc(height = 0.4),
-    style = Ann.Styles.WithText(Ann.Styles.LineArrow();
-        text = "from A to B", fontsize = 14),
-    color = :steelblue, labelspace = :data, shrink = (5.0, 5.0))
-f
-```
-
 ## Attributes
 
 ```@attrdocs

--- a/docs/src/reference/plots/pathtext.md
+++ b/docs/src/reference/plots/pathtext.md
@@ -1,0 +1,57 @@
+# pathtext
+
+```@shortdocs; canonical=false
+pathtext
+```
+
+## Examples
+
+### Along a BezierPath
+
+```@figure
+bp = BezierPath([
+    MoveTo(Point2(0, 0)),
+    CurveTo(Point2(1, 3), Point2(3, 3), Point2(4, 0)),
+])
+
+f = Figure()
+ax = Axis(f[1, 1], aspect = DataAspect(), limits = (nothing, (-0.5, 3)))
+lines!(ax, bp, color = (:steelblue, 0.4), linewidth = 2)
+pathtext!(ax, bp, text = "text along a Bezier curve", fontsize = 20, align = (:center, :bottom))
+f
+```
+
+### Along a polyline
+
+```@figure
+path = Point2f[(0, 0), (1, 0), (2, 1), (3, 1), (4, 0)]
+
+f = Figure()
+ax = Axis(f[1, 1])
+lines!(ax, path, color = :gray70)
+pathtext!(ax, path, text = "polyline path", fontsize = 18, align = (:center, :baseline))
+f
+```
+
+### RichText with sub/superscripts
+
+```@figure
+bp = BezierPath([
+    MoveTo(Point2(0, 0)),
+    CurveTo(Point2(2, 4), Point2(6, 4), Point2(8, 0)),
+])
+
+f = Figure()
+ax = Axis(f[1, 1], aspect = DataAspect(), limits = (nothing, (-0.5, 4)))
+lines!(ax, bp, color = (:gray, 0.4), linewidth = 2)
+pathtext!(ax, bp,
+    text = rich("H", subscript("2"), "O → H", superscript("+"), " + OH", superscript("−")),
+    fontsize = 24, align = (:center, :bottom))
+f
+```
+
+## Attributes
+
+```@attrdocs
+PathText
+```


### PR DESCRIPTION
Adds a `pathtext` recipe for placing `String` or `RichText` along a `Vector{<:Point2}` or `BezierPath`. For `BezierPath` inputs, glyph positions and tangents come from exact cubic-Bézier evaluation; arc-length quadrature is adapted from [`kurbo`](https://github.com/linebender/kurbo) (MIT).

Also adds `Ann.Styles.WithText`, which wraps another annotation style and layers a `pathtext` label along the connection path.

## Example

```julia
xs = range(0, 4π, length = 200)
path = Point2f.(xs, sin.(xs))

f = Figure(size = (900, 300))
ax = Axis(f[1, 1]; limits = ((0, 4π), (-2, 2)))
hidedecorations!(ax); hidespines!(ax)
lines!(ax, path; color = (:gray, 0.4), linewidth = 2)

pathtext!(ax, path; text = "text flowing along a sine wave",
    fontsize = 18, align = (:center, :bottom), offset = 6)

rt = rich("sin(x) = ", rich("Σ "; color = :crimson),
    "(−1)", superscript("n"), " x", superscript("2n+1"), " / (2n+1)!")
pathtext!(ax, path; text = rt, fontsize = 18,
    align = (:center, :top), offset = -6)

f
```

<img width="900" height="300" alt="pathtext along a sine wave" src="https://github.com/user-attachments/assets/a989474e-62a7-4751-b527-4672791fcd97">

## `Ann.Styles.WithText`

```julia
annotation!(ax, [Point2f(1, 2)], [Point2f(5, 5)];
    text = [""],
    path = Ann.Paths.Arc(height = 0.4),
    style = Ann.Styles.WithText(Ann.Styles.LineArrow();
        text = rich("H", subscript("2"), "O → ",
            rich("products"; color = :crimson)),
        fontsize = 14),
    color = :steelblue, labelspace = :data, shrink = (5.0, 5.0))
```

<img width="600" height="400" alt="annotation with WithText style" src="https://github.com/user-attachments/assets/a8eb9506-5305-4e71-9360-9cd6795cf9cc">

## Checks

- [x] Reference images for align, RichText + offset, polyline vs BezierPath, `:data` vs `:pixel` space, and `Ann.Styles.WithText`
- [x] Docs page with `attribute_examples`
