### PR TITLE
Format docstrings with Runic

### DIFF
--- a/.github/workflows/_formatting.yml
+++ b/.github/workflows/_formatting.yml
@@ -14,4 +14,6 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: fredrikekre/runic-action@v1
         with:
-          version: '1.4'
+          version: '1.7'
+          extensions: 'jl,md'
+          docstrings: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,13 @@ From the `.scratch/` directory, `dev` the local packages you need. Always dev `C
 ```julia
 using Pkg
 Pkg.activate(".scratch")
-Pkg.develop([
-    PackageSpec(path="ComputePipeline"),
-    PackageSpec(path="Makie"),
-    PackageSpec(path="CairoMakie"),  # or GLMakie, WGLMakie, ... as needed
-])
+Pkg.develop(
+    [
+        PackageSpec(path = "ComputePipeline"),
+        PackageSpec(path = "Makie"),
+        PackageSpec(path = "CairoMakie"),  # or GLMakie, WGLMakie, ... as needed
+    ]
+)
 ```
 
 ## Example Code for Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ We use [`Runic`](https://github.com/fredrikekre/Runic.jl) for code formatting.
 You should follow the instructions in the README of `Runic` to format the code.
 If you have the `runic` script installed, it should be sufficient to run
 ```sh
-$ runic --inplace src/ test/
+$ runic --inplace --extensions=jl,md --docstrings src/ test/
 ```
 for every workspace sub-package modified before finalizing the PR.
 

--- a/CairoMakie/README.md
+++ b/CairoMakie/README.md
@@ -35,7 +35,7 @@ canvas = @GtkCanvas()
 window = GtkWindow(canvas, "Makie", 500, 500)
 
 function drawonto(canvas, figure)
-    @guarded draw(canvas) do _
+    return @guarded draw(canvas) do _
         scene = figure.scene
         resize!(scene, Gtk.width(canvas), Gtk.height(canvas))
         config = CairoMakie.ScreenConfig(1.0, 1.0, :good, true, true)

--- a/ComputePipeline/README.md
+++ b/ComputePipeline/README.md
@@ -19,7 +19,7 @@ add_input!((key, value) -> Float32(value), graph, :input2, 2) # directly convert
 # add computations (edges + output nodes)
 register_computation!(graph, [:input1, :input2], [:output]) do inputs, changed, last_output
     input1, input2 = inputs
-    return (input1 + input2, )
+    return (input1 + input2,)
 end
 
 # Observable like API:

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -1014,7 +1014,7 @@ function (x::MapFunctionWrapper{false})(inputs, @nospecialize(changed), @nospeci
 end
 
 """
-    map!(f, compute_graph::ComputeGraph, inputs::Union{Symbol, Computed, Vector}, outputs::Union{Symbol, Vector{Symbol}}; init=nothing)
+    map!(f, compute_graph::ComputeGraph, inputs::Union{Symbol, Computed, Vector}, outputs::Union{Symbol, Vector{Symbol}}; init = nothing)
 
 Registers a new ComputeEdge in the `compute_graph` which connect one or multiple
 `inputs` to one or multiple `outputs`.
@@ -1041,12 +1041,12 @@ other_graph = ComputeGraph()
 add_input!(other_graph, :input, 3)
 
 map!(x -> 2x, graph, :input1, :output1)
-map!((x, y) -> x+y, graph, [:input1, other_graph.input], :output2)
-map!((x, y) -> (x+y, x-y), graph, [:input1, :input2], [:output3, :output4])
+map!((x, y) -> x + y, graph, [:input1, other_graph.input], :output2)
+map!((x, y) -> (x + y, x - y), graph, [:input1, :input2], [:output3, :output4])
 
 # With initial values
-map!(x -> 2x, graph, :input1, :output5; init=0)
-map!((x, y) -> (x+y, x-y), graph, [:input1, :input2], [:output6, :output7]; init=(0, 0))
+map!(x -> 2x, graph, :input1, :output5; init = 0)
+map!((x, y) -> (x + y, x - y), graph, [:input1, :input2], [:output6, :output7]; init = (0, 0))
 ```
 
 See also: [`add_input!`](@ref), [`register_computation!`](@ref)
@@ -1100,7 +1100,7 @@ function take_last!(channel::Channel; wait = false)
 end
 
 """
-    map_latest!(f, compute_graph::ComputeGraph, inputs::Vector{Symbol}, outputs::Vector{Symbol}; spawn=false, init=nothing)
+    map_latest!(f, compute_graph::ComputeGraph, inputs::Vector{Symbol}, outputs::Vector{Symbol}; spawn = false, init = nothing)
 
 Registers an asynchronous computation in the `compute_graph` that processes only the
 most recent input changes, skipping intermediate updates if the computation is still running.

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -756,7 +756,7 @@ function destroy!(screen::Screen)
 end
 
 """
-    close(screen::Screen; reuse=true)
+    close(screen::Screen; reuse = true)
 
 Closes screen and empties it.
 Doesn't destroy the screen and instead frees it to be reused again, if `reuse=true`.
@@ -1149,7 +1149,7 @@ end
 export plot2robjs
 
 """
-    render_asap([callback::Function, ]screen, N)
+    render_asap([callback::Function]screen, N)
 
 Renders N frames as fast as possible, calling `callback` before each frame if
 defined. This will stop the existing rendertask and disable vsync before

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -226,7 +226,7 @@ function mixin_shading_attributes()
 end
 
 """
-    calculated_attributes!(trait::Type{<: AbstractPlot}, plot)
+    calculated_attributes!(trait::Type{<:AbstractPlot}, plot)
 
 trait version of `calculated_attributes`
 """

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -6,7 +6,7 @@ module Aggregation
     abstract type AggOp end
 
     """
-        Canvas(bounds::Rect2; resolution::Tuple{Int,Int}=(800, 800), op=AggCount())
+        Canvas(bounds::Rect2; resolution::Tuple{Int, Int} = (800, 800), op = AggCount())
         Canvas(xmin::Number, xmax::Number, ymin::Number, ymax::Number; args...)
 
     # Example
@@ -32,7 +32,7 @@ module Aggregation
     end
 
     """
-        get_aggregation(canvas::Canvas; operation=equalize_histogram, local_operation=identity, result=similar(canvas.pixelbuffer, canvas.resolution))
+        get_aggregation(canvas::Canvas; operation = equalize_histogram, local_operation = identity, result = similar(canvas.pixelbuffer, canvas.resolution))
 
     Basically does `operation(map!(local_operation, result, canvas.pixelbuffer))`, but does the correct reshaping of the flat pixelbuffer and
     simplifies passing a local or global operation.
@@ -128,7 +128,7 @@ module Aggregation
     using InteractiveUtils
 
     """
-        aggregate!(c::Canvas, points; point_transform=identity, method::AggMethod=AggSerial())
+        aggregate!(c::Canvas, points; point_transform = identity, method::AggMethod = AggSerial())
 
     Aggregate points into a canvas. The points are transformed by `point_transform` before aggregation.
     Method can be `AggSerial()` or `AggThreads()`.
@@ -275,7 +275,7 @@ function equalize_histogram(matrix; nbins = 256)
 end
 
 """
-    datashader(points::AbstractVector{<: Point})
+    datashader(points::AbstractVector{<:Point})
 
 !!! warning
     This feature might change outside breaking releases, since the API is not yet finalized.
@@ -517,7 +517,7 @@ function xy_to_rect(x, y)
 end
 
 """
-    Resampler(matrix; max_resolution=automatic, method=Interpolations.Linear(), update_while_button_pressed=false)
+    Resampler(matrix; max_resolution = automatic, method = Interpolations.Linear(), update_while_button_pressed = false)
 
 Creates a resampling type which can be used with `heatmap`, to display large images/heatmaps.
 Passed can be any array that supports `array(linrange, linrange)`, as the interpolation interface from Interpolations.jl.

--- a/Makie/src/basic_recipes/raincloud.jl
+++ b/Makie/src/basic_recipes/raincloud.jl
@@ -16,7 +16,7 @@ rand_localized(min, max) = rand_localized(RAINCLOUD_RNG[], min, max)
 rand_localized(RNG::Random.AbstractRNG, min, max) = rand(RNG) * (max - min) .+ min
 
 """
-    rainclouds!(ax, category_labels, data_array; plot_boxplots=true, plot_clouds=true, kwargs...)
+    rainclouds!(ax, category_labels, data_array; plot_boxplots = true, plot_clouds = true, kwargs...)
 
 Plot a violin (/histogram), boxplot and individual data points with appropriate spacing
 between each.

--- a/Makie/src/basic_recipes/spy.jl
+++ b/Makie/src/basic_recipes/spy.jl
@@ -8,10 +8,10 @@ Usage:
 ```julia
 using SparseArrays, GLMakie
 N = 200_000
-x = sprand(Float64, N, N, (3(10^6)) / (N*N));
+x = sprand(Float64, N, N, (3(10^6)) / (N * N));
 spy(x)
 # or if you want to specify the range of x and y:
-spy(0..1, 0..1, x)
+spy(0 .. 1, 0 .. 1, x)
 ```
 """
 @recipe Spy (x::EndPoints, y::EndPoints, z::RealMatrix) begin
@@ -23,8 +23,8 @@ spy(0..1, 0..1, x)
     ```julia
     data = sprand(10, 10, 0.5)
     f = Figure()
-    spy(f[1, 1], data; marker=FastPixel())
-    spy(f[1, 2], data; marker=FastPixel(), axis=(; aspect=1))
+    spy(f[1, 1], data; marker = FastPixel())
+    spy(f[1, 2], data; marker = FastPixel(), axis = (; aspect = 1))
     f
     ```
     """

--- a/Makie/src/basic_recipes/streamplot.jl
+++ b/Makie/src/basic_recipes/streamplot.jl
@@ -11,8 +11,8 @@ and must return a subtype of `VecTypes{2}` or `VecTypes{3}`, for example a
 
 Example:
 ```julia
-v(x::Point2{T}) where T = Point2f(x[2], 4*x[1])
-streamplot(v, -2..2, -2..2)
+v(x::Point2{T}) where {T} = Point2f(x[2], 4 * x[1])
+streamplot(v, -2 .. 2, -2 .. 2)
 ```
 
 ## Implementation

--- a/Makie/src/basic_recipes/timeseries.jl
+++ b/Makie/src/basic_recipes/timeseries.jl
@@ -16,7 +16,7 @@ display(scene)
     signal[] = data
     # sleep/ wait for new data/ whatever...
     # It's important to yield here though, otherwise nothing will be rendered
-    sleep(1/30)
+    sleep(1 / 30)
 end
 
 ```

--- a/Makie/src/camera/camera2d.jl
+++ b/Makie/src/camera/camera2d.jl
@@ -335,7 +335,7 @@ function (cam::UpdatePixelCam)(window_size)
 end
 
 """
-    campixel!(scene; nearclip=-1000.0, farclip=1000.0)
+    campixel!(scene; nearclip = -1000.0, farclip = 1000.0)
 
 Creates a pixel camera for the given `scene`. This means that the positional
 data of a plot will be interpreted in pixel units. This camera does not feature

--- a/Makie/src/colorsampler.jl
+++ b/Makie/src/colorsampler.jl
@@ -257,7 +257,7 @@ Will make sure to map one value to one color and create the correct Colorbar for
 
 Example:
 ```julia
-fig, ax, pl = barplot(1:3; color=1:3, colormap=Makie.Categorical(:viridis))
+fig, ax, pl = barplot(1:3; color = 1:3, colormap = Makie.Categorical(:viridis))
 ```
 
 !!! warning

--- a/Makie/src/conversion.jl
+++ b/Makie/src/conversion.jl
@@ -123,7 +123,7 @@ end
 should_dim_convert(::Type) = false
 
 """
-    should_dim_convert(::Type{<: Plot}, args)::Bool
+    should_dim_convert(::Type{<:Plot}, args)::Bool
     should_dim_convert(eltype::DataType)::Bool
 
 Returns `true` if the plot type should convert its arguments via DimConversions.

--- a/Makie/src/coretypes.jl
+++ b/Makie/src/coretypes.jl
@@ -122,7 +122,7 @@ const px = Pixel(1)
 
 """
     Billboard([angle::Real])
-    Billboard([angles::Vector{<: Real}])
+    Billboard([angles::Vector{<:Real}])
 
 Billboard attribute to always have a primitive face the camera.
 Can be used for rotation.

--- a/Makie/src/dim-converts/categorical-integration.jl
+++ b/Makie/src/dim-converts/categorical-integration.jl
@@ -1,5 +1,5 @@
 """
-    CategoricalConversion(; sortby=identity)
+    CategoricalConversion(; sortby = identity)
 
 Categorical conversion. Gets chosen automatically only for `Categorical(array_of_objects)` and `Enums` right now.
 The categories work with any sortable value though, so one can always do `Axis(fig; dim1_conversion=CategoricalConversion())`,
@@ -20,8 +20,8 @@ struct Named
 end
 Base.show(io::IO, s::SomeStruct) = println(io, "[\$(s.value)]")
 
-conversion = Makie.CategoricalConversion(sortby=x->x.value)
-barplot(Named.([:a, :b, :c]), 1:3, axis=(dim1_conversion=conversion,))
+conversion = Makie.CategoricalConversion(sortby = x -> x.value)
+barplot(Named.([:a, :b, :c]), 1:3, axis = (dim1_conversion = conversion,))
 ```
 """
 struct CategoricalConversion <: AbstractDimConversion

