### PR TITLE
fix(GLMakie): chunk large GL_LINE_STRIP_ADJACENCY draws on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed `lines` rendering a phantom segment between the first and last point on macOS for line plots above ~2.4M points, by splitting `GL_LINE_STRIP_ADJACENCY` draw calls into chunks of 2M indices on macOS. Each chunk stays below the threshold at which Apple's OpenGL geometry-shader emulation emits the spurious primitive; consecutive chunks overlap by 3 indices to preserve the strip's adjacency context. No buffers change and non-Apple platforms are unaffected. [#5622](https://github.com/MakieOrg/Makie.jl/pull/5622)
 - Fixed memory-aliased arrays not propagating in ComputePipeline [#5605](https://github.com/MakieOrg/Makie.jl/pull/5605)
 
 ## [0.24.10] - 2026-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed `lines` rendering a phantom segment between the first and last point on macOS for line plots above ~2.4M points, by splitting `GL_LINE_STRIP_ADJACENCY` draw calls into chunks of 2M indices on macOS. Each chunk stays below the threshold at which Apple's OpenGL geometry-shader emulation emits the spurious primitive; consecutive chunks overlap by 3 indices to preserve the strip's adjacency context. No buffers change and non-Apple platforms are unaffected. [#5622](https://github.com/MakieOrg/Makie.jl/pull/5622)
+- Fixed `lines` rendering a phantom segment between the first and last point on macOS for line plots above ~2.4M points [#5622](https://github.com/MakieOrg/Makie.jl/pull/5622)
 - Fixed `Legend` not reflecting `linecap` and `joinstyle` set on `lines!`/`linesegments!` plots [#5621](https://github.com/MakieOrg/Makie.jl/pull/5621)
 - Fixed memory-aliased arrays not propagating in ComputePipeline [#5605](https://github.com/MakieOrg/Makie.jl/pull/5605)
 

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -145,6 +145,10 @@ function render(vao::GLVertexArray{T}, mode::GLenum = GL_TRIANGLES) where {T <: 
     return nothing
 end
 
+# Empirically bisected: GL_LINE_STRIP_ADJACENCY breaks at count >= 2_418_341.
+# Picked with ~17% headroom since the exact driver-side cutoff may drift.
+const MAC_LINE_STRIP_CHUNK = 2_000_000
+
 # using indexbuffer (faces)
 function render(vao::GLVertexArray{GLBuffer{T}}, mode::GLenum = GL_TRIANGLES) where {T <: Union{Integer, AbstractFace}}
     # Note: not discarding draw calls with 0 indices may cause segfaults even if
@@ -158,7 +162,26 @@ function render(vao::GLVertexArray{GLBuffer{T}}, mode::GLenum = GL_TRIANGLES) wh
         N_addressed = GeometryBasics.raw(mapreduce(maximum, max, data))
         vao_boundscheck(length(vao), N_addressed, vao)
     end
-    glDrawElements(mode, N, julia2glenum(T), C_NULL)
+    if Sys.isapple() && mode == GL_LINE_STRIP_ADJACENCY && N > MAC_LINE_STRIP_CHUNK
+        # macOS workaround for Makie#5491. Apple's OpenGL geometry-shader emulation emits
+        # one phantom segment between the first and last vertex when a single draw call
+        # exceeds ~2.42M indices. Splitting into chunks below the threshold sidesteps the
+        # bug per chunk. Consecutive chunks overlap by 3 indices to give the joints at the
+        # chunk boundary the same adjacency context they would have in a single draw; with
+        # LINE_STRIP_ADJACENCY a primitive (p, q, r, s) only draws segment q→r and uses
+        # p and s as joint hints, so this is adjacency-only overlap, not overdraw - every
+        # segment is drawn exactly once.
+        elt_size = sizeof(T)
+        glenum = julia2glenum(T)
+        offset = 0
+        while offset < N - 3
+            count = min(MAC_LINE_STRIP_CHUNK, N - offset)
+            glDrawElements(mode, count, glenum, Ptr{Cvoid}(offset * elt_size))
+            offset += MAC_LINE_STRIP_CHUNK - 3
+        end
+    else
+        glDrawElements(mode, N, julia2glenum(T), C_NULL)
+    end
     return nothing
 end
 


### PR DESCRIPTION
## Summary

Fixes #5491 fixes #5304. On macOS, `GLMakie`'s `lines!` plots draw a phantom segment between the first and last point of the line whenever the plot exceeds ~2.4M points. Empirically bisected: a single `GL_LINE_STRIP_ADJACENCY` draw call breaks at `count >= 2_418_341` indices (= 2,418,338 primitives) and is fine below that. The bug only reproduces under Apple's OpenGL → Metal layer (Metal has no native geometry shaders, so they're emulated) — Linux and Windows GL drivers handle the same draw fine.

Workaround: when the bound element buffer would exceed the threshold, the renderer now splits the single `glDrawElements` call into chunks of 2M indices, with consecutive chunks overlapping by 3 indices in the same buffer to give the joints at the chunk boundary their adjacency context. With `LINE_STRIP_ADJACENCY` a primitive `(p, q, r, s)` only draws segment `q→r` and uses `p, s` as joint hints, so the 3-index overlap is adjacency-only — every segment is still drawn exactly once, no overdraw.

- No buffer or shader changes; the index buffer that the rest of GLMakie produces is reused as-is.
- macOS-only branch gated on `Sys.isapple() && mode == GL_LINE_STRIP_ADJACENCY`. Other platforms keep the single-draw fast path.
- ~17% headroom below the bisected threshold to absorb any drift in the Apple driver-side cutoff (it's an opaque internal constant we can't observe).

## Alternatives considered

Two other approaches reproduce-tested as fixes; both were dropped in favour of chunked draws because they cost more for no visible benefit:

- **NaN sentinel padding.** Append one NaN entry to the position buffer (and matching zero entries to `valid_vertex` / `lastlen`), and one extra index pointing at it; the spurious primitive then reads NaN at one end and is culled. Works in practice, but requires coordinated edits in 3–4 places across the compute graph (positions for both the FAST_PATH and the linestyle path, plus `valid_vertex` and `lastlen`), and depends on Apple's spurious primitive always reading the buffer tail. The added bookkeeping and the cross-pipeline coupling is more fragile than the single-function chunked-draw branch.
- **Switch `GL_LINE_STRIP_ADJACENCY` → `GL_LINES_ADJACENCY`** with the index buffer expanded into independent 4-tuples (the geometry shader doesn't need to change because `layout(lines_adjacency)` accepts both primitive types). Reproduce-tested as a clean fix on macOS, but the index buffer grows by ~4× (e.g. ~120 MB extra at N=10M) — a real cost for animated/streaming line plots. The `LINE_STRIP_ADJACENCY` strip already shares indices implicitly, and chunked draws preserve that sharing while avoiding the bug.

Chunked draws win on memory (zero added bytes), code locality (one `if` in `render`), and platform isolation (the branch is only taken on Apple).

## Example

```julia
using GLMakie

N = 2_500_000
y = zeros(Float64, N); y[end] = 1.0
fig = Figure(size = (1000, 600))
ax = Axis(fig[1, 1], title = "L-shape, N=$N")
lines!(ax, 1:N, y, color = :blue, linewidth = 2)
fig
```

**Before**

<img width="1000" height="600" alt="L-shape with phantom diagonal across the figure (triangle instead of L)" src="https://github.com/user-attachments/assets/a5323b2e-ce9a-46e0-b53e-f15c5b79df58">

**After**

<img width="1000" height="600" alt="Clean L-shape, no phantom" src="https://github.com/user-attachments/assets/b7fb49de-a755-40f0-baec-bea3e1bfb373">

The original issue's MWE (10 overlaid `cumsum` random walks up to N=5M):

```julia
using GLMakie, Random
Random.seed!(42)
max_n = 5_000_000
step_size = 500_000
data = rand(-1:0.05:1, max_n)
datac = cumsum(data)
subset_sizes = reverse(collect(step_size:step_size:max_n))
fig = Figure(size = (1000, 600))
ax = Axis(fig[1, 1], title = "Issue #5491 MWE (random walks)")
colors = cgrad(:viridis, length(subset_sizes), categorical = true)
for (i, n) in enumerate(subset_sizes)
    lines!(ax, 1:n, datac[1:n], label = "N=$(n)", color = colors[i], linewidth = 2)
end
axislegend(ax)
fig
```

**Before**

<img width="1000" height="600" alt="Original issue MWE: spurious diagonal lines connecting first and last points of each long subset" src="https://github.com/user-attachments/assets/87214036-512e-45de-a727-7cc207cedf5c">

**After**

<img width="1000" height="600" alt="Original issue MWE: clean overlaid random walks with no diagonal artifacts" src="https://github.com/user-attachments/assets/13309649-b57f-4409-bf87-4701a8d66241">

## Checks

- L-shape (`zeros(N); y[end]=1`) at N = 2,500,000 / 5,000,000 / 10,000,000: clean.
- Original issue's `cumsum` MWE: clean.
- Existing line behaviors unchanged: closed loops (circle, square), NaN-split lines, dashed/joints lines.
- Chunk-boundary cases verified: N just below chunk size (1,999,999), just over (2,000,001), exactly 2 chunks (4,000,000) — no visible discontinuity at chunk seams.
- `GLMakie/test/isolated_tests.jl` (line indices) passes 20/20.
- `julia tooling/formatter/format.jl` clean.
- Bisection (with workaround temporarily disabled) confirms the bug starts at exactly count = 2,418,341 indices and the workaround at chunk size 2,000,000 prevents recurrence at every tested N up to 10M.
