### PR TITLE
fix: use RelocatableFolders.@path for shared precompile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed shared precompile file path not being relocatable by using `RelocatableFolders.@path` [#5597](https://github.com/MakieOrg/Makie.jl/pull/5597)
 - Added possibility to gather legend entries from multiple axes [#5551](https://github.com/MakieOrg/Makie.jl/pull/5551)
 - Added complete inverse transformation support to `register_projected_positions!` with `apply_inverse_transform`, `apply_inverse_transform_func`, `apply_inverse_float32convert`, and `apply_inverse_model` kwargs. These enable correct projection from non-data spaces back to data space. Includes early-exit optimization to skip redundant transform/inverse pairs when `input_space === output_space`. [#5485](https://github.com/MakieOrg/Makie.jl/pull/5485)
 - Fixed `bracket` not supporting `LaTeXString` text, which would render with dollar signs instead of mathematical notation [#5536](https://github.com/MakieOrg/Makie.jl/pull/5536)

--- a/CairoMakie/src/precompiles.jl
+++ b/CairoMakie/src/precompiles.jl
@@ -10,9 +10,7 @@ end
 let
     @compile_workload begin
         CairoMakie.activate!()
-        base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
-        shared_precompile = joinpath(base_path, "shared-precompile.jl")
-        include(shared_precompile)
+        include(Makie.SHARED_PRECOMPILE_PATH)
         # Cleanup globals to avoid serializing stale state (fonts, figures, tasks)
         # Note: __init__ doesn't run during precompilation, so we must always clean up here
         Makie.cleanup_globals()

--- a/GLMakie/src/GLMakie.jl
+++ b/GLMakie/src/GLMakie.jl
@@ -20,7 +20,6 @@ using Makie: to_native
 using Makie: spaces, is_data_space, is_pixel_space, is_relative_space, is_clip_space
 using Makie: BudgetedTimer, reset!
 import Makie: to_font, el32convert, Shape, CIRCLE, RECTANGLE, ROUNDED_RECTANGLE, DISTANCEFIELD, TRIANGLE
-import Makie: RelocatableFolders
 
 using ShaderAbstractions
 using FreeTypeAbstraction

--- a/GLMakie/src/precompiles.jl
+++ b/GLMakie/src/precompiles.jl
@@ -21,9 +21,7 @@ let
             close(screen)
             destroy!(screen)
 
-            base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
-            shared_precompile = joinpath(base_path, "shared-precompile.jl")
-            include(shared_precompile)
+            include(Makie.SHARED_PRECOMPILE_PATH)
             try
                 display(plot(x); visible = false)
             catch

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -49,7 +49,7 @@ using ComputePipeline
 
 import Unitful
 import UnicodeFun
-import RelocatableFolders
+using RelocatableFolders: @path
 import StatsBase
 import Distributions
 import KernelDensity
@@ -450,6 +450,8 @@ function cleanup_globals()
 end
 
 export cleanup_globals
+
+const SHARED_PRECOMPILE_PATH = @path joinpath(@__DIR__, "..", "precompile", "shared-precompile.jl")
 
 include("precompiles.jl")
 

--- a/Makie/src/precompiles.jl
+++ b/Makie/src/precompiles.jl
@@ -26,9 +26,7 @@ let
         f = Figure()
         ax = Axis(f[1, 1])
         Makie.initialize_block!(ax)
-        base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
-        shared_precompile = joinpath(base_path, "shared-precompile.jl")
-        include(shared_precompile)
+        include(SHARED_PRECOMPILE_PATH)
         # Cleanup globals to avoid serializing stale state (fonts, figures, tasks)
         # Note: __init__ doesn't run during precompilation, so we must always clean up here
         cleanup_globals()

--- a/WGLMakie/src/precompiles.jl
+++ b/WGLMakie/src/precompiles.jl
@@ -23,9 +23,7 @@ end
 let
     @compile_workload begin
         WGLMakie.activate!()
-        base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
-        shared_precompile = joinpath(base_path, "shared-precompile.jl")
-        include(shared_precompile)
+        include(Makie.SHARED_PRECOMPILE_PATH)
         # Cleanup globals to avoid serializing stale state (servers, sessions, fonts, figures, tasks)
         # Note: __init__ doesn't run during precompilation, so we must always clean up here
         Bonito.cleanup_globals()


### PR DESCRIPTION
## Summary

- The backends computed the path to `shared-precompile.jl` via `pathof(Makie)`, which bakes in an absolute path that breaks after package relocation in deployed systems.
- Replaced with a `RelocatableFolders.@path` const in Makie that all backends reference.
- Removed a stale `import Makie: RelocatableFolders` from GLMakie.

## Checks

- Loaded CairoMakie, GLMakie, and WGLMakie locally without errors or warnings