--- a/Makie/src/dim-converts/dates-integration.jl
+++ b/Makie/src/dim-converts/dates-integration.jl
@@ -20,7 +20,7 @@ function date_to_number(::Type{Time}, value::Unitful.Quantity)
 end
 
 """
-    DateTimeConversion(type=Automatic; k_min=automatic, k_max=automatic, k_ideal=automatic)
+    DateTimeConversion(type = Automatic; k_min = automatic, k_max = automatic, k_ideal = automatic)
 
 Creates conversion and conversions for Date, DateTime and Time. For other time units one should use `UnitfulConversion`, which work with e.g. Seconds.
 
@@ -34,14 +34,14 @@ For DateTimes `PlotUtils.optimize_datetime_ticks` is used for getting the conver
 
 ```julia
 date_time = DateTime("2021-10-27T11:11:55.914")
-date_time_range = range(date_time, step=Week(5), length=10)
+date_time_range = range(date_time, step = Week(5), length = 10)
 # Automatically choose xticks as DateTimeTicks:
 scatter(date_time_range, 1:10)
 
 # explicitly choose DateTimeConversion and use it to plot unitful values into it and display in the `Time` format:
 using Makie.Unitful
 conversion = Makie.DateTimeConversion(Time)
-scatter(1:4, (1:4) .* u"s", axis=(dim2_conversion=conversion,))
+scatter(1:4, (1:4) .* u"s", axis = (dim2_conversion = conversion,))
 ```
 """
 struct DateTimeConversion <: AbstractDimConversion

--- a/Makie/src/dim-converts/dynamic-quantities-integration.jl
+++ b/Makie/src/dim-converts/dynamic-quantities-integration.jl
@@ -1,5 +1,5 @@
 """
-    DQConversion(unit=automatic; units_in_label=false)
+    DQConversion(unit = automatic; units_in_label = false)
 
 Allows to plot arrays of DynamicQuantity objects into an axis.
 
@@ -19,7 +19,7 @@ Fix unit to always use Meter & display unit in the xlabel:
 ```julia
 dqc = Makie.DQConversion(us"m"; units_in_label = false)
 
-scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis=(dim2_conversion=dqc, xlabel="x (km)"))
+scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis = (dim2_conversion = dqc, xlabel = "x (km)"))
 ```
 """
 struct DQConversion <: AbstractDimConversion

