### PR TITLE
fix updates of memory aliased arrays getting discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - CairoMakie now batches glyphs from the same text string into a single PDF/SVG text object, so that text can be selected and edited as a unit in vector editors like Inkscape and Illustrator [#5561](https://github.com/MakieOrg/Makie.jl/pull/5561)
 - Fixed `annotation` not showing lines/arrows when `text` is blank [#5560](https://github.com/MakieOrg/Makie.jl/pull/5560)
 - Fixed error/nan offsets in `annotation!()` when an annotation is perfectly centered [#5568](https://github.com/MakieOrg/Makie.jl/pull/5568)
+- Fixed memory-aliased arrays not propagating in ComputePipeline [#5605](https://github.com/MakieOrg/Makie.jl/pull/5605)
 
 ## [0.24.9] - 2026-03-04
 

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -613,7 +613,7 @@ function is_same(a::T, b::T) where {T}
         return same_object ? false : isequal(a, b)
     end
 end
-function is_same(old::AbstractArray, new::AbstractArray)
+function is_same(old::Array, new::Array)
     # same pointer means memory aliased (which does not require old === new)
     # and same memory means we can't compare before and after => assume not same
     is_distinct = pointer(old) !== pointer(new)

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -613,6 +613,12 @@ function is_same(a::T, b::T) where {T}
         return same_object ? false : isequal(a, b)
     end
 end
+function is_same(old::AbstractArray, new::AbstractArray)
+    # same pointer means memory aliased (which does not require old === new)
+    # and same memory means we can't compare before and after => assume not same
+    is_distinct = pointer(old) !== pointer(new)
+    return is_distinct && isequal(old, new)
+end
 
 # do we want this type stable?
 # This is how we could get a type stable callback body for resolve

--- a/ComputePipeline/test/unit_tests.jl
+++ b/ComputePipeline/test/unit_tests.jl
@@ -1104,3 +1104,16 @@ end
         @test_throws ErrorException ComputePipeline.unsafe_init!(graph.xy, 0)
     end
 end
+
+@testset "Array memory aliasing" begin
+    M = fill(0, 2, 2)
+    graph = ComputeGraph()
+    add_input!(graph, :mat, M)
+    map!(vec, graph, :mat, :vec)
+    map!(v -> Float32.(v), graph, :vec, :vecf)
+    v = graph.vec[]
+    M .= 1
+    graph.mat = M
+    @assert pointer(v) == pointer(graph.vec[]) "this is expected to be memory aliased, but isn't"
+    @test graph.vecf[] == [1, 1, 1, 1]
+end


### PR DESCRIPTION
# Description

```julia
M = fill(0, 2, 2)
v = vec(M)
w = vec(M)
```
The vectors v and w created by this are not `===` but do point to the same memory. Changing `M` causes both of them to change as well.

When using `map!(vec, graph, ...)` this results in the output always being considered not-dirty, because the result of `vec` is always a different object than stored (never `===`) and always contains the same values (always `isequal`), thus always `is_same`. This means that the compute edge will never propagate beyond its output.

To fix this the pr adds another method of `is_same` that checks `pointer(array)` equality instead of `===` for any `Array`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
