### PR TITLE
chore(compat): Set julia compat to "1" in CairoMakie, WGLMakie, RPRMakie

### DIFF
--- a/CairoMakie/Project.toml
+++ b/CairoMakie/Project.toml
@@ -26,7 +26,7 @@ GeometryBasics = "0.5"
 LinearAlgebra = "1.0, 1.6"
 Makie = "=0.24.10"
 PrecompileTools = "1.0"
-julia = "1.3"
+julia = "1"
 
 [sources.Makie]
 path = "../Makie"

--- a/RPRMakie/Project.toml
+++ b/RPRMakie/Project.toml
@@ -20,7 +20,7 @@ LinearAlgebra = "1.0, 1.6"
 Makie = "=0.24.10"
 Printf = "1.0, 1.6"
 RadeonProRender = "0.3.2"
-julia = "1.3"
+julia = "1"
 
 [sources.Makie]
 path = "../Makie"

--- a/WGLMakie/Project.toml
+++ b/WGLMakie/Project.toml
@@ -34,7 +34,7 @@ PrecompileTools = "1.0"
 RelocatableFolders = "0.1, 0.2, 0.3, 1.0"
 ShaderAbstractions = "0.5"
 StaticArrays = "0.12, 1.0"
-julia = "1.3"
+julia = "1"
 
 [sources.Makie]
 path = "../Makie"


### PR DESCRIPTION
## Summary

Sets `julia = \"1\"` in `CairoMakie`, `WGLMakie`, and `RPRMakie` Project.toml to match `GLMakie`. Previously these were `julia = \"1.3\"`.

This is purely cosmetic: backends are pinned to a specific patch of Makie, and Makie's own `julia` compat is `\"1.10\"`, which is the effective lower bound for any installation. The stale `\"1.3\"` was misleading and tripped up registration tooling.