--- a/Makie/src/dim-converts/unitful-integration.jl
+++ b/Makie/src/dim-converts/unitful-integration.jl
@@ -129,7 +129,7 @@ unit_convert(unit::T, value) where {T <: Union{Unitful.MixedUnits, Quantity{<:Un
 # Overload conversion functions for Axis, to properly display units
 
 """
-    UnitfulConversion(unit=automatic; units_in_label=false)
+    UnitfulConversion(unit = automatic; units_in_label = false)
 
 Allows to plot arrays of unitful objects into an axis.
 
@@ -149,8 +149,8 @@ scatter(1:4, [1u"ns", 2u"ns", 3u"ns", 4u"ns"])
 
 Fix unit to always use Meter & display unit in the ylabel:
 ```julia
-uc = Makie.UnitfulConversion(u"m"; units_in_label=false)
-scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis=(dim2_conversion=uc, ylabel="y (m)"))
+uc = Makie.UnitfulConversion(u"m"; units_in_label = false)
+scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis = (dim2_conversion = uc, ylabel = "y (m)"))
 ```
 """
 struct UnitfulConversion <: AbstractDimConversion

--- a/Makie/src/display.jl
+++ b/Makie/src/display.jl
@@ -85,7 +85,7 @@ end
 const ALWAYS_INLINE_PLOTS = Ref{Union{Automatic, Bool}}(automatic)
 
 """
-    inline!(inline=true)
+    inline!(inline = true)
 
 Prevents opening a window when e.g. in the REPL.
 Usually, Makie opens a window when displaying a plot.
@@ -119,7 +119,7 @@ function can_show_inline(Backend)
 end
 
 """
-    Base.display(figlike::FigureLike; backend=current_backend(), screen_config...)
+    Base.display(figlike::FigureLike; backend = current_backend(), screen_config...)
 
 Displays the figurelike in a window or the browser, depending on the backend.
 
@@ -461,7 +461,7 @@ isvisible(::Nothing) = false
 const COLORBUFFER_LOCK = ReentrantLock()
 
 """
-    colorbuffer(scene, format::ImageStorageFormat = JuliaNative; update=true, backend=current_backend(), figure=nothing, screen_config...)
+    colorbuffer(scene, format::ImageStorageFormat = JuliaNative; update = true, backend = current_backend(), figure = nothing, screen_config...)
 
 Returns the content of the given scene or screen rasterised to a Matrix of
 Colors. The return type is backend-dependent, but will be some form of RGB

--- a/Makie/src/float32-scaling.jl
+++ b/Makie/src/float32-scaling.jl
@@ -92,7 +92,7 @@ end
 # end
 
 """
-    Float32Convert([resolution = 1e4])
+    Float32Convert([resolution = 1.0e4])
 
 Creates a Float32Convert which acts as an additional conversion step when
 attached to a `scene` as `scene.float32convert`. The optional `resolution`

--- a/Makie/src/interaction/interactive_api.jl
+++ b/Makie/src/interaction/interactive_api.jl
@@ -6,7 +6,7 @@ const PICK_TRACKING = Ref(false)
 const _PICK_COUNTER = Ref(0)
 
 """
-    mouseover(fig/ax/scene, plots::AbstractPlot...)
+    mouseover(fig / ax / scene, plots::AbstractPlot...)
 
 Returns true if the mouse currently hovers any of `plots`.
 """
@@ -17,7 +17,7 @@ function mouseover(scene::Scene, plots::AbstractPlot...)
 end
 
 """
-    onpick(f, fig/ax/scene, plots::AbstractPlot...)
+    onpick(f, fig / ax / scene, plots::AbstractPlot...)
 
 Calls `f(plot, idx)` whenever the mouse is over any of `plots`.
 `idx` is an index, e.g. when over a scatter plot, it will be the index of the
@@ -134,7 +134,7 @@ end
 using InteractiveUtils
 
 """
-    pick_sorted(fig/ax/scene, xy::VecLike, range)
+    pick_sorted(fig / ax / scene, xy::VecLike, range)
 
 Return all `(plot, index)` pairs in a `(xy .- range, xy .+ range)` region
 sorted by distance to `xy`. See [`pick`](@ref) for more details.

--- a/Makie/src/interaction/ray_casting.jl
+++ b/Makie/src/interaction/ray_casting.jl
@@ -18,7 +18,7 @@ end
 
 
 """
-    ray_at_cursor(fig/ax/scene)
+    ray_at_cursor(fig / ax / scene)
 
 Returns a Ray into the scene starting at the current cursor position.
 """

--- a/Makie/src/interfaces.jl
+++ b/Makie/src/interfaces.jl
@@ -89,7 +89,7 @@ plottype(P1::Type{<:Plot{T1}}, ::Type{<:Plot{T2}}) where {T1, T2} = P1
 plottype(::Type{Plot{plot}}, ::Type{Plot{plot}}) = Plot{plot}
 
 """
-    plottype(P1::Type{<: Plot{T1}}, P2::Type{<: Plot{T2}})
+    plottype(P1::Type{<:Plot{T1}}, P2::Type{<:Plot{T2}})
 
 Chooses the more concrete plot type
 ```julia

--- a/Makie/src/layouting/transformation.jl
+++ b/Makie/src/layouting/transformation.jl
@@ -216,7 +216,7 @@ function origin!(::Type{T}, t::Transformable, xyz::VecTypes) where {T}
 end
 
 """
-    transform!(transformable, plane_offset::Tuple{Symbol, <: Real})
+    transform!(transformable, plane_offset::Tuple{Symbol, <:Real})
 
 This function views the transformable (plot or scene) as an xy plane and transforms
 it to the given `plane_offset = (plane, offset)`. This implies a rotation of the
@@ -518,7 +518,7 @@ function Symlog10(lower, upper; linscale = 1)
 end
 
 """
-    AsinhScale(a=0.1)
+    AsinhScale(a = 0.1)
 
 An asinh scaling defined as
 ```math
@@ -533,7 +533,7 @@ function AsinhScale(a = 0.1)
 end
 
 """
-    SinhScale(a=1/3)
+    SinhScale(a = 1 / 3)
 A sinh scaling defined as
 ```math
 y = \\frac{\\text{sinh} \\left(x/a\\right)}{\\text{sinh} \\left(1/a\\right)}
@@ -547,7 +547,7 @@ function SinhScale(a = 1 / 3)
 end
 
 """
-    LogScale(a=1000, base=ℯ)
+    LogScale(a = 1000, base = ℯ)
 
 A logarithmic scaling defined as
 ```math
@@ -563,7 +563,7 @@ function LogScale(a = 1000, base = ℯ)
 end
 
 """
-    LuptonAsinhScale(a=0.1, Q=0.01, frac=0.1)
+    LuptonAsinhScale(a = 0.1, Q = 0.01, frac = 0.1)
 
 A modified asinh scaling based on
 [Lupton et al. 2004](https://ui.adsabs.harvard.edu/abs/2004PASP..116..133L)
@@ -584,7 +584,7 @@ function LuptonAsinhScale(a = 0.1, Q = 0.01, frac = 0.1)
 end
 
 """
-    PowerScale(a=1)
+    PowerScale(a = 1)
 
 A power-law scaling derived as ``y = x^a``.
 """

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -1082,8 +1082,10 @@ end
 
 
 """
-    hidexdecorations!(la::Axis; label = true, ticklabels = true, ticks = true, grid = true,
-        minorgrid = true, minorticks = true)
+    hidexdecorations!(
+        la::Axis; label = true, ticklabels = true, ticks = true, grid = true,
+        minorgrid = true, minorticks = true
+    )
 
 Hide decorations of the x-axis: label, ticklabels, ticks and grid. Keyword
 arguments can be used to disable hiding of certain types of decorations.
@@ -1113,8 +1115,10 @@ function hidexdecorations!(
 end
 
 """
-    hideydecorations!(la::Axis; label = true, ticklabels = true, ticks = true, grid = true,
-        minorgrid = true, minorticks = true)
+    hideydecorations!(
+        la::Axis; label = true, ticklabels = true, ticks = true, grid = true,
+        minorgrid = true, minorticks = true
+    )
 
 Hide decorations of the y-axis: label, ticklabels, ticks and grid. Keyword
 arguments can be used to disable hiding of certain types of decorations.
@@ -1144,8 +1148,10 @@ function hideydecorations!(
 end
 
 """
-    hidedecorations!(la::Axis; label = true, ticklabels = true, ticks = true,
-                     grid = true, minorgrid = true, minorticks = true)
+    hidedecorations!(
+        la::Axis; label = true, ticklabels = true, ticks = true,
+        grid = true, minorgrid = true, minorticks = true
+    )
 
 Hide decorations of both x and y-axis: label, ticklabels, ticks and grid.
 Keyword arguments can be used to disable hiding of certain types of decorations.
@@ -1280,7 +1286,7 @@ end
     xlims!(ax, low, high)
     xlims!(ax; low = nothing, high = nothing)
     xlims!(ax, (low, high))
-    xlims!(ax, low..high)
+    xlims!(ax, low .. high)
 
 Set the x-axis limits of axis `ax` to `low` and `high` or a tuple
 `xlims = (low,high)`. If the limits are ordered high-low, the axis orientation
@@ -1292,7 +1298,7 @@ Makie.xlims!(ax, low, high) = Makie.xlims!(ax, (low, high))
     ylims!(ax, low, high)
     ylims!(ax; low = nothing, high = nothing)
     ylims!(ax, (low, high))
-    ylims!(ax, low..high)
+    ylims!(ax, low .. high)
 
 Set the y-axis limits of axis `ax` to `low` and `high` or a tuple
 `ylims = (low,high)`. If the limits are ordered high-low, the axis orientation
@@ -1304,7 +1310,7 @@ Makie.ylims!(ax, low, high) = Makie.ylims!(ax, (low, high))
     zlims!(ax, low, high)
     zlims!(ax; low = nothing, high = nothing)
     zlims!(ax, (low, high))
-    zlims!(ax, low..high)
+    zlims!(ax, low .. high)
 
 Set the z-axis limits of axis `ax` to `low` and `high` or a tuple
 `zlims = (low,high)`. If the limits are ordered high-low, the axis orientation
@@ -1974,7 +1980,7 @@ function axis_bounds_with_decoration(axis::Axis)
 end
 
 """
-    colorbuffer(ax::Axis; include_decorations=true, colorbuffer_kws...)
+    colorbuffer(ax::Axis; include_decorations = true, colorbuffer_kws...)
 
 Gets the colorbuffer of the `Axis` in `JuliaNative` image format.
 If `include_decorations=false`, only the inside of the axis is fetched.

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -939,7 +939,8 @@ end
         contents::AbstractArray,
         labels::AbstractArray,
         title = nothing;
-        kwargs...)
+        kwargs...
+    )
 
 Create a legend from `contents` and `labels` where each label is associated to
 one content element. A content element can be an `AbstractPlot`, an array of
@@ -970,7 +971,8 @@ end
         contentgroups::AbstractVector{<:AbstractVector},
         labelgroups::AbstractVector{<:AbstractVector},
         titles::AbstractVector;
-        kwargs...)
+        kwargs...
+    )
 
 Create a multi-group legend from `contentgroups`, `labelgroups` and `titles`.
 Each group from `contentgroups` and `labelgroups` is associated with one title

--- a/Makie/src/makielayout/helpers.jl
+++ b/Makie/src/makielayout/helpers.jl
@@ -323,8 +323,10 @@ end
 
 
 """
-    labelslider!(scene, label, range; format = string, sliderkw = Dict(),
-    labelkw = Dict(), valuekw = Dict(), value_column_width = automatic, layoutkw...)
+    labelslider!(
+        scene, label, range; format = string, sliderkw = Dict(),
+        labelkw = Dict(), valuekw = Dict(), value_column_width = automatic, layoutkw...
+    )
 
 **`labelslider!` is deprecated, use `SliderGrid` instead**
 
@@ -382,9 +384,11 @@ end
 
 
 """
-    labelslidergrid!(scene, labels, ranges; formats = [string],
+    labelslidergrid!(
+        scene, labels, ranges; formats = [string],
         sliderkw = Dict(), labelkw = Dict(), valuekw = Dict(),
-        value_column_width = automatic, layoutkw...)
+        value_column_width = automatic, layoutkw...
+    )
 
 **`labelslidergrid!` is deprecated, use `SliderGrid` instead**
 

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1035,11 +1035,14 @@ SliderGrid(fig_or_scene, nts::NamedTuple...; kwargs...)
 ## Examples
 
 ```julia
-sg = SliderGrid(fig[1, 1],
+sg = SliderGrid(
+    fig[1, 1],
     (label = "Amplitude", range = 0:0.1:10, startvalue = 5),
     (label = "Frequency", range = 0:0.5:50, format = "{:.1f}Hz", startvalue = 10),
-    (label = "Phase", range = 0:0.01:2pi,
-        format = x -> string(round(x/pi, digits = 2), "π"))
+    (
+        label = "Phase", range = 0:0.01:2pi,
+        format = x -> string(round(x / pi, digits = 2), "π"),
+    )
 )
 ```
 
@@ -1231,7 +1234,7 @@ Toggle(fig_or_scene; kwargs...)
 ```julia
 t_horizontal = Toggle(fig[1, 1])
 t_vertical = Toggle(fig[2, 1], orientation = :vertical)
-t_diagonal = Toggle(fig[3, 1], orientation = pi/4)
+t_diagonal = Toggle(fig[3, 1], orientation = pi / 4)
 on(t_vertical.active) do switch_is_on
     switch_is_on ? println("good morning!") : println("good night")
 end

--- a/Makie/src/recipes.jl
+++ b/Makie/src/recipes.jl
@@ -132,7 +132,7 @@ The following signatures are defined to make `MyPlot` nice to use:
 A specialization of `argument_names` is emitted if you have an argument list
 `(x,y,z)` provided to the recipe macro:
 
-    argument_names(::Type{<: MyPlot}) = (:x, :y, :z)
+    argument_names(::Type{<:MyPlot}) = (:x, :y, :z)
 
 This is optional but it will allow the use of `plot_object[:x]` to
 fetch the first argument from the call
@@ -146,7 +146,7 @@ specialization of `default_theme` which inserts the theme into any scene that
 plots `MyPlot`:
 
     function default_theme(scene, ::MyPlot)
-        Attributes(
+        return Attributes(
             plot_color = :red
         )
     end
@@ -159,19 +159,19 @@ plotting of the `MyPlot` object by specializing `plot!`:
         # or atomic plotting operations, and adding to the combined `plot`:
         lines!(plot, rand(10), color = plot[:plot_color])
         plot!(plot, plot[:x], plot[:y])
-        plot
+        return plot
     end
 
 It's possible to add specializations here, depending on the argument *types*
 supplied to `myplot`. For example, to specialize the behavior of `myplot(a)`
 when `a` is a 3D array of floating point numbers:
 
-    const MyVolume = MyPlot{Tuple{<:AbstractArray{<: AbstractFloat, 3}}}
-    argument_names(::Type{<: MyVolume}) = (:volume,) # again, optional
+    const MyVolume = MyPlot{Tuple{<:AbstractArray{<:AbstractFloat, 3}}}
+    argument_names(::Type{<:MyVolume}) = (:volume,) # again, optional
     function plot!(plot::MyVolume)
         # plot a volume with a colormap going from fully transparent to plot_color
         volume!(plot, plot[:volume], colormap = :transparent => plot[:plot_color])
-        plot
+        return plot
     end
 
 The docstring given to the recipe will be transferred to the functions it generates.
@@ -649,7 +649,7 @@ function expand_mixin(e::Expr)
 end
 
 """
-    Plot(args::Vararg{DataType,N})
+    Plot(args::Vararg{DataType, N})
 
 Returns the Plot type that represents the signature of `args`.
 Example:
@@ -688,7 +688,7 @@ Any custom argument combination that has a preferred way to be plotted should ov
 e.g.:
 ```julia
     # make plot(rand(5, 5, 5)) plot as a volume
-    plottype(x::Array{<: AbstractFloat, 3}) = Volume
+plottype(x::Array{<:AbstractFloat, 3}) = Volume
 ```
 """
 plottype(plot_args...) = Plot{plot} # default to dispatch to type recipes!

--- a/Makie/src/shorthands.jl
+++ b/Makie/src/shorthands.jl
@@ -118,7 +118,7 @@ function ztickrange(scene)
 end
 
 """
-    ticks!([scene,]; tickranges=tickranges(scene), ticklabels=ticklabels(scene))
+    ticks!([scene]; tickranges = tickranges(scene), ticklabels = ticklabels(scene))
 
 Set the tick labels and ranges along all axes. The respective labels and ranges
 along each axis must be of the same length.
@@ -135,7 +135,7 @@ function ticks!(scene::Scene; tickranges = tickranges(scene), ticklabels = tickl
 end
 
 """
-    xticks!([scene,]; xtickrange=xtickrange(scene), xticklabels=xticklabel(scene))
+    xticks!([scene]; xtickrange = xtickrange(scene), xticklabels = xticklabel(scene))
 
 Set the tick labels and range along the x-axis. See also `ticks!`.
 """
@@ -145,7 +145,7 @@ function xticks!(scene::Scene; xtickrange = xtickrange(scene), xticklabels = xti
 end
 
 """
-    yticks!([scene,]; ytickrange=ytickrange(scene), yticklabels=yticklabel(scene))
+    yticks!([scene]; ytickrange = ytickrange(scene), yticklabels = yticklabel(scene))
 
 Set the tick labels and range along all the y-axis. See also `ticks!`.
 """
@@ -161,7 +161,7 @@ function yticks!(scene::Scene; ytickrange = ytickrange(scene), yticklabels = yti
 end
 
 """
-    zticks!([scene,]; ztickranges=ztickrange(scene), zticklabels=zticklabel(scene))
+    zticks!([scene]; ztickranges = ztickrange(scene), zticklabels = zticklabel(scene))
 
 Set the tick labels and range along all z-axis. See also `ticks!`.
 """

--- a/Makie/src/specapi.jl
+++ b/Makie/src/specapi.jl
@@ -514,20 +514,20 @@ import Makie.SpecApi as S
 
 fig = Figure()
 ax = Axis(fig[1, 1])
-plots = Observable([S.heatmap(0 .. 1, 0 .. 1, Makie.peaks()), S.lines(0 .. 1, sin.(0:0.01:1); color=:blue)])
+plots = Observable([S.heatmap(0 .. 1, 0 .. 1, Makie.peaks()), S.lines(0 .. 1, sin.(0:0.01:1); color = :blue)])
 pl = plot!(ax, plots)
 display(fig)
 
 # Updating the plot dynamically
-plots[] = [S.heatmap(0 .. 1, 0 .. 1, Makie.peaks()), S.lines(0 .. 1, sin.(0:0.01:1); color=:red)]
+plots[] = [S.heatmap(0 .. 1, 0 .. 1, Makie.peaks()), S.lines(0 .. 1, sin.(0:0.01:1); color = :red)]
 plots[] = [
     S.image(0 .. 1, 0 .. 1, Makie.peaks()),
     S.poly(Rect2f(0.45, 0.45, 0.1, 0.1)),
-    S.lines(0 .. 1, sin.(0:0.01:1); linewidth=10, color=Makie.resample_cmap(:viridis, 101)),
+    S.lines(0 .. 1, sin.(0:0.01:1); linewidth = 10, color = Makie.resample_cmap(:viridis, 101)),
 ]
 
 plots[] = [
-    S.surface(0..1, 0..1, Makie.peaks(); colormap = :viridis, translation = Vec3f(0, 0, -1)),
+    S.surface(0 .. 1, 0 .. 1, Makie.peaks(); colormap = :viridis, translation = Vec3f(0, 0, -1)),
 ]
 ```
 """

--- a/Makie/src/theming.jl
+++ b/Makie/src/theming.jl
@@ -272,14 +272,14 @@ Nested attributes are either also updated incrementally, or replaced if they are
 To change the default colormap to `:greys`, you can pass that attribute as
 a keyword argument to `update_theme!` as demonstrated below.
 ```julia
-update_theme!(colormap=:greys)
+update_theme!(colormap = :greys)
 ```
 
 This can also be achieved by passing an object of types `Attributes` or `Theme`
 as the first and only positional argument:
 ```julia
-update_theme!(Attributes(colormap=:greys))
-update_theme!(Theme(colormap=:greys))
+update_theme!(Attributes(colormap = :greys))
+update_theme!(Theme(colormap = :greys))
 ```
 """
 function update_theme!(with_theme = Attributes(); kwargs...)

--- a/Makie/src/utilities/Plane.jl
+++ b/Makie/src/utilities/Plane.jl
@@ -64,7 +64,7 @@ function distance(plane::Plane{N, T}, point::VecTypes) where {N, T}
 end
 
 """
-    min_clip_distance(planes::Vector{<: Plane}, point)
+    min_clip_distance(planes::Vector{<:Plane}, point)
 
 Returns the smallest absolute distance between the point each clip plane. If
 the point is clipped by any plane, only negative distances are considered.

--- a/Makie/src/utilities/texture_atlas.jl
+++ b/Makie/src/utilities/texture_atlas.jl
@@ -703,7 +703,7 @@ Helper to debug texture atlas (this usually happens on the GPU)!
 can be used like this:
 ```julia
 matr = Makie.get_uv_img(atlas, glyph_index, font)
-scatter(Point2f(0), distancefield=matr, uv_offset_width=Vec4f(0, 0, 1, 1), markersize=100)
+scatter(Point2f(0), distancefield = matr, uv_offset_width = Vec4f(0, 0, 1, 1), markersize = 100)
 ```
 """
 get_uv_img(atlas::TextureAtlas, glyph, font) = get_uv_img(atlas, primitive_uv_offset_width(atlas, glyph, font))

--- a/Makie/src/utilities/utilities.jl
+++ b/Makie/src/utilities/utilities.jl
@@ -13,7 +13,7 @@ end
 
 
 """
-    resample_cmap(cmap, ncolors::Integer; alpha=1.0)
+    resample_cmap(cmap, ncolors::Integer; alpha = 1.0)
 
 * cmap: anything that `to_colormap` accepts
 * ncolors: number of desired colors
@@ -362,7 +362,7 @@ end
 # This function was copied from GR.jl,
 # written by Josef Heinen.
 """
-    peaks([n=49])
+    peaks([n = 49])
 
 Return a nonlinear function on a grid.  Useful for test cases.
 """
@@ -407,7 +407,7 @@ end
 ############################################################
 
 """
-    nan_aware_orthogonal_vector(v1, v2, v3) where N
+    nan_aware_orthogonal_vector(v1, v2, v3) where {N}
 
 Returns an un-normalized normal vector for the triangle formed by the three input points.
 Skips any combination of the inputs for which any point has a NaN component.
@@ -418,7 +418,7 @@ function nan_aware_orthogonal_vector(v1, v2, v3)
 end
 
 """
-    nan_aware_normals(vertices::AbstractVector{<: Union{Point, PointMeta}}, faces::AbstractVector{F})
+    nan_aware_normals(vertices::AbstractVector{<:Union{Point, PointMeta}}, faces::AbstractVector{F})
 
 Computes the normals of a mesh defined by `vertices` and `faces` (a vector of `GeometryBasics.NgonFace`)
 which ignores all contributions from points with `NaN` components.

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ The following examples are supposed to be self-explanatory. For further informat
 
 ```julia
 x = 1:0.1:10
-fig = lines(x, x.^2; label = "Parabola",
-    axis = (; xlabel = "x", ylabel = "y", title ="Title"),
-    figure = (; size = (800,600), fontsize = 22))
+fig = lines(
+    x, x .^ 2; label = "Parabola",
+    axis = (; xlabel = "x", ylabel = "y", title = "Title"),
+    figure = (; size = (800, 600), fontsize = 22)
+)
 axislegend(; position = :lt)
 save("./images/parabola.png", fig)
 fig
@@ -155,13 +157,16 @@ fig
 x = -2pi:0.1:2pi
 approx = fill(0.0, length(x))
 cmap = [:gold, :deepskyblue3, :orangered, "#e82051"]
-with_theme(palette = (; patchcolor = cgrad(cmap, alpha=0.45))) do
-    fig, axis, lineplot = lines(x, sin.(x); label = L"sin(x)", linewidth = 3, color = :black,
-        axis = (; title = "Polynomial approximation of sin(x)",
+with_theme(palette = (; patchcolor = cgrad(cmap, alpha = 0.45))) do
+    fig, axis, lineplot = lines(
+        x, sin.(x); label = L"sin(x)", linewidth = 3, color = :black,
+        axis = (;
+            title = "Polynomial approximation of sin(x)",
             xgridstyle = :dash, ygridstyle = :dash,
             xticksize = 10, yticksize = 10, xtickalign = 1, ytickalign = 1,
-            xticks = (-π:π/2:π, ["π", "-π/2", "0", "π/2", "π"])
-        ))
+            xticks = (-π:(π / 2):π, ["π", "-π/2", "0", "π/2", "π"]),
+        )
+    )
     translate!(lineplot, 0, 0, 2) # move line to foreground
     band!(x, sin.(x), approx .+= x; label = L"n = 0")
     band!(x, sin.(x), approx .+= -x .^ 3 / 6; label = L"n = 1")
@@ -188,15 +193,19 @@ z = x .^ 2 .+ y' .^ 2
 cmap = :plasma
 with_theme(colormap = cmap) do
     fig = Figure(fontsize = 22)
-    ax3d = Axis3(fig[1, 1]; aspect = (1, 1, 1),
-        perspectiveness = 0.5, azimuth = 2.19, elevation = 0.57)
-    ax2d = Axis(fig[1, 2]; aspect = 1, xlabel = "x", ylabel="y")
+    ax3d = Axis3(
+        fig[1, 1]; aspect = (1, 1, 1),
+        perspectiveness = 0.5, azimuth = 2.19, elevation = 0.57
+    )
+    ax2d = Axis(fig[1, 2]; aspect = 1, xlabel = "x", ylabel = "y")
     pltobj = surface!(ax3d, x, y, z; transparency = true)
     heatmap!(ax2d, x, y, z; colormap = (cmap, 0.65))
     contour!(ax2d, x, y, z; linewidth = 2, levels = 12, color = :black)
-    contour3d!(ax3d, x, y, z; linewidth = 4, levels = 12,
-        transparency = true)
-    Colorbar(fig[1, 3], pltobj; label="z", labelrotation=pi)
+    contour3d!(
+        ax3d, x, y, z; linewidth = 4, levels = 12,
+        transparency = true
+    )
+    Colorbar(fig[1, 3], pltobj; label = "z", labelrotation = pi)
     colsize!(fig.layout, 1, Aspect(1, 1.0))
     colsize!(fig.layout, 2, Aspect(1, 1.0))
     resize_to_layout!(fig)

--- a/WGLMakie/README.md
+++ b/WGLMakie/README.md
@@ -18,12 +18,12 @@ using Bonito
 app = App() do session, request
     return DOM.div(
         DOM.h1("Some Makie Plots:"),
-        meshscatter(1:4, color=1:4),
-        meshscatter(1:4, color=rand(RGBAf, 4)),
-        meshscatter(1:4, color=rand(RGBf, 4)),
-        meshscatter(1:4, color=:red),
-        meshscatter(rand(Point3f, 10), color=rand(RGBf, 10)),
-        meshscatter(rand(Point3f, 10), marker=WGLMakie.Pyramid(Point3f(0), 1f0, 1f0)),
+        meshscatter(1:4, color = 1:4),
+        meshscatter(1:4, color = rand(RGBAf, 4)),
+        meshscatter(1:4, color = rand(RGBf, 4)),
+        meshscatter(1:4, color = :red),
+        meshscatter(rand(Point3f, 10), color = rand(RGBf, 10)),
+        meshscatter(rand(Point3f, 10), marker = WGLMakie.Pyramid(Point3f(0), 1.0f0, 1.0f0)),
     )
 end
 isdefined(Main, :server) && close(server)

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -207,9 +207,9 @@ Example:
 ```julia
 App() do
     f1 = scatter(1:4)
-    f2 = scatter(1:4; figure=(; backgroundcolor=:gray))
-    wc = WGLMakie.WithConfig(f2; resize_to=:parent)
-    DOM.div(f1, DOM.div(wc; style="height: 200px; width: 50%"))
+    f2 = scatter(1:4; figure = (; backgroundcolor = :gray))
+    wc = WGLMakie.WithConfig(f2; resize_to = :parent)
+    DOM.div(f1, DOM.div(wc; style = "height: 200px; width: 50%"))
 end
 ```
 """

--- a/WGLMakie/src/picking.jl
+++ b/WGLMakie/src/picking.jl
@@ -85,7 +85,7 @@ function Makie.pick(::Scene, screen::Screen, r::Rect2)
 end
 
 """
-    ToolTip(figurelike, js_callback; plots=plots_you_want_to_hover)
+    ToolTip(figurelike, js_callback; plots = plots_you_want_to_hover)
 
 Returns a Bonito DOM element, which creates a popup whenever you click on a plot element in `plots`.
 The content of the popup is filled with the return value of js_callback, which can be a string or `HTMLNode`.

--- a/WGLMakie/src/spinner.jl
+++ b/WGLMakie/src/spinner.jl
@@ -1,7 +1,7 @@
 # Spinner components for loading indication
 
 """
-    CircleSpinner(; size=40, stroke=4, color="currentColor", background_color="rgba(0, 0, 0, 0.1)", duration=1)
+    CircleSpinner(; size = 40, stroke = 4, color = "currentColor", background_color = "rgba(0, 0, 0, 0.1)", duration = 1)
 
 A circular CSS spinner component that shows a loading animation.
 This is the default spinner for WGLMakie scene loading.
@@ -22,8 +22,8 @@ ensuring that each scene gets its own spinner instance (avoiding shared DOM issu
 WGLMakie.activate!()
 
 # Customize spinner appearance
-spinner = WGLMakie.CircleSpinner(size=60, stroke=6, color="blue")
-WGLMakie.activate!(; spinner=spinner)
+spinner = WGLMakie.CircleSpinner(size = 60, stroke = 6, color = "blue")
+WGLMakie.activate!(; spinner = spinner)
 ```
 
 # Custom Spinners

--- a/docs/src/explanations/animation.md
+++ b/docs/src/explanations/animation.md
@@ -44,7 +44,7 @@ Instead of the above, we could also have written:
 
 ```julia
 function change_function(hue)
-    lineplot.color = HSV(hue, 1, 0.75)
+    return lineplot.color = HSV(hue, 1, 0.75)
 end
 
 record(change_function, fig, "color_animation.mp4", hue_iterator; framerate = framerate)
@@ -168,10 +168,10 @@ limits!(ax, -4, 4, -4, 4)
 fps = 60
 nframes = 120
 
-for i = 1:nframes
+for i in 1:nframes
     new_point = Point2f(randn(2))
     points[] = push!(points[], new_point)
-    sleep(1/fps) # refreshes the display!
+    sleep(1 / fps) # refreshes the display!
 end
 ```
 

--- a/docs/src/explanations/backends/cairomakie.md
+++ b/docs/src/explanations/backends/cairomakie.md
@@ -58,5 +58,5 @@ The version of output PDFs can be restricted via the `pdf_version` argument of t
 ```julia
 using CairoMakie
 fig = Figure()
-save("figure.pdf", fig, pdf_version="1.4")
+save("figure.pdf", fig, pdf_version = "1.4")
 ```

--- a/docs/src/explanations/backends/rprmakie.md
+++ b/docs/src/explanations/backends/rprmakie.md
@@ -32,12 +32,12 @@ radiance = 10000
 # supporting multiple light sources and EnvironmentLights right now
 lights = [
     EnvironmentLight(0.5, Makie.FileIO.load(RPR.assetpath("studio026.exr"))),
-    PointLight(Vec3f(0, 0, 20), RGBf(radiance, radiance, radiance))
+    PointLight(Vec3f(0, 0, 20), RGBf(radiance, radiance, radiance)),
 ]
 
 # Only LScene is supported right now,
 # since the other projections don't map to the physical accurate Camera in RPR.
-ax = LScene(fig[1, 1]; show_axis = false, scenekw=(lights=lights,))
+ax = LScene(fig[1, 1]; show_axis = false, scenekw = (lights = lights,))
 # Note that since RPRMakie doesn't yet support text (this is being worked on!),
 # you can't show a 3d axis yet.
 
@@ -47,7 +47,7 @@ ax = LScene(fig[1, 1]; show_axis = false, scenekw=(lights=lights,))
 # manually created Context would be invalid. Since RPRs error handling is pretty
 # bad, this usually results in Segfaults.
 # See below how to render a picture with a manually created context
-screen = RPRMakie.Screen(ax.scene; iterations=10, plugin=RPR.Northstar)
+screen = RPRMakie.Screen(ax.scene; iterations = 10, plugin = RPR.Northstar)
 matsys = screen.matsys
 context = screen.context
 # You can use lots of materials from RPR.
@@ -55,7 +55,7 @@ context = screen.context
 # Or at least one, that doesn't need to access the RPR context
 mat = RPR.Chrome(matsys)
 # The material attribute is specific to RPRMakie and gets ignored by other Backends. This may change in the future
-mesh!(ax, Sphere(Point3f(0), 1), material=mat)
+mesh!(ax, Sphere(Point3f(0), 1), material = mat)
 
 # There are three main ways to turn a Makie scene into a picture:
 # Get the colorbuffer of the Screen. Screen also has `show` overloaded for the MIME `image/png`
@@ -64,10 +64,10 @@ image = colorbuffer(screen)::Matrix{RGB{N0f8}}
 # Replace a specific (sub) LScene with RPR, and display the whole scene interactively in RPRMakie
 using RPRMakie
 refresh = Observable(nothing) # Optional observable that triggers rerendering
-display(ax.scene; backend=GLMakie) # Make sure to display scene first in GLMakie
+display(ax.scene; backend = GLMakie) # Make sure to display scene first in GLMakie
 # Replace the scene with an interactively rendered RPR output.
 # See more about this in the RPRMakie interop example
-context, task = RPRMakie.replace_scene_rpr!(ax.scene, screen; refresh=refresh)
+context, task = RPRMakie.replace_scene_rpr!(ax.scene, screen; refresh = refresh)
 # If one doesn't create the Screen manually to create custom materials,
 # display(ax.scene), show(io, MIME"image/png", ax.scene), save("rpr.png", ax.scene)
 # Should work just like with other backends.
@@ -89,11 +89,13 @@ using Colors, FileIO
 using Colors: N0f8
 
 radiance = 500
-lights = [EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
-            PointLight(Vec3f(10), RGBf(radiance, radiance, radiance * 1.1))]
-fig = Figure(; size=(1500, 700));
-ax = LScene(fig[1, 1]; show_axis=false, scenekw=(; lights=lights))
-screen = RPRMakie.Screen(ax.scene; plugin=RPR.Northstar, iterations=400)
+lights = [
+    EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
+    PointLight(Vec3f(10), RGBf(radiance, radiance, radiance * 1.1)),
+]
+fig = Figure(; size = (1500, 700));
+ax = LScene(fig[1, 1]; show_axis = false, scenekw = (; lights = lights))
+screen = RPRMakie.Screen(ax.scene; plugin = RPR.Northstar, iterations = 400)
 
 matsys = screen.matsys
 emissive = RPR.EmissiveMaterial(matsys)
@@ -104,20 +106,22 @@ chrome = RPR.Chrome(matsys)
 dielectric = RPR.DielectricBrdfX(matsys)
 gold = RPR.SurfaceGoldX(matsys)
 
-materials = [glass chrome;
-                gold dielectric;
-                emissive plastic]
+materials = [
+    glass chrome;
+    gold dielectric;
+    emissive plastic
+]
 
-mesh!(ax, GeometryBasics.Mesh(load(Makie.assetpath("matball_floor.obj"))); color=:white)
+mesh!(ax, GeometryBasics.Mesh(load(Makie.assetpath("matball_floor.obj"))); color = :white)
 palette = reshape(Makie.wong_colors()[1:6], size(materials))
 
 for i in CartesianIndices(materials)
     x, y = Tuple(i)
     mat = materials[i]
     mplot = if mat === emissive
-        matball!(ax, diffuse; inner=emissive, color=nothing)
+        matball!(ax, diffuse; inner = emissive, color = nothing)
     else
-        matball!(ax, mat; color=nothing)
+        matball!(ax, mat; color = nothing)
     end
     v = Vec3f(((x, y) .- (0.5 .* size(materials)) .- 0.5)..., 0)
     translate!(mplot, 0.9 .* (v .- Vec3f(0, 3, 0)))
@@ -166,22 +170,26 @@ function glow_material(data_normed)
     )
 end
 
-RPRMakie.activate!(iterations=32, plugin=RPR.Northstar)
-fig = Figure(; size=(2000, 800))
+RPRMakie.activate!(iterations = 32, plugin = RPR.Northstar)
+fig = Figure(; size = (2000, 800))
 radiance = 30000
-lights = [EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
-            PointLight(Vec3f(0, 100, 100), RGBf(radiance, radiance, radiance))]
+lights = [
+    EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
+    PointLight(Vec3f(0, 100, 100), RGBf(radiance, radiance, radiance)),
+]
 
-ax = LScene(fig[1, 1]; show_axis=false, scenekw=(lights=lights,))
+ax = LScene(fig[1, 1]; show_axis = false, scenekw = (lights = lights,))
 
 mini, maxi = extrema(data)
 data_normed = ((data .- mini) ./ (maxi - mini))
 
 material = glow_material(data_normed)
 
-pltobj = surface!(ax, lon, lat, data_normed .* 20;
-                    material=material, colormap=[:black, :white, :brown],
-                    colorrange=(0.2, 0.8) .* 20)
+pltobj = surface!(
+    ax, lon, lat, data_normed .* 20;
+    material = material, colormap = [:black, :white, :brown],
+    colorrange = (0.2, 0.8) .* 20
+)
 # Set the camera to a nice angle
 cam = cameracontrols(ax.scene)
 cam.eyeposition[] = Vec3f(3, -300, 300)
@@ -207,24 +215,28 @@ using Colors: N0f8
 f = (u, v) -> cos(v) * (6 - (5 / 4 + sin(3u)) * sin(u - 3v))
 g = (u, v) -> sin(v) * (6 - (5 / 4 + sin(3u)) * sin(u - 3v))
 h = (u, v) -> -cos(u - 3v) * (5 / 4 + sin(3u));
-u = range(0; stop=2π, length=150)
-v = range(0; stop=2π, length=150)
+u = range(0; stop = 2π, length = 150)
+v = range(0; stop = 2π, length = 150)
 radiance = 500
-lights = [EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
-          PointLight(Vec3f(10), RGBf(radiance, radiance, radiance * 1.1))]
+lights = [
+    EnvironmentLight(1.0, load(RPR.assetpath("studio026.exr"))),
+    PointLight(Vec3f(10), RGBf(radiance, radiance, radiance * 1.1)),
+]
 
-fig = Figure(; size=(1500, 1000))
-ax = LScene(fig[1, 1]; show_axis=false, scenekw=(; lights))
-screen = RPRMakie.Screen(size(ax.scene); plugin=RPR.Tahoe)
+fig = Figure(; size = (1500, 1000))
+ax = LScene(fig[1, 1]; show_axis = false, scenekw = (; lights))
+screen = RPRMakie.Screen(size(ax.scene); plugin = RPR.Tahoe)
 material = RPR.UberMaterial(screen.matsys)
 
-surface!(ax, f.(u, v'), g.(u, v'), h.(u, v'); ambient=Vec3f(0.5), diffuse=Vec3f(1),
-         specular=0.5, colormap=:balance, material)
+surface!(
+    ax, f.(u, v'), g.(u, v'), h.(u, v'); ambient = Vec3f(0.5), diffuse = Vec3f(1),
+    specular = 0.5, colormap = :balance, material
+)
 
 function Input(fig, val::RGB)
-    hue = Slider(fig; range=1:380, width=200)
-    lightness = Slider(fig; range=LinRange(0, 1, 100), width=200)
-    labels = [Label(fig, "hue"; halign=:left), Label(fig, "light"; halign=:left)]
+    hue = Slider(fig; range = 1:380, width = 200)
+    lightness = Slider(fig; range = LinRange(0, 1, 100), width = 200)
+    labels = [Label(fig, "hue"; halign = :left), Label(fig, "light"; halign = :left)]
     layout = grid!(hcat(labels, [hue, lightness]))
     hsl = HSL(val)
     set_close_to!(hue, hsl.h)
@@ -234,54 +246,56 @@ function Input(fig, val::RGB)
 end
 
 function Input(fig, val::Vec4)
-    s = Slider(fig; range=LinRange(0, 1, 100), width=200)
+    s = Slider(fig; range = LinRange(0, 1, 100), width = 200)
     set_close_to!(s, first(val))
     return map(Vec4f, s.value), s
 end
 
 function Input(fig, val::Bool)
-    toggle = Toggle(fig; active=val)
+    toggle = Toggle(fig; active = val)
     return toggle.active, toggle
 end
 
 reflection_sliders = (
-    reflection_color=Input(fig, RGB(0, 0, 0)),
-    reflection_weight=Input(fig, Vec4(0)),
-    reflection_roughness=Input(fig, Vec4(0)),
-    reflection_anisotropy=Input(fig, Vec4(0)),
-    reflection_anisotropy_rotation=Input(fig, Vec4(0)),
-    reflection_mode=Input(fig, Vec4(0)),
-    reflection_ior=Input(fig, Vec4(0)),
-    reflection_metalness=Input(fig, Vec4(0)),
+    reflection_color = Input(fig, RGB(0, 0, 0)),
+    reflection_weight = Input(fig, Vec4(0)),
+    reflection_roughness = Input(fig, Vec4(0)),
+    reflection_anisotropy = Input(fig, Vec4(0)),
+    reflection_anisotropy_rotation = Input(fig, Vec4(0)),
+    reflection_mode = Input(fig, Vec4(0)),
+    reflection_ior = Input(fig, Vec4(0)),
+    reflection_metalness = Input(fig, Vec4(0)),
 )
 refraction_sliders = (
-    refraction_color=Input(fig, RGB(0, 0, 0)),
-    refraction_weight=Input(fig, Vec4(0)),
-    refraction_roughness=Input(fig, Vec4(0)),
-    refraction_ior=Input(fig, Vec4(0)),
-    refraction_absorption_color=Input(fig, RGB(0, 0, 0)),
-    refraction_absorption_distance=Input(fig, Vec4(0)),
-    refraction_caustics=Input(fig, true),
+    refraction_color = Input(fig, RGB(0, 0, 0)),
+    refraction_weight = Input(fig, Vec4(0)),
+    refraction_roughness = Input(fig, Vec4(0)),
+    refraction_ior = Input(fig, Vec4(0)),
+    refraction_absorption_color = Input(fig, RGB(0, 0, 0)),
+    refraction_absorption_distance = Input(fig, Vec4(0)),
+    refraction_caustics = Input(fig, true),
 )
 sss_sliders = (
-    sss_scatter_color=Input(fig, RGB(0, 0, 0)),
-    sss_scatter_distance=Input(fig, Vec4(0)),
-    sss_scatter_direction=Input(fig, Vec4(0)),
-    sss_weight=Input(fig, Vec4(0)),
-    sss_multiscatter=Input(fig, false),
+    sss_scatter_color = Input(fig, RGB(0, 0, 0)),
+    sss_scatter_distance = Input(fig, Vec4(0)),
+    sss_scatter_direction = Input(fig, Vec4(0)),
+    sss_weight = Input(fig, Vec4(0)),
+    sss_multiscatter = Input(fig, false),
 )
 backscatter_sliders = (
-    backscatter_weight=Input(fig, Vec4(0)),
-    backscatter_color=Input(fig, RGB(0, 0, 0))
+    backscatter_weight = Input(fig, Vec4(0)),
+    backscatter_color = Input(fig, RGB(0, 0, 0)),
 )
-sliders = merge(reflection_sliders, refraction_sliders,
-                sss_sliders, backscatter_sliders)
+sliders = merge(
+    reflection_sliders, refraction_sliders,
+    sss_sliders, backscatter_sliders
+)
 
 labels = []
 inputs = []
 refresh = Observable(nothing)
 for (key, (obs, input)) in pairs(sliders)
-    push!(labels, Label(fig, string(key); align=:left))
+    push!(labels, Label(fig, string(key); align = :left))
     push!(inputs, input)
     on(obs) do value
         setproperty!(material, key, value)
@@ -289,7 +303,7 @@ for (key, (obs, input)) in pairs(sliders)
     end
 end
 
-fig[1, 2] = grid!(hcat(labels, inputs); width=500)
+fig[1, 2] = grid!(hcat(labels, inputs); width = 500)
 RPRMakie.activate!()
 
 cam = cameracontrols(ax.scene)
@@ -300,7 +314,7 @@ cam.fov[] = 30
 
 display(fig)
 
-context, task = RPRMakie.replace_scene_rpr!(ax.scene, screen; refresh=refresh)
+context, task = RPRMakie.replace_scene_rpr!(ax.scene, screen; refresh = refresh)
 
 # Change light parameters interactively
 begin
@@ -342,8 +356,8 @@ origins = Dict(
 )
 
 rotation_axes = Dict(
-    "arm_right" => Vec3f(0.0000, -0.9828, 0.1848),
-    "arm_left" => Vec3f(0.0000, 0.9828, 0.1848),
+    "arm_right" => Vec3f(0.0, -0.9828, 0.1848),
+    "arm_left" => Vec3f(0.0, 0.9828, 0.1848),
     "leg_right" => Vec3f(0, -1, 0),
     "leg_left" => Vec3f(0, 1, 0),
 )
@@ -361,37 +375,37 @@ function plot_part!(scene, parent, name::String)
     else
         translate!(trans, -ptrans.translation[])
     end
-    return mesh!(scene, m; color=color, transformation=trans)
+    return mesh!(scene, m; color = color, transformation = trans)
 end
 
-function plot_lego_figure(s, floor=true)
+function plot_lego_figure(s, floor = true)
     # Plot hierarchical mesh!
     figure = Dict()
     # Plot hierarchical mesh!
     figure["torso"] = plot_part!(s, s, "torso")
-        figure["head"] = plot_part!(s, figure["torso"], "head")
-            figure["eyes_mouth"] = plot_part!(s, figure["head"], "eyes_mouth")
-        figure["arm_right"] = plot_part!(s, figure["torso"], "arm_right")
-            figure["hand_right"] = plot_part!(s, figure["arm_right"], "hand_right")
-        figure["arm_left"] = plot_part!(s, figure["torso"], "arm_left")
-            figure["hand_left"] = plot_part!(s, figure["arm_left"], "hand_left")
-        figure["belt"] = plot_part!(s, figure["torso"], "belt")
-            figure["leg_right"] = plot_part!(s, figure["belt"], "leg_right")
-            figure["leg_left"] = plot_part!(s, figure["belt"], "leg_left")
+    figure["head"] = plot_part!(s, figure["torso"], "head")
+    figure["eyes_mouth"] = plot_part!(s, figure["head"], "eyes_mouth")
+    figure["arm_right"] = plot_part!(s, figure["torso"], "arm_right")
+    figure["hand_right"] = plot_part!(s, figure["arm_right"], "hand_right")
+    figure["arm_left"] = plot_part!(s, figure["torso"], "arm_left")
+    figure["hand_left"] = plot_part!(s, figure["arm_left"], "hand_left")
+    figure["belt"] = plot_part!(s, figure["torso"], "belt")
+    figure["leg_right"] = plot_part!(s, figure["belt"], "leg_right")
+    figure["leg_left"] = plot_part!(s, figure["belt"], "leg_left")
     # lift the little guy up
     translate!(figure["torso"], 0, 0, 20)
     # add some floor
-    floor && mesh!(s, Rect3f(Vec3f(-400, -400, -2), Vec3f(800, 800, 2)), color=:white)
+    floor && mesh!(s, Rect3f(Vec3f(-400, -400, -2), Vec3f(800, 800, 2)), color = :white)
     return figure
 end
 
-RPRMakie.activate!(iterations=200, plugin=RPR.Northstar)
+RPRMakie.activate!(iterations = 200, plugin = RPR.Northstar)
 radiance = 50000
 lights = [
     EnvironmentLight(1.5, rotl90(load(assetpath("sunflowers_1k.hdr"))')),
-    PointLight(Vec3f(50, 0, 200), RGBf(radiance, radiance, radiance*1.1)),
+    PointLight(Vec3f(50, 0, 200), RGBf(radiance, radiance, radiance * 1.1)),
 ]
-s = Scene(size=(500, 500), lights=lights)
+s = Scene(size = (500, 500), lights = lights)
 
 cam3d!(s)
 c = cameracontrols(s)
@@ -400,12 +414,12 @@ c.far[] = 1000
 update_cam!(s, c, Vec3f(100, 30, 80), Vec3f(0, 0, -10))
 figure = plot_lego_figure(s)
 
-rot_joints_by = 0.25*pi
+rot_joints_by = 0.25 * pi
 total_translation = 50
 animation_strides = 10
 
 a1 = LinRange(0, rot_joints_by, animation_strides)
-angles = [a1; reverse(a1[1:end-1]); -a1[2:end]; reverse(-a1[1:end-1]);]
+angles = [a1; reverse(a1[1:(end - 1)]); -a1[2:end]; reverse(-a1[1:(end - 1)]);]
 nsteps = length(angles); #Number of animation steps
 translations = LinRange(0, total_translation, nsteps)
 
@@ -476,24 +490,26 @@ end
 
 earth_img = load(Downloads.download("https://upload.wikimedia.org/wikipedia/commons/5/56/Blue_Marble_Next_Generation_%2B_topography_%2B_bathymetry.jpg"))
 # the actual plot !
-RPRMakie.activate!(; iterations=100)
+RPRMakie.activate!(; iterations = 100)
 scene = with_theme(theme_dark()) do
-    fig = Figure(; size=(1000, 1000))
+    fig = Figure(; size = (1000, 1000))
     radiance = 30
-    lights = [EnvironmentLight(0.5, load(RPR.assetpath("starmap_4k.tif"))),
-              PointLight(Vec3f(1, 1, 3), RGBf(radiance, radiance, radiance))]
-    ax = LScene(fig[1, 1]; show_axis=false, scenekw=(;lights=lights))
+    lights = [
+        EnvironmentLight(0.5, load(RPR.assetpath("starmap_4k.tif"))),
+        PointLight(Vec3f(1, 1, 3), RGBf(radiance, radiance, radiance)),
+    ]
+    ax = LScene(fig[1, 1]; show_axis = false, scenekw = (; lights = lights))
     n = 1024 ÷ 4 # 2048
     θ = LinRange(0, pi, n)
     φ = LinRange(-pi, pi, 2 * n)
     xe = [cos(φ) * sin(θ) for θ in θ, φ in φ]
     ye = [sin(φ) * sin(θ) for θ in θ, φ in φ]
     ze = [cos(θ) for θ in θ, φ in φ]
-    surface!(ax, xe, ye, ze; color=earth_img)
-    meshscatter!(toPoints3D; color=1:length(toPoints3D), markersize=0.005, colormap=:plasma)
+    surface!(ax, xe, ye, ze; color = earth_img)
+    meshscatter!(toPoints3D; color = 1:length(toPoints3D), markersize = 0.005, colormap = :plasma)
     colors = Makie.default_palettes.color[]
     c = Iterators.cycle(colors)
-    foreach(((l, c),) -> lines!(ax, l; linewidth=2, color=c), zip(splitLines3D, c))
+    foreach(((l, c),) -> lines!(ax, l; linewidth = 2, color = c), zip(splitLines3D, c))
     ax.scene.camera_controls.eyeposition[] = Vec3f(1.5)
     return ax.scene
 end

--- a/docs/src/explanations/backends/wglmakie.md
+++ b/docs/src/explanations/backends/wglmakie.md
@@ -47,7 +47,7 @@ Locally, WGLMakie should just work out of the box for Pluto/IJulia. However, if 
 begin
     using Bonito
     some_forwarded_port = 8080
-    Page(listen_url="0.0.0.0", listen_port=some_forwarded_port)
+    Page(listen_url = "0.0.0.0", listen_port = some_forwarded_port)
 end
 ```
 
@@ -78,7 +78,7 @@ WGLMakie shows a loading spinner while the scene is being initialized. By defaul
 To remove the spinner entirely, pass `nothing`:
 
 ```julia
-WGLMakie.activate!(; spinner=nothing)
+WGLMakie.activate!(; spinner = nothing)
 ```
 
 #### Styling the Default Spinner
@@ -89,13 +89,13 @@ The default `CircleSpinner` accepts several styling options:
 using WGLMakie
 # Customize the spinner's appearance
 spinner = WGLMakie.CircleSpinner(;
-    size=100,                                    # diameter in pixels
-    stroke=10,                                   # border width in pixels
-    color="red",                       # color of the spinning part
-    background_color="rgba(1, 0, 0, 0.9)",      # color of the background circle
-    duration=1                                  # rotation speed in seconds
+    size = 100,                                    # diameter in pixels
+    stroke = 10,                                   # border width in pixels
+    color = "red",                       # color of the spinning part
+    background_color = "rgba(1, 0, 0, 0.9)",      # color of the background circle
+    duration = 1                                  # rotation speed in seconds
 )
-WGLMakie.activate!(; spinner=spinner)
+WGLMakie.activate!(; spinner = spinner)
 ```
 
 #### Using a Custom Spinner
@@ -129,12 +129,12 @@ function Bonito.jsrender(session::Bonito.Session, spinner::TextSpinner)
             "font-size" => "14px",
         )
     )
-    return Bonito.jsrender(session, Bonito.DOM.div(container_styles, spinner.message; class="wglmakie-spinner"))
+    return Bonito.jsrender(session, Bonito.DOM.div(container_styles, spinner.message; class = "wglmakie-spinner"))
 end
 
 # Use the custom spinner
 custom_spinner = TextSpinner("Loading visualization...", "rgba(0, 0, 0, 0.7)")
-WGLMakie.activate!(; spinner=custom_spinner)
+WGLMakie.activate!(; spinner = custom_spinner)
 ```
 
 Note: The `wglmakie-spinner` class is required as WGLMakie uses it to find and remove the spinner once the scene is fully loaded.
@@ -171,8 +171,8 @@ WGLMakie.activate!(; use_html_widgets = true)
 
 fig = Figure()
 ax = Axis(fig[1, 1])
-sl = Makie.Slider(fig[2, 1], range = 0:0.1:10, startvalue = 5, tellwidth=false)
-btn = Makie.Button(fig[3, 1], label = "Click me", tellwidth=false)
+sl = Makie.Slider(fig[2, 1], range = 0:0.1:10, startvalue = 5, tellwidth = false)
+btn = Makie.Button(fig[3, 1], label = "Click me", tellwidth = false)
 x = 0:10
 lines!(ax, x, map(y -> sin.(y .* x), sl.value))
 fig # Will get rendered with HTML widgets
@@ -182,7 +182,7 @@ You can also use this locally in a Bonito app:
 
 ```julia
 App() do
-    DOM.div(WGLMakie.WithConfig(fig; use_html_widget=true))
+    DOM.div(WGLMakie.WithConfig(fig; use_html_widget = true))
 end
 ```
 
@@ -413,11 +413,13 @@ Bonito also offers the `Styles` type, which allows to define whole stylesheets a
 That's how Bonito creates styleable components:
 
 ```julia
-Rows(args...) = DOM.div(args..., style=Styles(
-    "display" => "grid",
-    "grid-template-rows" => "fr",
-    "grid-template-columns" => "repeat($(length(args)), fr)",
-))
+Rows(args...) = DOM.div(
+    args..., style = Styles(
+        "display" => "grid",
+        "grid-template-rows" => "fr",
+        "grid-template-columns" => "repeat($(length(args)), fr)",
+    )
+)
 ```
 This Style object will only be inserted one time into the DOM in one Session, and subsequent uses will just give the div the same class.
 
@@ -470,31 +472,37 @@ using WGLMakie, Bonito, FileIO
 WGLMakie.activate!()
 
 open("index.html", "w") do io
-    println(io, """
-    <html>
-        <head>
-        </head>
-        <body>
-    """)
-    Page(exportable=true, offline=true)
+    println(
+        io, """
+        <html>
+            <head>
+            </head>
+            <body>
+        """
+    )
+    Page(exportable = true, offline = true)
     # Then, you can just inline plots or whatever you want :)
     # Of course it would make more sense to put this into a single app
     app = App() do
-        C(x;kw...) = Card(x; height="fit-content", width="fit-content", kw...)
-        figure = (; size=(300, 300))
+        C(x; kw...) = Card(x; height = "fit-content", width = "fit-content", kw...)
+        figure = (; size = (300, 300))
         f1 = scatter(1:4; figure)
         f2 = mesh(load(assetpath("brain.stl")); figure)
-        C(DOM.div(
-            Bonito.StylableSlider(1:100),
-            Row(C(f1), C(f2))
-        ); padding="30px", margin="15px")
+        C(
+            DOM.div(
+                Bonito.StylableSlider(1:100),
+                Row(C(f1), C(f2))
+            ); padding = "30px", margin = "15px"
+        )
     end
     show(io, MIME"text/html"(), app)
     # or anything else from Bonito, or that can be displayed as html:
-    println(io, """
-        </body>
-    </html>
-    """)
+    println(
+        io, """
+            </body>
+        </html>
+        """
+    )
 end
 ```
 

--- a/docs/src/explanations/compute-pipeline.md
+++ b/docs/src/explanations/compute-pipeline.md
@@ -22,7 +22,7 @@ add_input!((key, value) -> Float32(value), graph, :input2, 2)
 # add computations (edges + output nodes)
 register_computation!(graph, [:input1, :input2], [:output]) do inputs, changed, cached
     input1, input2 = inputs
-    return (input1[] + input2[], )
+    return (input1[] + input2[],)
 end
 ```
 
@@ -84,14 +84,14 @@ add_input!(graph, :input2, 2)
 
 register_computation!(graph, [:input1, :input2], [:sum]) do inputs, changed, cached
     input1, input2 = inputs
-    return (input1[] + input2[], )
+    return (input1[] + input2[],)
 end
 
 graph2 = ComputeGraph()
 add_input!(graph2, :sum, graph[:sum])
 
 register_computation!(graph2, [:sum], [:output]) do (sum,), changed, cached
-    return (2 * sum[], )
+    return (2 * sum[],)
 end
 
 graph2[:output][] # 2 * (1 + 2) = 6

--- a/docs/src/explanations/dim-converts.md
+++ b/docs/src/explanations/dim-converts.md
@@ -58,7 +58,7 @@ And set them accordingly:
 
 ```julia
 f = Figure()
-ax = Axis(f[1, 1]; dim1_conversion=Makie.CategoricalConversion())
+ax = Axis(f[1, 1]; dim1_conversion = Makie.CategoricalConversion())
 ```
 
 ### Experimental DynamicQuantities.jl support

--- a/docs/src/explanations/events.md
+++ b/docs/src/explanations/events.md
@@ -402,8 +402,8 @@ In this example, we sample from the Scene `scene` for 10 seconds, at a rate of 1
 ```julia
 fps = 10
 record(scene, "test.mp4"; framerate = fps) do io
-    for i = 1:100
-        sleep(1/fps)
+    for i in 1:100
+        sleep(1 / fps)
         recordframe!(io)
     end
 end

--- a/docs/src/explanations/faq.md
+++ b/docs/src/explanations/faq.md
@@ -36,11 +36,13 @@ Tiling the plot, as shown below, yields a correct image.
 ```julia
 sc = Scene()
 data = rand(Float32, 24900, 26620)
-heatmap!(sc, 1:size(data, 1)÷2, 1:size(data, 2)÷2, data[1:end÷2, 1:end÷2])
-heatmap!(sc, (size(data, 1)÷2 + 1):size(data, 1), 1:size(data, 2)÷2, data[(end÷2 + 1):end, 1:end÷2])
-heatmap!(sc, 1:size(data, 1)÷2, (size(data, 2)÷2 + 1):size(data, 2), data[1:end÷2, (end÷2 + 1):end])
-heatmap!(sc, (size(data, 1)÷2 + 1):size(data, 1), (size(data, 2)÷2 + 1):size(data, 2),
-         data[(end÷2 + 1):end, (end÷2 + 1):end])
+heatmap!(sc, 1:(size(data, 1) ÷ 2), 1:(size(data, 2) ÷ 2), data[1:(end ÷ 2), 1:(end ÷ 2)])
+heatmap!(sc, (size(data, 1) ÷ 2 + 1):size(data, 1), 1:(size(data, 2) ÷ 2), data[(end ÷ 2 + 1):end, 1:(end ÷ 2)])
+heatmap!(sc, 1:(size(data, 1) ÷ 2), (size(data, 2) ÷ 2 + 1):size(data, 2), data[1:(end ÷ 2), (end ÷ 2 + 1):end])
+heatmap!(
+    sc, (size(data, 1) ÷ 2 + 1):size(data, 1), (size(data, 2) ÷ 2 + 1):size(data, 2),
+    data[(end ÷ 2 + 1):end, (end ÷ 2 + 1):end]
+)
 ```
 ![tiled heatmap](https://user-images.githubusercontent.com/32143268/61105143-a3b35780-a496-11e9-83d1-bebe549aa593.png)
 

--- a/docs/src/explanations/headless.md
+++ b/docs/src/explanations/headless.md
@@ -58,7 +58,7 @@ If you want to change the port on which WGLMakie runs on the remote, say `8081`,
 ```julia
 using Bonito
 
-Bonito.configure_server!(listen_port=8081)
+Bonito.configure_server!(listen_port = 8081)
 ```
 before any plotting commands with WGLMakie.
 
@@ -67,5 +67,5 @@ you will also need to set the `forwarded_port` like this:
 ```julia
 using Bonito
 
-Bonito.configure_server!(listen_port=8081, forwarded_port=8080)
+Bonito.configure_server!(listen_port = 8081, forwarded_port = 8080)
 ```

--- a/docs/src/explanations/inspector.md
+++ b/docs/src/explanations/inspector.md
@@ -70,11 +70,11 @@ We thus implement
 import Makie: show_data
 
 function show_data(inspector::DataInspector, plot::BarPlot, idx, ::Lines)
-    return show_barplot(inspector, plot, div(idx-1, 6)+1)
+    return show_barplot(inspector, plot, div(idx - 1, 6) + 1)
 end
 
 function show_data(inspector::DataInspector, plot::BarPlot, idx, ::Mesh)
-    return show_barplot(inspector, plot, div(idx-1, 4)+1)
+    return show_barplot(inspector, plot, div(idx - 1, 4) + 1)
 end
 ```
 

--- a/docs/src/explanations/recipes.md
+++ b/docs/src/explanations/recipes.md
@@ -25,7 +25,7 @@ This is the sequential logic by which conversions in Makie are attempted:
 Plotting of a `Circle` for example can be defined via a conversion into a vector of points for any existing plot type:
 
 ```julia
-Makie.convert_arguments(::Type{<: AbstractPlot}, x::Circle) = (decompose(Point2f, x),)
+Makie.convert_arguments(::Type{<:AbstractPlot}, x::Circle) = (decompose(Point2f, x),)
 ```
 
 !!! warning
@@ -114,7 +114,7 @@ Otherwise a set of default names `Symbol(:converted_, i)` is used.
 In our example we provided `(x, y, z)` and thus get:
 
 ```julia
-argument_names(::Type{<: MyPlot}, N) = (:x, :y, :z)
+argument_names(::Type{<:MyPlot}, N) = (:x, :y, :z)
 ```
 
 This is optional but it will allow the use of `plot_object.x` to fetch the first converted argument from the call `plot_object = myplot(rand(10), rand(10), rand(10))`, for example.
@@ -154,7 +154,7 @@ The function needs to return the output of `@DocumentedAttributes` for this.
 
 ```julia
 function shared_myplot_attributes()
-    Makie.@DocumentedAttributes begin
+    return Makie.@DocumentedAttributes begin
         "Some attribute that is used by multiple recipes"
         shared_attribute1 = 1
         shared_attribute2 = @inherit markersize
@@ -180,7 +180,7 @@ The function resolves the inherited attributes and returns the final set of defa
 You can control which kind of axis is used for the plot by defining
 
 ```julia
-Makie.args_preferred_axis(::Type{<: MyPlot}, x, y, z) =  Makie.LScene
+Makie.args_preferred_axis(::Type{<:MyPlot}, x, y, z) = Makie.LScene
 ```
 
 or
@@ -209,8 +209,8 @@ It's possible to add specializations here, depending on the converted argument t
 For example, to specialize the behavior of `myplot(a)` when `a` converts to a 3D array of floating point numbers:
 
 ```julia
-const MyVolume = MyPlot{Tuple{<:AbstractArray{<: AbstractFloat, 3}}}
-argument_names(::Type{<: MyVolume}) = (:volume,) # optional, to allow plot[:volume]
+const MyVolume = MyPlot{Tuple{<:AbstractArray{<:AbstractFloat, 3}}}
+argument_names(::Type{<:MyVolume}) = (:volume,) # optional, to allow plot[:volume]
 function plot!(plot::MyVolume)
     volume!(plot, plot[:volume], colormap = plot[:colormap])
     return plot
@@ -239,7 +239,7 @@ To register a new computation and produce new (output) nodes you can use
 map!(plot.attributes, [:positions, :window], :running_average) do positions, window
     # if the output name is a Symbol, return a value
     # if the output is Symbol[], return a tuple() of values (matching order)
-    return [mean(positions[i : i + window]) for i in 1 : length(positions)-window]
+    return [mean(positions[i:(i + window)]) for i in 1:(length(positions) - window)]
 end
 ```
 
@@ -257,11 +257,11 @@ register_computation!(plot.attributes, [:positions, :window], [:running_average]
 
     # cached contains the previous result or nothing if no previous result exists
 
-    output = [mean(positions[i : i + window]) for i in 1 : length(positions)-window]
+    output = [mean(positions[i:(i + window)]) for i in 1:(length(positions) - window)]
 
     # The return type should be either a tuple() of the new data, or nothing if
     # the calculation should be discarded
-    return (output, )
+    return (output,)
 end
 ```
 
@@ -298,7 +298,7 @@ While you can pass them one by one via keyword arguments, you can also pass `plo
 
 ```julia
 function Makie.plot!(myplot::MyPlot)
-    lines!(myplot, myplot.attributes, args...; kwargs...)
+    return lines!(myplot, myplot.attributes, args...; kwargs...)
 end
 ```
 
@@ -308,7 +308,7 @@ If you want to prevent an attribute from getting forwarded you can explicitly se
 
 ```julia
 function Makie.plot!(myplot::MyPlot)
-    lines!(myplot, myplot.attributes, args...; color = myplot.computed_color)
+    return lines!(myplot, myplot.attributes, args...; color = myplot.computed_color)
 end
 ```
 
@@ -323,7 +323,7 @@ They can still be used, but may run into update synchronization issues, can be h
 The code above can be translated to:
 
 ```julia
-@recipe MyPlot (positions, ) begin
+@recipe MyPlot (positions,) begin
     window = 10
 end
 
@@ -335,8 +335,8 @@ function Makie.plot!(myplot::MyPlot)
     running_variance = Observable(Float32[])
 
     onany(myplot, myplot.position, myplot.window) do positions, window
-        running_average.val = [mean(positions[i : i + window]) for i in 1 : length(positions)-window]
-        running_variance.val = [var(positions[i : i + window]) for i in 1 : length(positions)-window]
+        running_average.val = [mean(positions[i:(i + window)]) for i in 1:(length(positions) - window)]
+        running_variance.val = [var(positions[i:(i + window)]) for i in 1:(length(positions) - window)]
         notify(running_average)
         notify(running_variance)
         return

--- a/docs/src/explanations/specapi.md
+++ b/docs/src/explanations/specapi.md
@@ -34,7 +34,7 @@ The convention is to always use the `S` prefix when creating spec objects, so th
 import Makie.SpecApi as S
 
 scatterspec = S.Scatter(1:4) # a PlotSpec describing a Scatter plot
-axspec = S.Axis(plots=[scatterspec]) # a BlockSpec describing an Axis with a Scatter plot
+axspec = S.Axis(plots = [scatterspec]) # a BlockSpec describing an Axis with a Scatter plot
 layout_spec = S.GridLayout(axspec) # a Layout describing a Figure with an Axis with a Scatter plot
 
 # Now we can instantiate the spec into a fully realized Figure.
@@ -48,14 +48,14 @@ f, _, pl = plot(layout_spec)
 # update all the content in the Figure with something new. In this case,
 # we just change the plot type in the Axis from Scatter to Lines, and the
 # axis title to "Lines".
-pl[1] = S.GridLayout(S.Axis(; title="Lines", plots=[S.Lines(1:4)]))
+pl[1] = S.GridLayout(S.Axis(; title = "Lines", plots = [S.Lines(1:4)]))
 ```
 
 You can not only `plot` specs describing whole layout, but also specs describing `Block`s or just single plots.
 
 ```julia
-s = Makie.PlotSpec(:Scatter, 1:4; color=:red)
-axis = Makie.BlockSpec(:Axis; title="Axis at layout position (1, 1)")
+s = Makie.PlotSpec(:Scatter, 1:4; color = :red)
+axis = Makie.BlockSpec(:Axis; title = "Axis at layout position (1, 1)")
 ```
 
 ## Building layouts for specs
@@ -361,8 +361,8 @@ Note that things like `hidedecorations!(axis)` is not yet supported, since we wi
 One of the few functions that's already supported is `linkaxes!`:
 
 ```julia
-axes_1 = [S.Axis(title="Axis (1): $(i)") for i in 1:3]
-axes_2 = [S.Axis(title="Axis (2): $(i)") for i in 1:3]
+axes_1 = [S.Axis(title = "Axis (1): $(i)") for i in 1:3]
+axes_2 = [S.Axis(title = "Axis (2): $(i)") for i in 1:3]
 for ax1 in axes_1
     for ax2 in axes_2
         if ax1 != ax2

--- a/docs/src/reference/blocks/axis.md
+++ b/docs/src/reference/blocks/axis.md
@@ -272,14 +272,14 @@ function Makie.process_interaction(interaction::MyInteraction, event::MouseEvent
     if interaction.allow_left_click && event.type === MouseEventTypes.leftclick
         println("Left click in correct mode")
     end
-    if interaction.allow_right_click && event.type === MouseEventTypes.rightclick
+    return if interaction.allow_right_click && event.type === MouseEventTypes.rightclick
         println("Right click in correct mode")
     end
 end
 
 function Makie.process_interaction(interaction::MyInteraction, event::KeysEvent, axis)
     interaction.allow_left_click = Keyboard.l in event.keys
-    interaction.allow_right_click = Keyboard.r in event.keys
+    return interaction.allow_right_click = Keyboard.r in event.keys
 end
 
 register_interaction!(ax, :left_and_right, MyInteraction(false, false))

--- a/docs/src/reference/blocks/legend.md
+++ b/docs/src/reference/blocks/legend.md
@@ -182,7 +182,7 @@ The attributes for these elements are the following (the `[]` parts can be left 
 
 # MarkerElement
 [marker]points, marker, markersize, [marker]color,
-[marker]strokewidth, [marker]strokecolor
+    [marker]strokewidth, [marker]strokecolor
 
 # PolyElement
 [poly]points, [poly]color, [poly]strokewidth, [poly]strokecolor

--- a/docs/src/reference/plots/datashader.md
+++ b/docs/src/reference/plots/datashader.md
@@ -128,10 +128,11 @@ end
 
 # ~0.06s
 @time begin
-    f, ax, dsplot = datashader(points;
-        colormap=:fire,
-        axis=(; type=Axis, autolimitaspect = 1),
-        figure=(;figure_padding=0, size=(1200, 600))
+    f, ax, dsplot = datashader(
+        points;
+        colormap = :fire,
+        axis = (; type = Axis, autolimitaspect = 1),
+        figure = (; figure_padding = 0, size = (1200, 600))
     )
     # Zoom into the hotspot
     limits!(ax, Rect2f(-74.175, 40.619, 0.5, 0.25))
@@ -163,15 +164,15 @@ points = Mmap.mmap(open(path, "r"), Vector{Point2f});
         # For a big dataset its interesting to see how long each aggregation takes
         show_timings = true,
         # Use a local operation which is faster to calculate and looks good!
-        local_operation=x-> log10(x + 1),
+        local_operation = x -> log10(x + 1),
         #=
             in the code we used to save the binary, we had the points in the wrong order.
             A good chance to demonstrate the `point_transform` argument,
             Which gets applied to every point before aggregating it
         =#
-        point_transform=reverse,
-        axis=(; type=Axis, autolimitaspect = 1),
-        figure=(;figure_padding=0, size=(1200, 600))
+        point_transform = reverse,
+        axis = (; type = Axis, autolimitaspect = 1),
+        figure = (; figure_padding = 0, size = (1200, 600))
     )
     hidedecorations!(ax)
     hidespines!(ax)
@@ -217,18 +218,18 @@ fig
 We can also reuse the previous NYC example for a categorical plot:
 ```julia
 @time begin
-    f = Figure(figure_padding=0, size=(1200, 600))
+    f = Figure(figure_padding = 0, size = (1200, 600))
     ax = Axis(
         f[1, 1],
-        autolimitaspect=1,
-        limits=(-74.022, -73.827, 40.696, 40.793),
-        backgroundcolor=:black
+        autolimitaspect = 1,
+        limits = (-74.022, -73.827, 40.696, 40.793),
+        backgroundcolor = :black
     )
     datashader!(ax, groups, points)
     hidedecorations!(ax)
     hidespines!(ax)
     # Create a styled legend
-    axislegend("Vendor ID"; titlecolor=:white, framecolor=:grey, polystrokewidth=2, polystrokecolor=(:white, 0.5), rowgap=10, backgroundcolor=:black, labelcolor=:white)
+    axislegend("Vendor ID"; titlecolor = :white, framecolor = :grey, polystrokewidth = 2, polystrokecolor = (:white, 0.5), rowgap = 10, backgroundcolor = :black, labelcolor = :white)
     display(f)
 end
 ```

--- a/docs/src/reference/plots/heatmap.md
+++ b/docs/src/reference/plots/heatmap.md
@@ -182,7 +182,7 @@ using Downloads, FileIO, GLMakie
 # 30000×22943 image
 path = Downloads.download("https://upload.wikimedia.org/wikipedia/commons/7/7e/In_the_Conservatory.jpg")
 img = rotr90(load(path))
-f, ax, pl = heatmap(Resampler(img); axis=(; aspect=DataAspect()), figure=(;size=size(img)./20))
+f, ax, pl = heatmap(Resampler(img); axis = (; aspect = DataAspect()), figure = (; size = size(img) ./ 20))
 hidedecorations!(ax)
 f
 ```
@@ -195,11 +195,15 @@ For better down sampling quality we recommend using `Makie.Pyramid` (might be mo
 ```julia
 pyramid = Makie.Pyramid(img)
 fsize = (size(img) ./ 30) .* (1, 2)
-fig, ax, pl = heatmap(Resampler(pyramid);
-    axis=(; aspect=DataAspect(), title="Pyramid"), figure=(; size=fsize))
+fig, ax, pl = heatmap(
+    Resampler(pyramid);
+    axis = (; aspect = DataAspect(), title = "Pyramid"), figure = (; size = fsize)
+)
 hidedecorations!(ax)
-ax, pl = heatmap(fig[2, 1], Resampler(img1);
-    axis=(; aspect=DataAspect(), title="No Pyramid"))
+ax, pl = heatmap(
+    fig[2, 1], Resampler(img1);
+    axis = (; aspect = DataAspect(), title = "No Pyramid")
+)
 hidedecorations!(ax)
 save("heatmap-pyramid.png", fig)
 ```

--- a/docs/src/tutorials/inset-plot-tutorial.md
+++ b/docs/src/tutorials/inset-plot-tutorial.md
@@ -114,23 +114,27 @@ time = 1:500
 stock_price = cumsum(randn(500) .+ 0.5)
 
 # Create a figure
-fig = Figure(size=(800, 600))
+fig = Figure(size = (800, 600))
 
 # Main plot
-ax_main = Axis(fig[1, 1],
-    title="Stock Price Over Time",
-    xlabel="Days",
-    ylabel="Price")
+ax_main = Axis(
+    fig[1, 1],
+    title = "Stock Price Over Time",
+    xlabel = "Days",
+    ylabel = "Price"
+)
 
-line_main = lines!(ax_main, time, stock_price, color=:blue)
+line_main = lines!(ax_main, time, stock_price, color = :blue)
 
 # Inset axis
-ax_inset = Axis(fig[1, 1],
-    width=Relative(0.2),
-    height=Relative(0.2),
-    halign=0.1,
-    valign=0.9,
-    title="Zoomed View")
+ax_inset = Axis(
+    fig[1, 1],
+    width = Relative(0.2),
+    height = Relative(0.2),
+    halign = 0.1,
+    valign = 0.9,
+    title = "Zoomed View"
+)
 
 # Set xlims for a selected time data range
 xlims!(ax_inset, 50, 70)
@@ -140,7 +144,7 @@ min_price, max_price = extrema(stock_price[50:70])
 ylims!(ax_inset, min_price, max_price)
 
 # Plot the data in the inset axis
-line_inset = lines!(ax_inset, time, stock_price, color=:red)
+line_inset = lines!(ax_inset, time, stock_price, color = :red)
 
 # Z-Ordering for rendering order
 translate!(ax_inset.blockscene, 0, 0, 150)
@@ -150,7 +154,7 @@ Legend(fig[1, 2], [line_main, line_inset], ["Stock Price", "Zoomed Region"])
 
 # Mark the zoomed section (x, y, width, height)
 border_rect = Rect2(50, min_price, 20, max_price - min_price)
-lines!(ax_main, border_rect, color=:black, linewidth=1)
+lines!(ax_main, border_rect, color = :black, linewidth = 1)
 
 fig
 ```

--- a/docs/src/tutorials/layout-tutorial.md
+++ b/docs/src/tutorials/layout-tutorial.md
@@ -13,8 +13,10 @@ using CairoMakie
 using Makie.FileIO
 CairoMakie.activate!() # hide
 
-f = Figure(backgroundcolor = RGBf(0.98, 0.98, 0.98),
-    size = (1000, 700))
+f = Figure(
+    backgroundcolor = RGBf(0.98, 0.98, 0.98),
+    size = (1000, 700)
+)
 ga = f[1, 1] = GridLayout()
 gb = f[2, 1] = GridLayout()
 gcd = f[1:2, 2] = GridLayout()
@@ -51,23 +53,29 @@ leg.tellheight = true
 colgap!(ga, 10)
 rowgap!(ga, 10)
 
-Label(ga[1, 1:2, Top()], "Stimulus ratings", valign = :bottom,
+Label(
+    ga[1, 1:2, Top()], "Stimulus ratings", valign = :bottom,
     font = :bold,
-    padding = (0, 0, 5, 0))
+    padding = (0, 0, 5, 0)
+)
 
 xs = LinRange(0.5, 6, 50)
 ys = LinRange(0.5, 6, 50)
 data1 = [sin(x^1.5) * cos(y^0.5) for x in xs, y in ys] .+ 0.1 .* randn.()
 data2 = [sin(x^0.8) * cos(y^1.5) for x in xs, y in ys] .+ 0.1 .* randn.()
 
-ax1, hm = contourf(gb[1, 1], xs, ys, data1,
-    levels = 6)
+ax1, hm = contourf(
+    gb[1, 1], xs, ys, data1,
+    levels = 6
+)
 ax1.title = "Histological analysis"
 contour!(ax1, xs, ys, data1, levels = 5, color = :black)
 hidexdecorations!(ax1)
 
-ax2, hm2 = contourf(gb[2, 1], xs, ys, data2,
-    levels = 6)
+ax2, hm2 = contourf(
+    gb[2, 1], xs, ys, data2,
+    levels = 6
+)
 contour!(ax2, xs, ys, data2, levels = 5, color = :black)
 
 cb = Colorbar(gb[1:2, 2], hm, label = "cell group")
@@ -98,8 +106,10 @@ hidedecorations!.(axs, grid = false, label = false)
 for row in 1:3, col in 1:2
     xrange = col == 1 ? (0:0.1:6pi) : (0:0.1:10pi)
 
-    eeg = [sum(sin(pi * rand() + k * x) / k for k in 1:10)
-        for x in xrange] .+ 0.1 .* randn.()
+    eeg = [
+        sum(sin(pi * rand() + k * x) / k for k in 1:10)
+            for x in xrange
+    ] .+ 0.1 .* randn.()
 
     lines!(axs[row, col], eeg, color = (:black, 0.5))
 end
@@ -107,16 +117,18 @@ end
 axs[3, 1].xlabel = "Day 1"
 axs[3, 2].xlabel = "Day 2"
 
-Label(gd[1, :, Top()], "EEG traces", valign = :bottom,
+Label(
+    gd[1, :, Top()], "EEG traces", valign = :bottom,
     font = :bold,
-    padding = (0, 0, 5, 0))
+    padding = (0, 0, 5, 0)
+)
 
 rowgap!(gd, 10)
 colgap!(gd, 10)
 
 for (i, label) in enumerate(["sleep", "awake", "test"])
     Box(gd[i, 3], color = :gray90)
-    Label(gd[i, 3], label, rotation = pi/2, tellheight = false)
+    Label(gd[i, 3], label, rotation = pi / 2, tellheight = false)
 end
 
 colgap!(gd, 2, 0)
@@ -128,11 +140,13 @@ colsize!(gd, 1, Auto(n_day_1))
 colsize!(gd, 2, Auto(n_day_2))
 
 for (label, layout) in zip(["A", "B", "C", "D"], [ga, gb, gc, gd])
-    Label(layout[1, 1, TopLeft()], label,
+    Label(
+        layout[1, 1, TopLeft()], label,
         fontsize = 26,
         font = :bold,
         padding = (0, 5, 5, 0),
-        halign = :right)
+        halign = :right
+    )
 end
 
 colsize!(f.layout, 1, Auto(0.5))

--- a/docs/src/tutorials/scenes.md
+++ b/docs/src/tutorials/scenes.md
@@ -262,8 +262,8 @@ origins = Dict(
 )
 
 rotation_axes = Dict(
-    "arm_right" => Vec3f(0.0000, -0.9828, 0.1848),
-    "arm_left" => Vec3f(0.0000, 0.9828, 0.1848),
+    "arm_right" => Vec3f(0.0, -0.9828, 0.1848),
+    "arm_left" => Vec3f(0.0, 0.9828, 0.1848),
     "leg_right" => Vec3f(0, -1, 0),
     "leg_left" => Vec3f(0, 1, 0),
 )
@@ -289,27 +289,27 @@ function plot_part!(scene, parent, name::String)
         translate!(child, -ptrans.translation[])
     end
     # plot the part with transformation & color
-    return mesh!(scene, m; color=color, transformation=child)
+    return mesh!(scene, m; color = color, transformation = child)
 end
 
-function plot_lego_figure(s, floor=true)
+function plot_lego_figure(s, floor = true)
     # Plot hierarchical mesh and put all parts into a dictionary
     figure = Dict()
     figure["torso"] = plot_part!(s, s, "torso")
-        figure["head"] = plot_part!(s, figure["torso"], "head")
-            figure["eyes_mouth"] = plot_part!(s, figure["head"], "eyes_mouth")
-        figure["arm_right"] = plot_part!(s, figure["torso"], "arm_right")
-            figure["hand_right"] = plot_part!(s, figure["arm_right"], "hand_right")
-        figure["arm_left"] = plot_part!(s, figure["torso"], "arm_left")
-            figure["hand_left"] = plot_part!(s, figure["arm_left"], "hand_left")
-        figure["belt"] = plot_part!(s, figure["torso"], "belt")
-            figure["leg_right"] = plot_part!(s, figure["belt"], "leg_right")
-            figure["leg_left"] = plot_part!(s, figure["belt"], "leg_left")
+    figure["head"] = plot_part!(s, figure["torso"], "head")
+    figure["eyes_mouth"] = plot_part!(s, figure["head"], "eyes_mouth")
+    figure["arm_right"] = plot_part!(s, figure["torso"], "arm_right")
+    figure["hand_right"] = plot_part!(s, figure["arm_right"], "hand_right")
+    figure["arm_left"] = plot_part!(s, figure["torso"], "arm_left")
+    figure["hand_left"] = plot_part!(s, figure["arm_left"], "hand_left")
+    figure["belt"] = plot_part!(s, figure["torso"], "belt")
+    figure["leg_right"] = plot_part!(s, figure["belt"], "leg_right")
+    figure["leg_left"] = plot_part!(s, figure["belt"], "leg_left")
 
     # lift the little guy up
     translate!(figure["torso"], 0, 0, 20)
     # add some floor
-    floor && mesh!(s, Rect3f(Vec3f(-400, -400, -2), Vec3f(800, 800, 2)), color=:white)
+    floor && mesh!(s, Rect3f(Vec3f(-400, -400, -2), Vec3f(800, 800, 2)), color = :white)
     return figure
 end
 
@@ -319,15 +319,15 @@ end
 
 using RPRMakie
 # iterate rendering 200 times, to get less noise and more light
-RPRMakie.activate!(iterations=200)
+RPRMakie.activate!(iterations = 200)
 
 radiance = 50000
 # Note, that only RPRMakie supports `EnvironmentLight` so far
 lights = [
     EnvironmentLight(1.5, rotl90(load(assetpath("sunflowers_1k.hdr"))')),
-    PointLight(Vec3f(50, 0, 200), RGBf(radiance, radiance, radiance*1.1)),
+    PointLight(Vec3f(50, 0, 200), RGBf(radiance, radiance, radiance * 1.1)),
 ]
-s = Scene(size=(500, 500), lights=lights)
+s = Scene(size = (500, 500), lights = lights)
 cam3d!(s)
 c = cameracontrols(s)
 c.near[] = 5
@@ -335,19 +335,21 @@ c.far[] = 1000
 update_cam!(s, c, Vec3f(100, 30, 80), Vec3f(0, 0, -10))
 figure = plot_lego_figure(s)
 
-rot_joints_by = 0.25*pi
+rot_joints_by = 0.25 * pi
 total_translation = 50
 animation_strides = 10
 
 a1 = LinRange(0, rot_joints_by, animation_strides)
-angles = [a1; reverse(a1[1:end-1]); -a1[2:end]; reverse(-a1[1:end-1]);]
+angles = [a1; reverse(a1[1:(end - 1)]); -a1[2:end]; reverse(-a1[1:(end - 1)]);]
 nsteps = length(angles); #Number of animation steps
 translations = LinRange(0, total_translation, nsteps)
 
 Makie.record(s, "lego_walk.mp4", zip(translations, angles)) do (translation, angle)
     #Rotate right arm+hand
-    for name in ["arm_left", "arm_right",
-                            "leg_left", "leg_right"]
+    for name in [
+            "arm_left", "arm_right",
+            "leg_left", "leg_right",
+        ]
         rotate!(figure[name], rotation_axes[name], angle)
     end
     translate!(figure["torso"], translation, 0, 20)

--- a/tooling/formatter/Project.toml
+++ b/tooling/formatter/Project.toml
@@ -1,2 +1,5 @@
 [deps]
 Runic = "62bfec6d-59d7-401d-8490-b29ee721c001"
+
+[compat]
+Runic = "1.7"

--- a/tooling/formatter/format.jl
+++ b/tooling/formatter/format.jl
@@ -4,4 +4,4 @@ Pkg.instantiate()
 using Runic
 
 dir = joinpath(@__DIR__, "..", "..")
-Runic.main(["--verbose", "--inplace", dir])
+Runic.main(["--verbose", "--extensions=jl,md", "--docstrings", "--inplace", dir])


### PR DESCRIPTION
Since you have adopted Runic I am using your code base for testing things and now to solicit input on new features :p

I have implemented docstring formatting in Runic. This is the results. Runic assumes that fenced code blocks are valid Julia but for indented blocks (typically for function signatures in docstrings) the syntax isn't always valid Julia code, in particular when it comes to using `[...]` for optional arguments. I initially thought we should filter out such docstrings but I settled on: "if it parses we format it". This leads to some quirks (see inline comments) but I think it might be better to rewrite those cases to valid Julia code anyway.