### PR TITLE
fix(legend): Propagate linecap and joinstyle from line plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed `Legend` not reflecting `linecap` and `joinstyle` set on `lines!`/`linesegments!` plots [#5621](https://github.com/MakieOrg/Makie.jl/pull/5621)
 - Fixed memory-aliased arrays not propagating in ComputePipeline [#5605](https://github.com/MakieOrg/Makie.jl/pull/5605)
 
 ## [0.24.10] - 2026-04-27

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -440,7 +440,8 @@ function legendelement_plots!(scene, element::LineElement, bbox::Observable{Rect
     lin = lines!(
         scene, points, linewidth = attrs.linewidth, color = attrs.linecolor,
         colormap = attrs.linecolormap, colorrange = attrs.linecolorrange,
-        linestyle = attrs.linestyle, inspectable = false, alpha = attrs.alpha
+        linestyle = attrs.linestyle, linecap = attrs.linecap, joinstyle = attrs.joinstyle,
+        inspectable = false, alpha = attrs.alpha
     )
 
     return [lin]
@@ -576,7 +577,7 @@ end
 
 function apply_legend_override!(le::LineElement, override::LegendOverride)
     renamed_attrs = _rename_attributes!(LineElement, copy(override.overrides))
-    for sym in (:linepoints, :linewidth, :linecolor, :linecolormap, :linecolorrange, :linestyle, :alpha)
+    for sym in (:linepoints, :linewidth, :linecolor, :linecolormap, :linecolorrange, :linestyle, :linecap, :joinstyle, :alpha)
         if haskey(renamed_attrs, sym)
             le.attributes[sym] = renamed_attrs[sym]
         end
@@ -727,6 +728,8 @@ function legendelements(plot::Union{Lines, LineSegments}, legend)
             color = extract_color(plot, legend[:linecolor]),
             linestyle = choose_scalar(ls isa Vector ? Linestyle(ls) : ls, legend[:linestyle]),
             linewidth = choose_scalar(plot.linewidth, legend[:linewidth]),
+            linecap = choose_scalar(plot.linecap, legend[:linecap]),
+            joinstyle = choose_scalar(get(plot, :joinstyle, legend[:joinstyle]), legend[:joinstyle]),
             colormap = plot.colormap,
             colorrange = plot.colorrange,
             alpha = plot.alpha

--- a/Makie/src/makielayout/defaultattributes.jl
+++ b/Makie/src/makielayout/defaultattributes.jl
@@ -77,7 +77,7 @@ function attributenames(::Type{LegendEntry})
     return (
         :label, :labelsize, :labelfont, :labelcolor, :labelhalign, :labelvalign,
         :patchsize, :patchstrokecolor, :patchstrokewidth, :patchcolor,
-        :linepoints, :linewidth, :linecolor, :linestyle, :linecolorrange, :linecolormap,
+        :linepoints, :linewidth, :linecolor, :linestyle, :linecap, :joinstyle, :linecolorrange, :linecolormap,
         :markerpoints, :markersize, :markerstrokewidth, :markercolor, :markerstrokecolor, :markercolorrange, :markercolormap,
         :polypoints, :polystrokewidth, :polycolor, :polystrokecolor, :polycolorrange, :polycolormap, :alpha,
     )

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1522,6 +1522,10 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         linecolorrange = automatic
         "The default line style used for LineElements"
         linestyle = :solid
+        "The default line cap used for LineElements"
+        linecap = theme(scene, :linecap)
+        "The default join style used for LineElements"
+        joinstyle = theme(scene, :joinstyle)
 
         "The default marker color for MarkerElements"
         markercolor = theme(scene, :markercolor)

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -553,6 +553,27 @@ end
     @test leg.entrygroups[][][2][1].elements[2].plots[] == l2a
 end
 
+@testset "Legend linecap and joinstyle" begin
+    # The value stored on the LineElement may already be converted by the plot's
+    # compute graph (Int32) or kept as the original Symbol (override path), so
+    # we compare against both possible forms.
+    matches(stored, sym, key) = stored == sym || stored == Makie.convert_attribute(sym, Makie.Key{key}())
+
+    f = Figure()
+    ax = Axis(f[1, 1])
+    lines!(ax, 1:10, label = "a", linecap = :round, joinstyle = :round)
+    linesegments!(ax, [Point2f(0, 0), Point2f(1, 1)], label = "b", linecap = :square)
+    lines!(ax, 1:10, label = "c" => (; linecap = :square, joinstyle = :bevel))
+    leg = Legend(f[1, 2], ax)
+
+    entries = leg.entrygroups[][][2]
+    @test matches(entries[1].elements[1].attributes[:linecap][], :round, :linecap)
+    @test matches(entries[1].elements[1].attributes[:joinstyle][], :round, :joinstyle)
+    @test matches(entries[2].elements[1].attributes[:linecap][], :square, :linecap)
+    @test matches(entries[3].elements[1].attributes[:linecap][], :square, :linecap)
+    @test matches(entries[3].elements[1].attributes[:joinstyle][], :bevel, :joinstyle)
+end
+
 @testset "ReversibleScale" begin
     @test ReversibleScale(identity).inverse === identity
     @test ReversibleScale(log).inverse === exp

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -196,7 +196,8 @@ end
 
     li = lines!(
         1:10,
-        label = "Line" => (; linewidth = 4, color = :gray60, linestyle = :dot),
+        linecap = :round,
+        label = "Line" => (; linewidth = 8, color = :gray60, linestyle = :dot),
     )
     sc = scatter!(
         1:10,
@@ -209,16 +210,16 @@ end
             label => (; markersize = 30, color = i) for (i, label) in enumerate(["blue", "green", "yellow"])
         ]
     )
-    Legend(f[1, 2], ax)
+    Legend(f[1, 2], ax, patchsize = (60, 30))
     Legend(
         f[1, 3],
         [
             sc => (; markersize = 30, alpha = 0.3),
-            [li => (; color = :red, alpha = 0.3, linewidth = 4), sc => (; color = :cyan)],
-            [li, sc] => Dict(:color => :cyan),
+            [li => (; color = :red, alpha = 0.3, linewidth = 8), sc => (; color = :cyan)],
+            [li, sc] => Dict(:color => :cyan, :linecap => :butt),
         ],
         ["Scatter", "Line and Scatter", "Another"],
-        patchsize = (40, 20)
+        patchsize = (60, 30)
     )
     f
 end


### PR DESCRIPTION
## Summary

Fixes [#5525](https://github.com/MakieOrg/Makie.jl/issues/5525). `Legend` previously ignored `linecap` and `joinstyle` set on `lines!`/`linesegments!` plots, so dashed/dotted lines in the legend always rendered with `:butt` caps regardless of what the source plot specified.

This PR threads `linecap` and `joinstyle` through the legend pipeline:

- New `linecap`/`joinstyle` defaults on the `Legend` block (sourced from the active theme).
- `legendelements(::Lines/LineSegments, legend)` now copies `linecap` (and `joinstyle` for `Lines`) from the plot to the generated `LineElement`.
- The inner `lines!` call inside `legendelement_plots!(::LineElement, …)` receives both attributes.
- `apply_legend_override!(::LineElement, …)` accepts `linecap`/`joinstyle` so they can be set/overridden in `=>(; …)` and `Dict(...)` overrides.

The existing `Legend overrides` reference test was extended to cover the new path: the `lines!` plot sets `linecap = :round` (propagated through both legends), and one of the Dict overrides sets `:linecap => :butt` to exercise the override branch. `linewidth`/`patchsize` were bumped so the cap shapes are clearly visible.

Note: GLMakie/WGLMakie apply `linecap` only at line endpoints, not at dash transitions (the dash pattern is an SDF cut on a continuous line). So legend dash caps look rounded only on CairoMakie — same backend difference as for any other dashed line. ReferenceTests already maintains separate baselines per backend.

## Example

```julia
using CairoMakie

fig = Figure(; size = (500, 350))
ax = Axis(fig[1, 1])
lines!(ax, range(0, 2π, 100), cos, color = :black, label = "cos(x)",
    linewidth = 8, linestyle = :dash, linecap = :round)
axislegend(ax, patchsize = (60, 30))
fig
```

**Before**

<img width="500" height="350" alt="legend with flat dash caps" src="https://github.com/user-attachments/assets/7e6a6caa-14fa-4e19-9ef1-2186f7436397">

**After**

<img width="500" height="350" alt="legend with rounded dash caps matching the line" src="https://github.com/user-attachments/assets/382492d0-1758-459a-8f80-68b1805b42ad">

## Checks

- [ ] Updated reference image for `Legend overrides`
- [x] Added unit test `Legend linecap and joinstyle` covering plot→legend propagation for `Lines` and `LineSegments` plus the override path
