### PR TITLE
feat(textbox): editable text recipe with selections, multi-cursor, paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
+- A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Fixed `lines` rendering a phantom segment between the first and last point on macOS for line plots above ~2.4M points [#5622](https://github.com/MakieOrg/Makie.jl/pull/5622)
 - Fixed `Legend` not reflecting `linecap` and `joinstyle` set on `lines!`/`linesegments!` plots [#5621](https://github.com/MakieOrg/Makie.jl/pull/5621)
 - Fixed memory-aliased arrays not propagating in ComputePipeline [#5605](https://github.com/MakieOrg/Makie.jl/pull/5605)

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -184,6 +184,7 @@ include("basic_recipes/voxels.jl")
 include("basic_recipes/waterfall.jl")
 include("basic_recipes/wireframe.jl")
 include("basic_recipes/textlabel.jl")
+include("basic_recipes/editabletext.jl")
 include("basic_recipes/tooltip.jl")
 
 include("basic_recipes/makiecore_examples/scatter.jl")

--- a/Makie/src/basic_recipes/editabletext.jl
+++ b/Makie/src/basic_recipes/editabletext.jl
@@ -631,22 +631,26 @@ function Makie.plot!(plot::EditableText)
     cursor_visible_obs = Observable(true; ignore_equal_values = true)
 
     parent = Makie.parent_scene(plot)
-    push!(plot.deregister_callbacks, on(events(parent).tick) do tick
-        cursor_visible_obs[] = if !plot.focused[]
-            false
-        else
-            period = plot.blink_period[]
-            elapsed = tick.time - last_edit_time[]
-            isinf(period) || mod(elapsed, period) < period / 2
+    push!(
+        plot.deregister_callbacks, on(events(parent).tick) do tick
+            cursor_visible_obs[] = if !plot.focused[]
+                false
+            else
+                period = plot.blink_period[]
+                elapsed = tick.time - last_edit_time[]
+                isinf(period) || mod(elapsed, period) < period / 2
+            end
+            return nothing
         end
-        return nothing
-    end)
-    push!(plot.deregister_callbacks, on(plot.focused) do f
-        if f
-            last_edit_time[] = events(parent).tick[].time
+    )
+    push!(
+        plot.deregister_callbacks, on(plot.focused) do f
+            if f
+                last_edit_time[] = events(parent).tick[].time
+            end
+            return nothing
         end
-        return nothing
-    end)
+    )
 
     linesegments!(
         plot, cursor_segments_obs;
@@ -707,231 +711,239 @@ function attach_editabletext_events!(
         return offset_from_pixel_point(local_pt, anchors, line_idx)
     end
 
-    push!(plot.deregister_callbacks, on(events(parent).mousebutton, priority = 60) do event
-        event.button == Mouse.left || return Consume(false)
+    push!(
+        plot.deregister_callbacks, on(events(parent).mousebutton, priority = 60) do event
+            event.button == Mouse.left || return Consume(false)
 
-        if event.action == Mouse.press
-            mpos = Makie.mouseposition_px(parent)
-            if plot.manage_focus[]
-                # Auto-focus on clicks within the text bbox; auto-defocus
-                # on clicks outside.
-                if !is_click_inside_text(text_plot, plot, mpos)
-                    if plot.focused[]
-                        plot.focused[] = false
+            if event.action == Mouse.press
+                mpos = Makie.mouseposition_px(parent)
+                if plot.manage_focus[]
+                    # Auto-focus on clicks within the text bbox; auto-defocus
+                    # on clicks outside.
+                    if !is_click_inside_text(text_plot, plot, mpos)
+                        if plot.focused[]
+                            plot.focused[] = false
+                        end
+                        return Consume(false)
                     end
-                    return Consume(false)
+                else
+                    # Parent owns focus. Only place a cursor if we're actually
+                    # focused right now; otherwise leave the click for the parent.
+                    plot.focused[] || return Consume(false)
                 end
-            else
-                # Parent owns focus. Only place a cursor if we're actually
-                # focused right now; otherwise leave the click for the parent.
-                plot.focused[] || return Consume(false)
+
+                offset = _mouse_to_offset(Point2f(mpos))
+
+                # Multi-click handling
+                now = events(parent).tick[].time
+                ctrl_or_cmd = ispressed(parent, Keyboard.left_super | Keyboard.right_super) ||
+                    ispressed(parent, Keyboard.left_control | Keyboard.right_control)
+
+                prev = click_state[]
+                same_spot = norm(Point2f(mpos) - prev.pos) < 4
+                within_time = (now - prev.time) < 0.4
+                new_count = (same_spot && within_time) ? prev.count + 1 : 1
+                click_state[] = (count = new_count, time = now, pos = Point2f(mpos))
+
+                chars = chars_obs[]
+                plot.focused[] = true
+
+                # `new_selection` is what this click would produce on its own;
+                # `ctrl_or_cmd` then decides whether it replaces the existing
+                # cursors or extends them (multi-cursor / multi-selection).
+                new_selection = if new_count == 3
+                    lo, hi = line_at_offset(chars, offset)
+                    EditCursor(lo, hi)
+                elseif new_count == 2
+                    lo, hi = word_at_offset(chars, offset)
+                    EditCursor(lo, hi)
+                else
+                    EditCursor(offset)
+                end
+                cursors = ctrl_or_cmd ? vcat(plot.cursors[], [new_selection]) : EditCursor[new_selection]
+                plot.cursors[] = merge_cursors(cursors)
+
+                # On single click we set up a drag anchor so subsequent motion
+                # extends the selection.
+                drag_anchor[] = new_count == 1 ? offset : nothing
+                _bump_edit_time!(parent, last_edit_time)
+                # Consume only when *we* own focus management — that's the case
+                # where there's no parent waiting to react to the click. When the
+                # parent owns focus (Textbox), we must not consume so other
+                # widgets at the same priority (e.g. another EditableText that
+                # wants to defocus itself) still see the press.
+                return plot.manage_focus[] ? Consume(true) : Consume(false)
+
+            elseif event.action == Mouse.release
+                drag_anchor[] = nothing
+                return Consume(false)
             end
-
-            offset = _mouse_to_offset(Point2f(mpos))
-
-            # Multi-click handling
-            now = events(parent).tick[].time
-            ctrl_or_cmd = ispressed(parent, Keyboard.left_super | Keyboard.right_super) ||
-                          ispressed(parent, Keyboard.left_control | Keyboard.right_control)
-
-            prev = click_state[]
-            same_spot = norm(Point2f(mpos) - prev.pos) < 4
-            within_time = (now - prev.time) < 0.4
-            new_count = (same_spot && within_time) ? prev.count + 1 : 1
-            click_state[] = (count = new_count, time = now, pos = Point2f(mpos))
-
-            chars = chars_obs[]
-            plot.focused[] = true
-
-            # `new_selection` is what this click would produce on its own;
-            # `ctrl_or_cmd` then decides whether it replaces the existing
-            # cursors or extends them (multi-cursor / multi-selection).
-            new_selection = if new_count == 3
-                lo, hi = line_at_offset(chars, offset)
-                EditCursor(lo, hi)
-            elseif new_count == 2
-                lo, hi = word_at_offset(chars, offset)
-                EditCursor(lo, hi)
-            else
-                EditCursor(offset)
-            end
-            cursors = ctrl_or_cmd ? vcat(plot.cursors[], [new_selection]) : EditCursor[new_selection]
-            plot.cursors[] = merge_cursors(cursors)
-
-            # On single click we set up a drag anchor so subsequent motion
-            # extends the selection.
-            drag_anchor[] = new_count == 1 ? offset : nothing
-            _bump_edit_time!(parent, last_edit_time)
-            # Consume only when *we* own focus management — that's the case
-            # where there's no parent waiting to react to the click. When the
-            # parent owns focus (Textbox), we must not consume so other
-            # widgets at the same priority (e.g. another EditableText that
-            # wants to defocus itself) still see the press.
-            return plot.manage_focus[] ? Consume(true) : Consume(false)
-
-        elseif event.action == Mouse.release
-            drag_anchor[] = nothing
             return Consume(false)
         end
-        return Consume(false)
-    end)
+    )
 
-    push!(plot.deregister_callbacks, on(events(parent).mouseposition, priority = 60) do _
-        anchor = drag_anchor[]
-        anchor === nothing && return Consume(false)
-        Mouse.left in events(parent).mousebuttonstate || return Consume(false)
-        mpos = Makie.mouseposition_px(parent)
-        head = _mouse_to_offset(Point2f(mpos))
-        cursors = plot.cursors[]
-        # Only rewrite the last cursor (the one created by the press) so prior
-        # multi-cursors stay intact. Skip if its head hasn't moved — mouseposition
-        # fires per pixel of motion so this saves a lot of redundant lift work.
-        last_cursor = cursors[end]
-        last_cursor.anchor == anchor && last_cursor.head == head && return Consume(true)
-        new_cursors = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(anchor, head)]))
-        plot.cursors[] = new_cursors
-        _bump_edit_time!(parent, last_edit_time)
-        return Consume(true)
-    end)
+    push!(
+        plot.deregister_callbacks, on(events(parent).mouseposition, priority = 60) do _
+            anchor = drag_anchor[]
+            anchor === nothing && return Consume(false)
+            Mouse.left in events(parent).mousebuttonstate || return Consume(false)
+            mpos = Makie.mouseposition_px(parent)
+            head = _mouse_to_offset(Point2f(mpos))
+            cursors = plot.cursors[]
+            # Only rewrite the last cursor (the one created by the press) so prior
+            # multi-cursors stay intact. Skip if its head hasn't moved — mouseposition
+            # fires per pixel of motion so this saves a lot of redundant lift work.
+            last_cursor = cursors[end]
+            last_cursor.anchor == anchor && last_cursor.head == head && return Consume(true)
+            new_cursors = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(anchor, head)]))
+            plot.cursors[] = new_cursors
+            _bump_edit_time!(parent, last_edit_time)
+            return Consume(true)
+        end
+    )
 
     # Unicode character input — type a character.
-    push!(plot.deregister_callbacks, on(events(parent).unicode_input, priority = 60) do char
-        plot.focused[] || return Consume(false)
-        char == '\0' && return Consume(false)
-        plot.input_filter[](char) || return Consume(true)  # filtered out, but consume so other listeners don't double-handle
-        new_text, new_cursors = apply_edits(plot.text[], plot.cursors[], c -> _replace_op(c, string(char)))
-        _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
-        return Consume(true)
-    end)
+    push!(
+        plot.deregister_callbacks, on(events(parent).unicode_input, priority = 60) do char
+            plot.focused[] || return Consume(false)
+            char == '\0' && return Consume(false)
+            plot.input_filter[](char) || return Consume(true)  # filtered out, but consume so other listeners don't double-handle
+            new_text, new_cursors = apply_edits(plot.text[], plot.cursors[], c -> _replace_op(c, string(char)))
+            _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
+            return Consume(true)
+        end
+    )
 
     # Keyboard.
-    push!(plot.deregister_callbacks, on(events(parent).keyboardbutton, priority = 60) do event
-        plot.focused[] || return Consume(false)
-        event.action == Keyboard.release && return Consume(false)
+    push!(
+        plot.deregister_callbacks, on(events(parent).keyboardbutton, priority = 60) do event
+            plot.focused[] || return Consume(false)
+            event.action == Keyboard.release && return Consume(false)
 
-        key = event.key
-        kbstate = events(parent).keyboardstate
-        shift = (Keyboard.left_shift in kbstate) || (Keyboard.right_shift in kbstate)
-        alt = (Keyboard.left_alt in kbstate) || (Keyboard.right_alt in kbstate)
-        cmd = (Keyboard.left_super in kbstate) || (Keyboard.right_super in kbstate) ||
-              (Keyboard.left_control in kbstate) || (Keyboard.right_control in kbstate)
+            key = event.key
+            kbstate = events(parent).keyboardstate
+            shift = (Keyboard.left_shift in kbstate) || (Keyboard.right_shift in kbstate)
+            alt = (Keyboard.left_alt in kbstate) || (Keyboard.right_alt in kbstate)
+            cmd = (Keyboard.left_super in kbstate) || (Keyboard.right_super in kbstate) ||
+                (Keyboard.left_control in kbstate) || (Keyboard.right_control in kbstate)
 
-        chars = chars_obs[]
-        text = plot.text[]
-        cursors = plot.cursors[]
+            chars = chars_obs[]
+            text = plot.text[]
+            cursors = plot.cursors[]
 
-        # Run an EditOp builder against `text` / `cursors`, push the result.
-        commit_op!(op_for) = begin
-            new_text, new_cursors = apply_edits(text, cursors, c -> op_for(chars, c))
-            _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
-        end
-        # Move every cursor through `move` and store the result.
-        commit_move!(move) = begin
-            plot.cursors[] = merge_cursors([move(c) for c in cursors])
-            _bump_edit_time!(parent, last_edit_time)
-        end
-
-        if key == Keyboard.escape
-            plot.focused[] = false
-            return Consume(true)
-
-        elseif key == Keyboard.left
-            commit_move!(c -> move_cursor(c, chars, -1; word = alt, extend = shift))
-            return Consume(true)
-
-        elseif key == Keyboard.right
-            commit_move!(c -> move_cursor(c, chars, +1; word = alt, extend = shift))
-            return Consume(true)
-
-        elseif key == Keyboard.up || key == Keyboard.down
-            anchors = anchors_obs[].anchors
-            li = line_idx_obs[]
-            n_lines = n_lines_obs[]
-            dir = key == Keyboard.up ? -1 : +1
-            commit_move!(c -> move_cursor_vertical(c, dir; anchors = anchors, line_idx = li, n_lines = n_lines, extend = shift))
-            return Consume(true)
-
-        elseif key == Keyboard.backspace
-            commit_op!(cmd ? _line_back_op : alt ? _word_back_op : _backspace_op)
-            return Consume(true)
-
-        elseif key == Keyboard.delete
-            commit_op!(cmd ? _line_forward_op : alt ? _word_forward_op : _delete_op)
-            return Consume(true)
-
-        elseif key == Keyboard.enter || key == Keyboard.kp_enter
-            multiline = plot.multiline[]
-            do_newline = multiline ? !cmd : shift
-            do_submit = multiline ? cmd : !shift
-            do_newline && commit_op!((_, c) -> _replace_op(c, "\n"))
-            if do_submit
-                cb = plot.on_submit[]
-                cb === nothing || cb(plot.text[])
+            # Run an EditOp builder against `text` / `cursors`, push the result.
+            commit_op!(op_for) = begin
+                new_text, new_cursors = apply_edits(text, cursors, c -> op_for(chars, c))
+                _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
             end
-            return Consume(true)
+            # Move every cursor through `move` and store the result.
+            commit_move!(move) = begin
+                plot.cursors[] = merge_cursors([move(c) for c in cursors])
+                _bump_edit_time!(parent, last_edit_time)
+            end
 
-        elseif key == Keyboard.a && cmd
-            # Select-all
-            n = length(chars)
-            plot.cursors[] = [EditCursor(0, n)]
-            _bump_edit_time!(parent, last_edit_time)
-            return Consume(true)
-
-        elseif key == Keyboard.c && cmd
-            content = _selection_text(chars, cursors)
-            isempty(content) || clipboard(content)
-            return Consume(true)
-
-        elseif key == Keyboard.x && cmd
-            content = _selection_text(chars, cursors)
-            isempty(content) && return Consume(true)
-            clipboard(content)
-            commit_op!((_, c) -> _replace_op(c, ""))
-            return Consume(true)
-
-        elseif key == Keyboard.v && cmd
-            content = try
-                String(clipboard())
-            catch err
-                @warn "Accessing the clipboard failed: $err"
+            if key == Keyboard.escape
+                plot.focused[] = false
                 return Consume(true)
-            end
-            # Run the same per-char filter as typed input so e.g. a single-line
-            # textbox strips newlines from a multi-line paste.
-            filtered = String(filter(plot.input_filter[], collect(content)))
-            isempty(filtered) && return Consume(true)
-            commit_op!((_, c) -> _replace_op(c, filtered))
-            return Consume(true)
 
-        elseif key == Keyboard.d && cmd
-            # Cmd+D: select next occurrence of the most recent cursor's text;
-            # Cmd+Shift+D: select previous. If the most recent cursor has no
-            # selection, the first press expands it to the word at the caret
-            # (matching the common "select word, then keep adding next match"
-            # pattern from VS Code / Sublime).
-            last_c = isempty(cursors) ? EditCursor(0) : cursors[end]
-            if !is_selection(last_c)
-                lo, hi = word_at_offset(chars, last_c.head)
-                lo == hi && return Consume(true)
-                plot.cursors[] = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(lo, hi)]))
+            elseif key == Keyboard.left
+                commit_move!(c -> move_cursor(c, chars, -1; word = alt, extend = shift))
+                return Consume(true)
+
+            elseif key == Keyboard.right
+                commit_move!(c -> move_cursor(c, chars, +1; word = alt, extend = shift))
+                return Consume(true)
+
+            elseif key == Keyboard.up || key == Keyboard.down
+                anchors = anchors_obs[].anchors
+                li = line_idx_obs[]
+                n_lines = n_lines_obs[]
+                dir = key == Keyboard.up ? -1 : +1
+                commit_move!(c -> move_cursor_vertical(c, dir; anchors = anchors, line_idx = li, n_lines = n_lines, extend = shift))
+                return Consume(true)
+
+            elseif key == Keyboard.backspace
+                commit_op!(cmd ? _line_back_op : alt ? _word_back_op : _backspace_op)
+                return Consume(true)
+
+            elseif key == Keyboard.delete
+                commit_op!(cmd ? _line_forward_op : alt ? _word_forward_op : _delete_op)
+                return Consume(true)
+
+            elseif key == Keyboard.enter || key == Keyboard.kp_enter
+                multiline = plot.multiline[]
+                do_newline = multiline ? !cmd : shift
+                do_submit = multiline ? cmd : !shift
+                do_newline && commit_op!((_, c) -> _replace_op(c, "\n"))
+                if do_submit
+                    cb = plot.on_submit[]
+                    cb === nothing || cb(plot.text[])
+                end
+                return Consume(true)
+
+            elseif key == Keyboard.a && cmd
+                # Select-all
+                n = length(chars)
+                plot.cursors[] = [EditCursor(0, n)]
+                _bump_edit_time!(parent, last_edit_time)
+                return Consume(true)
+
+            elseif key == Keyboard.c && cmd
+                content = _selection_text(chars, cursors)
+                isempty(content) || clipboard(content)
+                return Consume(true)
+
+            elseif key == Keyboard.x && cmd
+                content = _selection_text(chars, cursors)
+                isempty(content) && return Consume(true)
+                clipboard(content)
+                commit_op!((_, c) -> _replace_op(c, ""))
+                return Consume(true)
+
+            elseif key == Keyboard.v && cmd
+                content = try
+                    String(clipboard())
+                catch err
+                    @warn "Accessing the clipboard failed: $err"
+                    return Consume(true)
+                end
+                # Run the same per-char filter as typed input so e.g. a single-line
+                # textbox strips newlines from a multi-line paste.
+                filtered = String(filter(plot.input_filter[], collect(content)))
+                isempty(filtered) && return Consume(true)
+                commit_op!((_, c) -> _replace_op(c, filtered))
+                return Consume(true)
+
+            elseif key == Keyboard.d && cmd
+                # Cmd+D: select next occurrence of the most recent cursor's text;
+                # Cmd+Shift+D: select previous. If the most recent cursor has no
+                # selection, the first press expands it to the word at the caret
+                # (matching the common "select word, then keep adding next match"
+                # pattern from VS Code / Sublime).
+                last_c = isempty(cursors) ? EditCursor(0) : cursors[end]
+                if !is_selection(last_c)
+                    lo, hi = word_at_offset(chars, last_c.head)
+                    lo == hi && return Consume(true)
+                    plot.cursors[] = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(lo, hi)]))
+                    _bump_edit_time!(parent, last_edit_time)
+                    return Consume(true)
+                end
+                pattern = chars[(sel_lo(last_c) + 1):sel_hi(last_c)]
+                found = if shift
+                    _find_prev_match(chars, pattern, sel_lo(cursors[1]))
+                else
+                    _find_next_match(chars, pattern, sel_hi(cursors[end]))
+                end
+                found === nothing && return Consume(true)
+                lo, hi = found
+                plot.cursors[] = merge_cursors(vcat(cursors, [EditCursor(lo, hi)]))
                 _bump_edit_time!(parent, last_edit_time)
                 return Consume(true)
             end
-            pattern = chars[(sel_lo(last_c) + 1):sel_hi(last_c)]
-            found = if shift
-                _find_prev_match(chars, pattern, sel_lo(cursors[1]))
-            else
-                _find_next_match(chars, pattern, sel_hi(cursors[end]))
-            end
-            found === nothing && return Consume(true)
-            lo, hi = found
-            plot.cursors[] = merge_cursors(vcat(cursors, [EditCursor(lo, hi)]))
-            _bump_edit_time!(parent, last_edit_time)
-            return Consume(true)
-        end
 
-        return Consume(false)
-    end)
+            return Consume(false)
+        end
+    )
     return
 end
 

--- a/Makie/src/basic_recipes/editabletext.jl
+++ b/Makie/src/basic_recipes/editabletext.jl
@@ -1,0 +1,959 @@
+"""
+    EditCursor(anchor, head)
+
+A single cursor / selection inside an `EditableText`. `anchor` and `head` are
+0-based character offsets into the underlying string, where offset `i` denotes
+the position between character `i` and character `i+1` (so valid offsets are
+`0:length(string)`). When `anchor == head` this is just a caret with no
+selection; otherwise the selected range is `min(anchor, head):max(anchor, head)`.
+
+`head` is the side that moves under arrow keys / drag; `anchor` is the fixed
+side.
+"""
+struct EditCursor
+    anchor::Int
+    head::Int
+end
+EditCursor(i::Int) = EditCursor(i, i)
+
+sel_lo(c::EditCursor) = min(c.anchor, c.head)
+sel_hi(c::EditCursor) = max(c.anchor, c.head)
+is_selection(c::EditCursor) = c.anchor != c.head
+
+"""
+    editabletext(text; attributes...)
+
+A `Text`-like recipe that renders an editable string. Selections and a blinking
+cursor are derived from the `cursors` attribute, which can hold multiple
+[`EditCursor`](@ref) entries (multi-cursor). Editing happens through mouse and
+keyboard event handlers that update `text` and `cursors` in place.
+
+Only single-font / single-color text is supported (no per-glyph styling). The
+recipe relies on the basic `Text` path producing a 1:1 character-to-glyph
+mapping (which it already does for plain `String`s — newline glyphs are kept
+with `glyph_index = 0` and skipped at the backend).
+"""
+@recipe_internal EditableText (text,) begin
+    "The position at which the text is anchored, in `space`."
+    position = Point2f(0)
+    "Active cursors / selections. A `Vector{EditCursor}`; the default is a single empty caret at offset 0."
+    cursors = [EditCursor(0)]
+    "Whether the text is focused. When `true` the cursor blinks and edit keys take effect."
+    focused = false
+    "Color of the rendered text."
+    color = @inherit textcolor
+    "Font used for the text (single font, no per-glyph styling)."
+    font = @inherit font
+    fonts = @inherit fonts
+    "Pixel size of the text."
+    fontsize = @inherit fontsize
+    "Alignment of the text relative to `position`."
+    align = (:left, :baseline)
+    "Multiplier for vertical line spacing."
+    lineheight = 1.0
+    "Color of selection rectangles drawn behind the text."
+    selection_color = RGBAf(0.4, 0.6, 1.0, 0.35)
+    "Color of the cursor caret."
+    cursor_color = @inherit textcolor
+    "Width of the cursor caret in pixels."
+    cursor_width = 1.5
+    "Full on/off period of the cursor blink in seconds. Set to `Inf` to disable blinking."
+    blink_period = 1.0
+    "Space the `position` is given in (passed through to the inner text plot)."
+    space = :data
+    """
+    If `true` (default), the recipe focuses on click inside the text bbox and
+    defocuses on click outside. Set to `false` when a parent block (e.g.
+    `Textbox`) owns focus state — the recipe will then only place the cursor
+    when clicked while already focused, leaving focus changes to the parent.
+    """
+    manage_focus = true
+    """
+    If `true`, Enter inserts a newline and Cmd/Ctrl+Enter triggers `on_submit`.
+    If `false`, plain Enter triggers `on_submit` and Shift+Enter inserts a
+    newline (chat-box / single-line input style).
+    """
+    multiline = true
+    "Optional callback `(text::String) -> Any` invoked on submit (Cmd/Ctrl+Enter when `multiline = true`, plain Enter when `multiline = false`)."
+    on_submit = nothing
+    """
+    Filter applied to typed characters: `(c::Char) -> Bool`. Characters that
+    fail the predicate are dropped. Newlines inserted via the Enter / Shift+Enter
+    keypath are not subject to this filter — use `multiline = false` to forbid
+    them. Default accepts everything.
+    """
+    input_filter = c -> true
+    visible = true
+    inspectable = false
+end
+
+################################################################################
+# Word / line helpers (operating on Vector{Char}, 0-based offsets)
+################################################################################
+
+isword_char(c::Char) = isletter(c) || isdigit(c) || c == '_'
+
+function next_word_offset(chars::Vector{Char}, i::Int)
+    n = length(chars)
+    j = clamp(i, 0, n)
+    j == n && return n
+    while j < n && !isword_char(chars[j + 1])
+        j += 1
+    end
+    while j < n && isword_char(chars[j + 1])
+        j += 1
+    end
+    return j
+end
+
+function prev_word_offset(chars::Vector{Char}, i::Int)
+    j = clamp(i, 0, length(chars))
+    j == 0 && return 0
+    while j > 0 && !isword_char(chars[j])
+        j -= 1
+    end
+    while j > 0 && isword_char(chars[j])
+        j -= 1
+    end
+    return j
+end
+
+# Word containing the cursor at offset `i`. Returns (lo, hi).
+function word_at_offset(chars::Vector{Char}, i::Int)
+    n = length(chars)
+    j = clamp(i, 0, n)
+    target = if j < n && isword_char(chars[j + 1])
+        j + 1
+    elseif j > 0 && isword_char(chars[j])
+        j
+    else
+        return (j, j)
+    end
+    a = target
+    while a > 1 && isword_char(chars[a - 1])
+        a -= 1
+    end
+    b = target
+    while b < n && isword_char(chars[b + 1])
+        b += 1
+    end
+    return (a - 1, b)
+end
+
+# Line containing the cursor at offset `i`. Returns (lo, hi) such that the
+# selection covers from start-of-line to end-of-line (excluding the trailing '\n').
+function line_at_offset(chars::Vector{Char}, i::Int)
+    n = length(chars)
+    j = clamp(i, 0, n)
+    a = j
+    while a > 0 && chars[a] != '\n'
+        a -= 1
+    end
+    b = j
+    while b < n && chars[b + 1] != '\n'
+        b += 1
+    end
+    return (a, b)
+end
+
+################################################################################
+# Cursor anchor positions in markerspace (relative to the text block position)
+################################################################################
+
+"""
+    CursorAnchors
+
+Layout output from `cursor_anchor_positions`.
+
+* `anchors[i+1]` is the baseline position of the cursor at offset `i` (0-based).
+* `ascender` / `descender` are pixel offsets from the baseline (descender is
+  negative); the visible caret spans `[baseline + descender, baseline + ascender]`.
+* `line_h` is the spacing between line baselines, used for vertical
+  extrapolation past the last glyph.
+"""
+struct CursorAnchors
+    anchors::Vector{Point2f}
+    ascender::Float32
+    descender::Float32
+    line_h::Float32
+end
+
+function cursor_anchor_positions(
+        glyph_origins::AbstractVector{<:VecTypes{3}},
+        glyph_extents::AbstractVector{GlyphExtent},
+        text_scales::AbstractVector{Vec2f},
+        font::Makie.NativeFont,
+        fontsize::Float32, lineheight::Float32,
+        align::Tuple, trailing_newline::Bool,
+    )::CursorAnchors
+    line_h = Float32(font.height / font.units_per_EM * fontsize * lineheight)
+    # A single font is in use, so the font-level ascender / descender apply to
+    # every glyph (including the empty-editor case). FreeType gives them in
+    # font units; multiply by `fontsize` to get pixels.
+    ascender = Float32(Makie.FreeTypeAbstraction.ascender(font) * fontsize)
+    descender = Float32(Makie.FreeTypeAbstraction.descender(font) * fontsize)
+
+    n = length(glyph_origins)
+    if n == 0
+        # No glyphs to anchor to. Place the caret at where the first glyph's
+        # baseline *would* sit given the current `align` — for `:top` the
+        # baseline is `ascender` pixels below the position; for `:bottom`
+        # it's `descender` (negative) below; etc. This matches what the text
+        # plot does to its first glyph in the alignment step, so the caret
+        # remains in the same spot when the user types the first character.
+        _halign, valign = align
+        y0 = if valign === :top
+            -ascender
+        elseif valign === :bottom
+            -descender
+        elseif valign === :center
+            -(ascender + descender) / 2
+        else  # :baseline or numeric
+            0.0f0
+        end
+        return CursorAnchors([Point2f(0, y0)], ascender, descender, line_h)
+    end
+
+    anchors = Vector{Point2f}(undef, n + 1)
+    anchors[1] = Point2f(glyph_origins[1][1], glyph_origins[1][2])
+    for i in 1:(n - 1)
+        anchors[i + 1] = Point2f(glyph_origins[i + 1][1], glyph_origins[i + 1][2])
+    end
+    if trailing_newline
+        # Trailing newline: extrapolate to the start of the empty next line.
+        anchors[n + 1] = Point2f(0, glyph_origins[n][2] - line_h)
+    else
+        adv = Float32(glyph_extents[n].hadvance) * text_scales[n][1]
+        anchors[n + 1] = Point2f(glyph_origins[n][1] + adv, glyph_origins[n][2])
+    end
+    return CursorAnchors(anchors, ascender, descender, line_h)
+end
+
+# `line_idx[i+1]` = 1-based line of cursor offset `i`.
+function cursor_anchor_lines(chars::Vector{Char})
+    n = length(chars)
+    line_idx = Vector{Int}(undef, n + 1)
+    line = 1
+    line_idx[1] = 1
+    for i in 1:n
+        if chars[i] == '\n'
+            line += 1
+        end
+        line_idx[i + 1] = line
+    end
+    return line_idx
+end
+
+################################################################################
+# Selection rectangles
+################################################################################
+
+# Build per-line rectangles covering the selection range lo..hi.
+function selection_rects_for_range(
+        lo::Int, hi::Int,
+        anchors::Vector{Point2f}, line_idx::Vector{Int},
+        ascender::Float32, descender::Float32, line_h::Float32,
+    )
+    lo == hi && return Rect2f[]
+    rects = Rect2f[]
+    seg_lo = lo
+    while seg_lo < hi
+        line = line_idx[seg_lo + 1]
+        seg_hi = seg_lo
+        while seg_hi < hi && line_idx[seg_hi + 2] == line
+            seg_hi += 1
+        end
+        a = anchors[seg_lo + 1]
+        b = anchors[seg_hi + 1]
+        crosses_newline = seg_hi < hi
+        # When the segment ends at a newline, give the rectangle a small visible
+        # tail to the right so it is clear the newline is included.
+        right_x = crosses_newline ? max(b[1], a[1] + 0.4f0 * line_h) : b[1]
+        x0 = min(a[1], right_x)
+        w = abs(right_x - a[1])
+        # The rect spans descender..ascender vertically.
+        push!(rects, Rect2f(Point2f(x0, a[2] + descender), Vec2f(w, ascender - descender)))
+        # If the segment crosses a newline (chars[seg_hi+1] == '\n'), step past it
+        # so the next iteration starts on the next line. Otherwise we'd loop forever
+        # when the inner while didn't advance.
+        seg_lo = crosses_newline ? seg_hi + 1 : seg_hi
+    end
+    return rects
+end
+
+################################################################################
+# Multi-cursor edit application
+################################################################################
+
+# Merge cursors that overlap or touch. Direction (anchor vs head) is taken from
+# the cursor that "wins" each merge.
+function merge_cursors(cursors::Vector{EditCursor})
+    isempty(cursors) && return cursors
+    sorted = sort(cursors; by = sel_lo)
+    out = EditCursor[sorted[1]]
+    for c in @view sorted[2:end]
+        last = out[end]
+        if sel_lo(c) <= sel_hi(last)
+            new_lo = min(sel_lo(last), sel_lo(c))
+            new_hi = max(sel_hi(last), sel_hi(c))
+            out[end] = c.anchor <= c.head ? EditCursor(new_lo, new_hi) : EditCursor(new_hi, new_lo)
+        else
+            push!(out, c)
+        end
+    end
+    return out
+end
+
+# A single primitive edit: remove the characters in `range` (0-based char
+# offsets, where `a:b` denotes the chars between cursor positions `a` and `b`)
+# and insert `insert` in their place. Either side can be empty:
+#   * insert only (range a:a, insert "x"): pure insertion at cursor `a`
+#   * delete only (range a:b, insert ""): pure deletion of chars (a, b]
+#   * replace   (range a:b, insert "x"): selection replacement
+# All movement / deletion key handlers reduce to one of these primitives;
+# `apply_edits` then composes per-cursor ops left-to-right.
+struct EditOp
+    range::UnitRange{Int}
+    insert::String
+end
+
+# Apply per-cursor edit ops. `op_for(cursor) -> EditOp`. Returns
+# `(new_text, new_cursors)`. Overlapping ops are coalesced left-to-right.
+function apply_edits(text::String, cursors::Vector{EditCursor}, op_for)
+    # Single-cursor fast path: skip the sort / paired round-trip; this is the
+    # path every keystroke takes in a normal Textbox.
+    if length(cursors) == 1
+        chars = collect(text)
+        n = length(chars)
+        edit = op_for(cursors[1])::EditOp
+        a = clamp(edit.range.start, 0, n)
+        b = clamp(edit.range.stop, 0, n)
+        new_chars = Char[]
+        sizehint!(new_chars, n - (b - a) + length(edit.insert))
+        append!(new_chars, view(chars, 1:a))
+        append!(new_chars, edit.insert)
+        append!(new_chars, view(chars, (b + 1):n))
+        return String(new_chars), [EditCursor(a + length(edit.insert))]
+    end
+    chars = collect(text)
+    n = length(chars)
+    paired = [(i, op_for(c)::EditOp) for (i, c) in enumerate(cursors)]
+    sort!(paired; by = p -> p[2].range.start)
+
+    new_chars = Char[]
+    new_cursors = Vector{EditCursor}(undef, length(cursors))
+    pos = 0
+    for (cursor_idx, edit) in paired
+        a = clamp(edit.range.start, 0, n)
+        b = clamp(edit.range.stop, 0, n)
+        if a < pos
+            # Range overlaps the previous edit's deletion. Skip this insert and
+            # collapse the cursor onto the previous edit's tail position so the
+            # combined output never duplicates an insertion in the overlap.
+            new_cursors[cursor_idx] = EditCursor(length(new_chars))
+            pos = max(pos, b)
+            continue
+        end
+        for j in (pos + 1):a
+            push!(new_chars, chars[j])
+        end
+        for c in edit.insert
+            push!(new_chars, c)
+        end
+        new_cursors[cursor_idx] = EditCursor(length(new_chars))
+        pos = b
+    end
+    for j in (pos + 1):n
+        push!(new_chars, chars[j])
+    end
+    return String(new_chars), merge_cursors(new_cursors)
+end
+
+# EditOp builders for common actions.
+_replace_op(c::EditCursor, replacement::String) = EditOp(sel_lo(c):sel_hi(c), replacement)
+
+function _backspace_op(_::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    h = c.head
+    return h == 0 ? EditOp(0:0, "") : EditOp((h - 1):h, "")
+end
+
+function _delete_op(chars::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    h = c.head
+    return h == length(chars) ? EditOp(h:h, "") : EditOp(h:(h + 1), "")
+end
+
+function _word_back_op(chars::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    return EditOp(prev_word_offset(chars, c.head):c.head, "")
+end
+
+function _word_forward_op(chars::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    return EditOp(c.head:next_word_offset(chars, c.head), "")
+end
+
+function _line_back_op(chars::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    line_start, _ = line_at_offset(chars, c.head)
+    return EditOp(line_start:c.head, "")
+end
+
+function _line_forward_op(chars::Vector{Char}, c::EditCursor)
+    is_selection(c) && return EditOp(sel_lo(c):sel_hi(c), "")
+    _, line_end = line_at_offset(chars, c.head)
+    return EditOp(c.head:line_end, "")
+end
+
+# Search for `pattern` in `chars`, starting *at or after* `from_offset`
+# (0-based character offset). Returns `(lo, hi)` such that `chars[lo+1:hi]` equals
+# `pattern`, or `nothing` if no further occurrence exists.
+function _find_next_match(chars::Vector{Char}, pattern::Vector{Char}, from_offset::Int)
+    n = length(chars)
+    m = length(pattern)
+    (m == 0 || m > n) && return nothing
+    lo = max(from_offset, 0)
+    @inbounds while lo <= n - m
+        match = true
+        for k in 1:m
+            if chars[lo + k] != pattern[k]
+                match = false
+                break
+            end
+        end
+        match && return (lo, lo + m)
+        lo += 1
+    end
+    return nothing
+end
+
+# Symmetric backward search: returns the last occurrence whose `hi <= up_to_offset`.
+function _find_prev_match(chars::Vector{Char}, pattern::Vector{Char}, up_to_offset::Int)
+    m = length(pattern)
+    m == 0 && return nothing
+    lo = up_to_offset - m
+    @inbounds while lo >= 0
+        match = true
+        for k in 1:m
+            if chars[lo + k] != pattern[k]
+                match = false
+                break
+            end
+        end
+        match && return (lo, lo + m)
+        lo -= 1
+    end
+    return nothing
+end
+
+# Concatenated text of every selection, in cursor order, joined by newlines.
+# Returns "" when no cursor has a selection (so callers can no-op cleanly).
+function _selection_text(chars::Vector{Char}, cursors::Vector{EditCursor})
+    buf = IOBuffer()
+    first = true
+    for c in cursors
+        is_selection(c) || continue
+        first || print(buf, '\n')
+        first = false
+        for ch in view(chars, (sel_lo(c) + 1):sel_hi(c))
+            print(buf, ch)
+        end
+    end
+    return String(take!(buf))
+end
+
+################################################################################
+# Cursor movement
+################################################################################
+
+function move_cursor(c::EditCursor, chars::Vector{Char}, dir::Int; word::Bool, extend::Bool)
+    if !extend && is_selection(c) && !word
+        return EditCursor(dir < 0 ? sel_lo(c) : sel_hi(c))
+    end
+    new_head = if word
+        dir < 0 ? prev_word_offset(chars, c.head) : next_word_offset(chars, c.head)
+    else
+        clamp(c.head + dir, 0, length(chars))
+    end
+    return extend ? EditCursor(c.anchor, new_head) : EditCursor(new_head)
+end
+
+function move_cursor_vertical(
+        c::EditCursor, dir::Int;
+        anchors::Vector{Point2f}, line_idx::Vector{Int}, n_lines::Int, extend::Bool,
+    )
+    head_line = line_idx[c.head + 1]
+    target_line = clamp(head_line + dir, 1, n_lines)
+    target_line == head_line && return c
+    target_x = anchors[c.head + 1][1]
+    best_off = c.head
+    best_dist = Inf32
+    for off in 0:(length(anchors) - 1)
+        if line_idx[off + 1] == target_line
+            d = abs(anchors[off + 1][1] - target_x)
+            if d < best_dist
+                best_dist = Float32(d)
+                best_off = off
+            end
+        end
+    end
+    return extend ? EditCursor(c.anchor, best_off) : EditCursor(best_off)
+end
+
+# Convert a pixel-space point (relative to the text block's anchor — already
+# in the same coordinate system as the entries of `anchors`) into the nearest
+# character offset.
+function offset_from_pixel_point(
+        pt::Point2f, anchors::Vector{Point2f}, line_idx::Vector{Int},
+    )
+    # Line first (closest y), then closest x within the line.
+    best_line = 1
+    best_dy = Inf32
+    seen_lines = Set{Int}()
+    for off in 0:(length(anchors) - 1)
+        line = line_idx[off + 1]
+        line in seen_lines && continue
+        push!(seen_lines, line)
+        dy = abs(anchors[off + 1][2] - pt[2])
+        if dy < best_dy
+            best_dy = Float32(dy)
+            best_line = line
+        end
+    end
+    best_off = 0
+    best_dx = Inf32
+    for off in 0:(length(anchors) - 1)
+        if line_idx[off + 1] == best_line
+            d = abs(anchors[off + 1][1] - pt[1])
+            if d < best_dx
+                best_dx = Float32(d)
+                best_off = off
+            end
+        end
+    end
+    return best_off
+end
+
+################################################################################
+# Recipe `plot!`
+################################################################################
+
+function Makie.plot!(plot::EditableText)
+    text_plot = text!(
+        plot, plot.position; text = plot.text,
+        color = plot.color, font = plot.font, fonts = plot.fonts,
+        fontsize = plot.fontsize, align = plot.align,
+        lineheight = plot.lineheight,
+        space = plot.space, markerspace = :pixel,
+        visible = plot.visible, inspectable = false,
+    )
+    Makie.register_markerspace_positions!(text_plot, Point2f)
+
+    # The block's projected pixel position. `text!` always renders one block
+    # per position vector, so `only` matches that invariant — it errors if the
+    # text plot is ever set up with more than one position.
+    block_pos_obs = lift(mps -> Point2f(only(mps)), text_plot.markerspace_positions)
+
+    chars_obs = lift(collect, plot.text)
+
+    anchors_obs = lift(
+        text_plot.glyph_origins, text_plot.glyph_extents,
+        text_plot.text_scales, text_plot.selected_font, plot.fontsize, plot.lineheight, plot.align,
+    ) do origins, extents, scales, font, fontsize, lh, align
+        # `plot.text` is the upstream input that drives `glyph_origins`, so by
+        # the time this lift fires the text observable is already up to date.
+        # We read it directly (rather than listing it as a dep) to avoid a
+        # second redundant fire per text change.
+        text = plot.text[]
+        trailing_newline = !isempty(text) && last(text) == '\n'
+        return cursor_anchor_positions(
+            origins, extents, scales, font,
+            Float32(fontsize), Float32(lh), align, trailing_newline,
+        )
+    end
+
+    line_idx_obs = lift(cursor_anchor_lines, chars_obs)
+    n_lines_obs = lift(li -> isempty(li) ? 1 : maximum(li), line_idx_obs)
+
+    # ── Selection rectangles ─────────────────────────────────────────────────
+    # `cursors` and `anchors_obs` live in different compute graphs (ours vs.
+    # the inner text plot's), so an edit fires this lift twice — once before
+    # the text-plot graph has caught up, once after. Clamping head/anchor to
+    # the current anchor range absorbs the transient mismatch; the second fire
+    # produces the final, correct rectangles.
+    selection_rects_obs = lift(plot.cursors, anchors_obs, line_idx_obs, block_pos_obs) do cursors, m, li, bp
+        rects = Rect2f[]
+        n = length(m.anchors) - 1
+        for c in cursors
+            cc = EditCursor(clamp(c.anchor, 0, n), clamp(c.head, 0, n))
+            is_selection(cc) || continue
+            for r in selection_rects_for_range(sel_lo(cc), sel_hi(cc), m.anchors, li, m.ascender, m.descender, m.line_h)
+                push!(rects, Rect2f(minimum(r) + bp, widths(r)))
+            end
+        end
+        return rects
+    end
+
+    selection_plot = poly!(
+        plot, selection_rects_obs;
+        color = plot.selection_color, strokewidth = 0,
+        # Hide selections when the editor isn't focused — matches typical
+        # text-input UX where the highlight disappears on click-away.
+        visible = plot.focused,
+        space = :pixel, transformation = :nothing, inspectable = false,
+    )
+    # The selection rects need to render *behind* the text. Plot order in
+    # `plot.plots` is rendering order, and the text plot was created first
+    # above, so move the poly to the front of the list.
+    deleteat!(plot.plots, findfirst(==(selection_plot), plot.plots))
+    pushfirst!(plot.plots, selection_plot)
+
+    # ── Cursor caret(s) ──────────────────────────────────────────────────────
+    # Each caret is a vertical segment spanning descender..ascender. See
+    # `selection_rects_obs` above for the clamp rationale.
+    cursor_segments_obs = lift(plot.cursors, anchors_obs, block_pos_obs) do cursors, m, bp
+        segs = Point2f[]
+        n = length(m.anchors) - 1
+        for c in cursors
+            head = clamp(c.head, 0, n)
+            p = m.anchors[head + 1] + bp
+            push!(segs, p + Point2f(0, m.descender))
+            push!(segs, p + Point2f(0, m.ascender))
+        end
+        return segs
+    end
+
+    # Cursor blink: simple binary on/off driven by render ticks. `last_edit_time`
+    # gets reset on focus and on every edit, so the caret is always solid when
+    # the cursor first appears or after the user types — never half-faded mid-cycle.
+    last_edit_time = Observable(0.0)
+    cursor_visible_obs = Observable(true; ignore_equal_values = true)
+
+    parent = Makie.parent_scene(plot)
+    push!(plot.deregister_callbacks, on(events(parent).tick) do tick
+        cursor_visible_obs[] = if !plot.focused[]
+            false
+        else
+            period = plot.blink_period[]
+            elapsed = tick.time - last_edit_time[]
+            isinf(period) || mod(elapsed, period) < period / 2
+        end
+        return nothing
+    end)
+    push!(plot.deregister_callbacks, on(plot.focused) do f
+        if f
+            last_edit_time[] = events(parent).tick[].time
+        end
+        return nothing
+    end)
+
+    linesegments!(
+        plot, cursor_segments_obs;
+        color = plot.cursor_color, linewidth = plot.cursor_width,
+        visible = cursor_visible_obs,
+        space = :pixel, transformation = :nothing, inspectable = false,
+    )
+
+    # ── Event handling ───────────────────────────────────────────────────────
+    attach_editabletext_events!(plot, parent, text_plot, chars_obs, anchors_obs, line_idx_obs, n_lines_obs, block_pos_obs, last_edit_time)
+
+    return plot
+end
+
+################################################################################
+# Event handlers
+################################################################################
+
+# Helper: bump `last_edit_time` to the current tick time so the caret is solid
+# again after editing.
+function _bump_edit_time!(parent::Scene, last_edit_time::Observable{Float64})
+    last_edit_time[] = events(parent).tick[].time
+    return
+end
+
+# Push a new (text, cursors) pair. We can't bundle the two updates into a
+# single observable notification: the text plot's glyph data lives in its own
+# compute graph, and propagation across graphs goes through observable
+# notifications whose ordering relative to our `cursors` listener isn't
+# guaranteed. The lifts on `cursors`/`anchors` therefore clamp head/anchor
+# offsets defensively to absorb a transient stale combination.
+function _commit_edit!(plot::EditableText, new_text::String, new_cursors::Vector{EditCursor}, parent::Scene, last_edit_time)
+    plot.cursors[] = new_cursors
+    plot.arg1 = new_text
+    _bump_edit_time!(parent, last_edit_time)
+    return
+end
+
+function attach_editabletext_events!(
+        plot::EditableText, parent::Scene, text_plot,
+        chars_obs, anchors_obs, line_idx_obs, n_lines_obs, block_pos_obs, last_edit_time,
+    )
+
+    # Track click count + timing for double/triple click. We can't reuse the
+    # `addmouseevents!` state machine for two reasons: it stops at double-click
+    # (no triple), and it runs at priority 1 while we need priority 60 to set
+    # focus before sibling EditableText listeners place a cursor.
+    click_state = Ref((count = 0, time = 0.0, pos = Point2f(0)))
+    drag_anchor = Ref{Union{Nothing, Int}}(nothing)
+
+    function _mouse_to_offset(state_data::Point2f)
+        # `state_data` is the scene-relative pixel mouse position. Subtract the
+        # block's projected pixel anchor to get a position relative to the
+        # cursor anchor list, then snap to the nearest offset.
+        anchors = anchors_obs[].anchors
+        line_idx = line_idx_obs[]
+        local_pt = state_data - block_pos_obs[]
+        return offset_from_pixel_point(local_pt, anchors, line_idx)
+    end
+
+    push!(plot.deregister_callbacks, on(events(parent).mousebutton, priority = 60) do event
+        event.button == Mouse.left || return Consume(false)
+
+        if event.action == Mouse.press
+            mpos = Makie.mouseposition_px(parent)
+            if plot.manage_focus[]
+                # Auto-focus on clicks within the text bbox; auto-defocus
+                # on clicks outside.
+                if !is_click_inside_text(text_plot, plot, mpos)
+                    if plot.focused[]
+                        plot.focused[] = false
+                    end
+                    return Consume(false)
+                end
+            else
+                # Parent owns focus. Only place a cursor if we're actually
+                # focused right now; otherwise leave the click for the parent.
+                plot.focused[] || return Consume(false)
+            end
+
+            offset = _mouse_to_offset(Point2f(mpos))
+
+            # Multi-click handling
+            now = events(parent).tick[].time
+            ctrl_or_cmd = ispressed(parent, Keyboard.left_super | Keyboard.right_super) ||
+                          ispressed(parent, Keyboard.left_control | Keyboard.right_control)
+
+            prev = click_state[]
+            same_spot = norm(Point2f(mpos) - prev.pos) < 4
+            within_time = (now - prev.time) < 0.4
+            new_count = (same_spot && within_time) ? prev.count + 1 : 1
+            click_state[] = (count = new_count, time = now, pos = Point2f(mpos))
+
+            chars = chars_obs[]
+            plot.focused[] = true
+
+            # `new_selection` is what this click would produce on its own;
+            # `ctrl_or_cmd` then decides whether it replaces the existing
+            # cursors or extends them (multi-cursor / multi-selection).
+            new_selection = if new_count == 3
+                lo, hi = line_at_offset(chars, offset)
+                EditCursor(lo, hi)
+            elseif new_count == 2
+                lo, hi = word_at_offset(chars, offset)
+                EditCursor(lo, hi)
+            else
+                EditCursor(offset)
+            end
+            cursors = ctrl_or_cmd ? vcat(plot.cursors[], [new_selection]) : EditCursor[new_selection]
+            plot.cursors[] = merge_cursors(cursors)
+
+            # On single click we set up a drag anchor so subsequent motion
+            # extends the selection.
+            drag_anchor[] = new_count == 1 ? offset : nothing
+            _bump_edit_time!(parent, last_edit_time)
+            # Consume only when *we* own focus management — that's the case
+            # where there's no parent waiting to react to the click. When the
+            # parent owns focus (Textbox), we must not consume so other
+            # widgets at the same priority (e.g. another EditableText that
+            # wants to defocus itself) still see the press.
+            return plot.manage_focus[] ? Consume(true) : Consume(false)
+
+        elseif event.action == Mouse.release
+            drag_anchor[] = nothing
+            return Consume(false)
+        end
+        return Consume(false)
+    end)
+
+    push!(plot.deregister_callbacks, on(events(parent).mouseposition, priority = 60) do _
+        anchor = drag_anchor[]
+        anchor === nothing && return Consume(false)
+        Mouse.left in events(parent).mousebuttonstate || return Consume(false)
+        mpos = Makie.mouseposition_px(parent)
+        head = _mouse_to_offset(Point2f(mpos))
+        cursors = plot.cursors[]
+        # Only rewrite the last cursor (the one created by the press) so prior
+        # multi-cursors stay intact. Skip if its head hasn't moved — mouseposition
+        # fires per pixel of motion so this saves a lot of redundant lift work.
+        last_cursor = cursors[end]
+        last_cursor.anchor == anchor && last_cursor.head == head && return Consume(true)
+        new_cursors = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(anchor, head)]))
+        plot.cursors[] = new_cursors
+        _bump_edit_time!(parent, last_edit_time)
+        return Consume(true)
+    end)
+
+    # Unicode character input — type a character.
+    push!(plot.deregister_callbacks, on(events(parent).unicode_input, priority = 60) do char
+        plot.focused[] || return Consume(false)
+        char == '\0' && return Consume(false)
+        plot.input_filter[](char) || return Consume(true)  # filtered out, but consume so other listeners don't double-handle
+        new_text, new_cursors = apply_edits(plot.text[], plot.cursors[], c -> _replace_op(c, string(char)))
+        _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
+        return Consume(true)
+    end)
+
+    # Keyboard.
+    push!(plot.deregister_callbacks, on(events(parent).keyboardbutton, priority = 60) do event
+        plot.focused[] || return Consume(false)
+        event.action == Keyboard.release && return Consume(false)
+
+        key = event.key
+        kbstate = events(parent).keyboardstate
+        shift = (Keyboard.left_shift in kbstate) || (Keyboard.right_shift in kbstate)
+        alt = (Keyboard.left_alt in kbstate) || (Keyboard.right_alt in kbstate)
+        cmd = (Keyboard.left_super in kbstate) || (Keyboard.right_super in kbstate) ||
+              (Keyboard.left_control in kbstate) || (Keyboard.right_control in kbstate)
+
+        chars = chars_obs[]
+        text = plot.text[]
+        cursors = plot.cursors[]
+
+        # Run an EditOp builder against `text` / `cursors`, push the result.
+        commit_op!(op_for) = begin
+            new_text, new_cursors = apply_edits(text, cursors, c -> op_for(chars, c))
+            _commit_edit!(plot, new_text, new_cursors, parent, last_edit_time)
+        end
+        # Move every cursor through `move` and store the result.
+        commit_move!(move) = begin
+            plot.cursors[] = merge_cursors([move(c) for c in cursors])
+            _bump_edit_time!(parent, last_edit_time)
+        end
+
+        if key == Keyboard.escape
+            plot.focused[] = false
+            return Consume(true)
+
+        elseif key == Keyboard.left
+            commit_move!(c -> move_cursor(c, chars, -1; word = alt, extend = shift))
+            return Consume(true)
+
+        elseif key == Keyboard.right
+            commit_move!(c -> move_cursor(c, chars, +1; word = alt, extend = shift))
+            return Consume(true)
+
+        elseif key == Keyboard.up || key == Keyboard.down
+            anchors = anchors_obs[].anchors
+            li = line_idx_obs[]
+            n_lines = n_lines_obs[]
+            dir = key == Keyboard.up ? -1 : +1
+            commit_move!(c -> move_cursor_vertical(c, dir; anchors = anchors, line_idx = li, n_lines = n_lines, extend = shift))
+            return Consume(true)
+
+        elseif key == Keyboard.backspace
+            commit_op!(cmd ? _line_back_op : alt ? _word_back_op : _backspace_op)
+            return Consume(true)
+
+        elseif key == Keyboard.delete
+            commit_op!(cmd ? _line_forward_op : alt ? _word_forward_op : _delete_op)
+            return Consume(true)
+
+        elseif key == Keyboard.enter || key == Keyboard.kp_enter
+            multiline = plot.multiline[]
+            do_newline = multiline ? !cmd : shift
+            do_submit = multiline ? cmd : !shift
+            do_newline && commit_op!((_, c) -> _replace_op(c, "\n"))
+            if do_submit
+                cb = plot.on_submit[]
+                cb === nothing || cb(plot.text[])
+            end
+            return Consume(true)
+
+        elseif key == Keyboard.a && cmd
+            # Select-all
+            n = length(chars)
+            plot.cursors[] = [EditCursor(0, n)]
+            _bump_edit_time!(parent, last_edit_time)
+            return Consume(true)
+
+        elseif key == Keyboard.c && cmd
+            content = _selection_text(chars, cursors)
+            isempty(content) || clipboard(content)
+            return Consume(true)
+
+        elseif key == Keyboard.x && cmd
+            content = _selection_text(chars, cursors)
+            isempty(content) && return Consume(true)
+            clipboard(content)
+            commit_op!((_, c) -> _replace_op(c, ""))
+            return Consume(true)
+
+        elseif key == Keyboard.v && cmd
+            content = try
+                String(clipboard())
+            catch err
+                @warn "Accessing the clipboard failed: $err"
+                return Consume(true)
+            end
+            # Run the same per-char filter as typed input so e.g. a single-line
+            # textbox strips newlines from a multi-line paste.
+            filtered = String(filter(plot.input_filter[], collect(content)))
+            isempty(filtered) && return Consume(true)
+            commit_op!((_, c) -> _replace_op(c, filtered))
+            return Consume(true)
+
+        elseif key == Keyboard.d && cmd
+            # Cmd+D: select next occurrence of the most recent cursor's text;
+            # Cmd+Shift+D: select previous. If the most recent cursor has no
+            # selection, the first press expands it to the word at the caret
+            # (matching the common "select word, then keep adding next match"
+            # pattern from VS Code / Sublime).
+            last_c = isempty(cursors) ? EditCursor(0) : cursors[end]
+            if !is_selection(last_c)
+                lo, hi = word_at_offset(chars, last_c.head)
+                lo == hi && return Consume(true)
+                plot.cursors[] = merge_cursors(vcat(cursors[1:(end - 1)], [EditCursor(lo, hi)]))
+                _bump_edit_time!(parent, last_edit_time)
+                return Consume(true)
+            end
+            pattern = chars[(sel_lo(last_c) + 1):sel_hi(last_c)]
+            found = if shift
+                _find_prev_match(chars, pattern, sel_lo(cursors[1]))
+            else
+                _find_next_match(chars, pattern, sel_hi(cursors[end]))
+            end
+            found === nothing && return Consume(true)
+            lo, hi = found
+            plot.cursors[] = merge_cursors(vcat(cursors, [EditCursor(lo, hi)]))
+            _bump_edit_time!(parent, last_edit_time)
+            return Consume(true)
+        end
+
+        return Consume(false)
+    end)
+    return
+end
+
+# Whether a pixel-space point clicks within the text's string boundingbox.
+# Used to decide focus-on-click vs defocus-on-click-outside.
+function is_click_inside_text(text_plot, plot, mpos)
+    # Best-effort: use `markerspace_positions` and pad by half the font size
+    # so an empty editor still receives clicks at its anchor point.
+    bbs = try
+        Makie.fast_string_boundingboxes(text_plot)
+    catch
+        nothing
+    end
+    bp = Point2f(only(text_plot.markerspace_positions[]))
+    pad = Float32(plot.fontsize[]) * 0.5f0
+    if bbs === nothing || isempty(bbs)
+        # Empty text — accept clicks within a small box at the anchor.
+        rect = Rect2f(bp - Point2f(pad), Vec2f(2pad, plot.fontsize[]))
+        return Point2f(mpos[1], mpos[2]) in rect
+    end
+    bb = bbs[1]
+    rect_min = Point2f(minimum(bb)[1], minimum(bb)[2]) + bp - Point2f(pad)
+    rect_w = Vec2f(widths(bb)[1] + 2pad, widths(bb)[2] + 2pad)
+    return Point2f(mpos[1], mpos[2]) in Rect2f(rect_min, rect_w)
+end

--- a/Makie/src/interaction/inspector.jl
+++ b/Makie/src/interaction/inspector.jl
@@ -11,12 +11,7 @@ function bbox2string(bbox::Rect3)
     p0 = origin(bbox)
     p1 = p0 .+ widths(bbox)
     return @sprintf(
-        """
-        Bounding Box:
-         x: (%0.3f, %0.3f)
-         y: (%0.3f, %0.3f)
-         z: (%0.3f, %0.3f)
-        """,
+        "Bounding Box:\n x: (%0.3f, %0.3f)\n y: (%0.3f, %0.3f)\n z: (%0.3f, %0.3f)",
         p0[1], p1[1], p0[2], p1[2], p0[3], p1[3]
     )
 end
@@ -25,11 +20,7 @@ function bbox2string(bbox::Rect2)
     p0 = origin(bbox)
     p1 = p0 .+ widths(bbox)
     return @sprintf(
-        """
-        Bounding Box:
-         x: (%0.3f, %0.3f)
-         y: (%0.3f, %0.3f)
-        """,
+        "Bounding Box:\n x: (%0.3f, %0.3f)\n y: (%0.3f, %0.3f)",
         p0[1], p1[1], p0[2], p1[2]
     )
 end

--- a/Makie/src/layouting/text_layouting.jl
+++ b/Makie/src/layouting/text_layouting.jl
@@ -76,6 +76,16 @@ function create_lineinfos(charinfos, word_wrap_width)
         end
     end
 
+    # If the input ends with '\n' (or word-wrap newlines), the loop pushes a new
+    # empty `Float32[]` to `xs` but never the matching empty view to `lineinfos`,
+    # so a trailing newline contributes no vertical space. Append empty views so
+    # lengths match — the trailing empty line then takes part in alignment and
+    # bounding box computations.
+    while length(lineinfos) < length(xs)
+        n = length(charinfos)
+        push!(lineinfos, view(charinfos, (n + 1):n))
+    end
+
     return lineinfos, xs
 end
 
@@ -121,9 +131,15 @@ function glyph_collection(
     # split the character info vector into lines after every \n
     lineinfos, xs = create_lineinfos(charinfos, word_wrap_width)
 
+    # For an empty trailing line (caused by a terminating '\n'), borrow metrics
+    # from the '\n' that ended the previous line so it still occupies vertical
+    # space and contributes to alignment / bounding boxes.
+    metric_char(i) = isempty(lineinfos[i]) ? last(lineinfos[i - 1]) : last(lineinfos[i])
+
     # calculate linewidths as the last origin plus hadvance for each line
     linewidths = map(lineinfos, xs) do line, xx
         nchars = length(line)
+        nchars == 0 && return 0.0f0  # empty trailing line (after a final '\n')
         # if the last and not the only character is \n, take the previous one
         # to compute the width
         i = (nchars > 1 && line[end].char == '\n') ? nchars - 1 : nchars
@@ -145,9 +161,10 @@ function glyph_collection(
     end
 
     # each character carries a "lineheight" metric given its font and scale and a lineheight scaling factor
-    # make each line's height the maximum of these values in the line
-    lineheights = map(lineinfos) do line
-        maximum(l -> l.lineheight, line)
+    # make each line's height the maximum of these values in the line.
+    lineheights = map(eachindex(lineinfos)) do i
+        line = lineinfos[i]
+        isempty(line) ? metric_char(i).lineheight : maximum(l -> l.lineheight, line)
     end
 
     # compute y values by adding up lineheights in negative y direction
@@ -163,8 +180,13 @@ function glyph_collection(
         last(l.scale) * l.extent.ascender
     end
 
-    last_line_descender = minimum(lineinfos[end]) do l
-        last(l.scale) * l.extent.descender
+    last_line_descender = if isempty(lineinfos[end])
+        c = metric_char(length(lineinfos))
+        last(c.scale) * c.extent.descender
+    else
+        minimum(lineinfos[end]) do l
+            last(l.scale) * l.extent.descender
+        end
     end
 
     # compute the height of all lines together

--- a/Makie/src/makielayout/blocks/textbox.jl
+++ b/Makie/src/makielayout/blocks/textbox.jl
@@ -1,48 +1,3 @@
-using InteractiveUtils: clipboard
-
-function _reset_to_stored(cursorindex, tbox)
-    cursorindex[] = 0
-    return if isnothing(tbox.stored_string[])
-        tbox.displayed_string[] = tbox.placeholder[]
-    else
-        tbox.displayed_string[] = tbox.stored_string[]
-    end
-end
-
-function _insertchar!(c, index, displayed_chars, tbox, cursorindex)
-    if displayed_chars[] == [' ']
-        empty!(displayed_chars[])
-        index = 1
-    end
-    newchars = [displayed_chars[][1:(index - 1)]; c; displayed_chars[][index:end]]
-    tbox.displayed_string[] = join(newchars)
-    return cursorindex[] = index
-end
-
-function _removechar!(index, displayed_chars, tbox, cursorindex)
-    newchars = [displayed_chars[][1:(index - 1)]; displayed_chars[][(index + 1):end]]
-
-    if isempty(newchars)
-        newchars = [' ']
-    end
-
-    if cursorindex[] >= index
-        cursorindex[] = max(0, cursorindex[] - 1)
-    end
-
-    return tbox.displayed_string[] = join(newchars)
-end
-
-function _cursor_forward(tbox, cursorindex)
-    return if tbox.displayed_string[] != " "
-        cursorindex[] = min(length(tbox.displayed_string[]), cursorindex[] + 1)
-    end
-end
-
-function _cursor_backward(cursorindex)
-    return cursorindex[] = max(0, cursorindex[] - 1)
-end
-
 function initialize_block!(tbox::Textbox)
 
     topscene = tbox.blockscene
@@ -53,22 +8,22 @@ function initialize_block!(tbox::Textbox)
 
     scene = Scene(topscene, scenearea, camera = campixel!)
 
-    cursorindex = Observable(0)
-    setfield!(tbox, :cursorindex, cursorindex)
-
     bbox = lift(Rect2f ∘ Makie.zero_origin, topscene, scenearea)
-
     roundedrectpoints = lift(roundedrectvertices, topscene, scenearea, tbox.cornerradius, tbox.cornersegments)
 
-    tbox.displayed_string[] = isnothing(tbox.stored_string[]) ? tbox.placeholder[] : tbox.stored_string[]
+    # Initial displayed_string. Empty means "show the placeholder."
+    if isnothing(tbox.displayed_string[])
+        tbox.displayed_string[] = isnothing(tbox.stored_string[]) ? "" : tbox.stored_string[]
+    end
 
     displayed_is_valid = lift(topscene, tbox.displayed_string, tbox.validator, ignore_equal_values = true) do str, validator
         return validate_textbox(str, validator)::Bool
     end
 
     hovering = Observable(false)
-    realbordercolor = Observable{RGBAf}()
 
+    # ── Box background + border ──────────────────────────────────────────────
+    realbordercolor = Observable{RGBAf}()
     map!(
         topscene, realbordercolor, tbox.bordercolor, tbox.bordercolor_focused,
         tbox.bordercolor_focused_invalid, tbox.bordercolor_hover, tbox.focused, displayed_is_valid, hovering
@@ -86,7 +41,6 @@ function initialize_block!(tbox::Textbox)
         topscene, realboxcolor, tbox.boxcolor, tbox.boxcolor_focused,
         tbox.boxcolor_focused_invalid, tbox.boxcolor_hover, tbox.focused, displayed_is_valid, hovering
     ) do bc, bcf, bcfi, bch, focused, valid, hovering
-
         c = if focused
             valid ? bcf : bcfi
         else
@@ -95,223 +49,209 @@ function initialize_block!(tbox::Textbox)
         return to_color(c)
     end
 
-    box = poly!(
+    poly!(
         topscene, roundedrectpoints, strokewidth = tbox.borderwidth,
         strokecolor = realbordercolor,
-        color = realboxcolor, inspectable = false
+        color = realboxcolor, inspectable = false,
     )
 
-    displayed_chars = lift(ds -> [c for c in ds], topscene, tbox.displayed_string)
-
-    realtextcolor = Observable{RGBAf}()
-    map!(
-        topscene, realtextcolor, tbox.textcolor, tbox.textcolor_placeholder, tbox.focused,
-        tbox.stored_string, tbox.displayed_string
-    ) do tc, tcph, foc, cont, disp
-        # the textbox has normal text color if it's focused
-        # if it's defocused, the displayed text has to match the stored text in order
-        # to be normal colored
-        return to_color(foc || cont == disp ? tc : tcph)
+    # ── Text colour: real text vs placeholder ────────────────────────────────
+    realtextcolor = lift(topscene, tbox.textcolor, tbox.textcolor_placeholder, tbox.focused, tbox.displayed_string, tbox.stored_string) do tc, tcph, foc, disp, stored
+        # The text reads as "active" (regular color) when focused, or when the
+        # displayed string already matches what's stored.
+        return foc || disp == stored ? to_color(tc) : to_color(tcph)
     end
 
-    t = Label(
-        scene, text = tbox.displayed_string, bbox = bbox, halign = :left, valign = :top,
-        width = Auto(true), height = Auto(true), color = realtextcolor,
-        fontsize = tbox.fontsize, padding = tbox.textpadding
+    # Position the editor at the top-left of the inner area, accounting for textpadding.
+    text_origin = lift(topscene, scenearea, tbox.textpadding) do area, padding
+        # padding = (left, right, bottom, top); text uses (:left, :top) align so we anchor at the top-left
+        l, _r, _b, t = padding
+        return Point2f(l, widths(area)[2] - t)
+    end
+
+    # Placeholder is rendered as a separate text! that's visible whenever
+    # the editor has no content. It stays visible after focus and only goes
+    # away once the user types the first character.
+    placeholder_visible = lift(s -> isempty(s), tbox.displayed_string)
+    placeholder_plot = text!(
+        scene, text_origin; text = tbox.placeholder,
+        align = (:left, :top), color = tbox.textcolor_placeholder,
+        font = tbox.font, fontsize = tbox.fontsize,
+        visible = placeholder_visible, inspectable = false,
     )
 
-    textplot = t.blockscene.plots[1]
-    # Manually add positions without considering transformations to prevent
-    # infinite loop from translate!() in on(cursorpoints)
-    displayed_charbbs = map(textplot.positions, fast_glyph_boundingboxes_obs(textplot)) do pos, bbs
-        return [Rect2f(bb) + Point2f(pos[1]) for bb in bbs]
+    # ── The editable text itself ─────────────────────────────────────────────
+    et = editabletext!(
+        scene, tbox.displayed_string;
+        position = text_origin,
+        align = (:left, :top),
+        focused = tbox.focused,
+        color = realtextcolor,
+        font = tbox.font,
+        fontsize = tbox.fontsize,
+        cursor_color = tbox.cursorcolor,
+        space = :pixel,
+        multiline = false,
+        manage_focus = false,            # Textbox drives focus (see below)
+        input_filter = c -> is_allowed(c, tbox.restriction[]),
+        on_submit = (text) -> begin
+            if displayed_is_valid[]
+                tbox.stored_string[] = text
+                tbox.defocus_on_submit[] && defocus!(tbox)
+            end
+        end,
+    )
+    setfield!(tbox, :editor, et)
+
+    # Sync displayed_string ↔ the editor's text. Passing the Observable to the
+    # recipe wires the forward direction (`tb.displayed_string` → editor text);
+    # this listener carries internal edits back out.
+    on(et.text) do t
+        if tbox.displayed_string[] != t
+            tbox.displayed_string[] = t
+        end
+        return
     end
 
-    cursorsize = Observable(Vec2f(1, tbox.fontsize[]))
-    cursorpoints = lift(topscene, cursorindex, displayed_charbbs; ignore_equal_values = true) do ci, bbs
-        isempty(bbs) && return Point2f(0)
-        local textplot = t.blockscene.plots[1]
-
-        hadvances = Float32[]
-        broadcast_foreach(textplot.glyph_extents[], textplot.text_scales[]) do ex, sc
-            hadvance = ex.hadvance * sc[1]
-            push!(hadvances, hadvance)
-        end
-
-        if ci > length(bbs)
-            # correct cursorindex if it's outside of the displayed charbbs range
-            ci = cursorindex[] = length(bbs)
-        end
-
-        line_ps = if 0 < ci < length(bbs)
-            leftline(bbs[ci + 1])
-        elseif ci == 0
-            leftline(bbs[1])
+    # ── Autosize ─────────────────────────────────────────────────────────────
+    # Listen on the *inputs* (displayed_string, font, fontsize, padding) rather
+    # than on the rendered bbox observable; reading the bbox inside the callback
+    # avoids the layout-feedback cycle (autosize → scenearea → text_origin →
+    # text plot bbox) that listening directly to the bbox would cause.
+    text_plot = only(p for p in et.plots if p isa Makie.Text)
+    onany(topscene, tbox.displayed_string, tbox.placeholder, tbox.fontsize, tbox.font, tbox.textpadding) do disp, ph, fs, _fnt, padding
+        l, r, b, t = padding
+        # Width from the rendered text bbox (placeholder while empty, real text
+        # once typed). Height is computed from line count + font metrics so an
+        # empty trailing line (`disp` ends with `\n`) still grows the textbox.
+        # Using a position-independent bbox here avoids registering a second
+        # projected pipeline and the layout feedback cycle.
+        plot = isempty(disp) ? placeholder_plot : text_plot
+        bbs = Makie.fast_string_boundingboxes(plot)
+        text_w = if isempty(bbs) || !isfinite(minimum(bbs[1])[1])
+            Float32(fs) * 0.5f0
         else
-            leftline(bbs[ci]) .+ (Point2f(hadvances[ci], 0),)
+            Float32(widths(bbs[1])[1])
         end
-
-        # could this be done statically as
-        # max_height = font.height / font.units_per_EM * fontsize
-        max_height = abs(line_ps[1][2] - line_ps[2][2])
-        if !(cursorsize[][2] ≈ max_height)
-            cursorsize[] = Vec2f(1, max_height)
-        end
-
-        return 0.5 * (line_ps[1] + line_ps[2])
+        # n_lines counts visible lines including a trailing empty line.
+        sample = isempty(disp) ? ph : disp
+        n_lines = count(==('\n'), sample) + 1
+        font_obj = plot.selected_font[]::Makie.NativeFont
+        line_h = Float32(font_obj.height / font_obj.units_per_EM * fs)
+        text_h = Float32(n_lines) * line_h
+        tbox.layoutobservables.autosize[] = (text_w + l + r, text_h + b + t)
+        return
     end
 
-    cursor = scatter!(
-        scene, cursorpoints, marker = Rect, color = tbox.cursorcolor,
-        markersize = cursorsize, inspectable = false
-    )
-
-    on(cursorpoints) do cpts
-        typeof(tbox.width[]) <: Number || return
-        isempty(displayed_charbbs[]) && return
-
-        # translate scene to keep cursor within box
-        rel_cursor_pos = cpts[1][1] + scene.transformation.translation[][1]
-        offset = if rel_cursor_pos <= 0
-            -rel_cursor_pos
-        elseif rel_cursor_pos < tbox.width[]
-            0
-        else
-            tbox.width[] - rel_cursor_pos
-        end
-        translate!(Accum, scene, offset, 0, 0)
-
-        # don't let right side of box be empty if length of text exceeds box width
-        offset = tbox.width[] - right(displayed_charbbs[][end])
-        scene.transformation.translation[][1] < offset < 0 && translate!(scene, offset, 0, 0)
-    end
-
-    tbox.cursoranimtask = nothing
-
-    on(topscene, t.layoutobservables.reporteddimensions) do dims
-        tbox.layoutobservables.autosize[] = dims.inner
-    end
-
-    # trigger text for autosize
-    t.text = tbox.displayed_string[]
-
-    # trigger bbox
-    tbox.layoutobservables.suggestedbbox[] = tbox.layoutobservables.suggestedbbox[]
-
+    # ── Hover tracking ───────────────────────────────────────────────────────
     mouseevents = addmouseevents!(scene)
-
-    onmouseleftdown(mouseevents) do state
-        focus!(tbox)
-
-        if tbox.displayed_string[] == tbox.placeholder[]
-            tbox.displayed_string[] = " "
-            cursorindex[] = 0
-            return Consume(true)
-        elseif tbox.displayed_string[] == " "
-            return Consume(true)
-        end
-
-        pos = if typeof(tbox.width[]) <: Number
-            state.data .- scene.transformation.translation[][1:2]
-        else
-            state.data
-        end
-        closest_charindex = argmin(
-            [sum((pos .- center(bb)) .^ 2) for bb in displayed_charbbs[]]
-        )
-        # set cursor to index of closest char if right of center, or previous char if left of center
-        cursorindex[] = if (pos .- center(displayed_charbbs[][closest_charindex]))[1] > 0
-            closest_charindex
-        else
-            closest_charindex - 1
-        end
-
-        return Consume(true)
-    end
-
-    onmouseover(mouseevents) do state
+    onmouseover(mouseevents) do _
         hovering[] = true
         return Consume(false)
     end
-
-    onmouseout(mouseevents) do state
+    onmouseout(mouseevents) do _
         hovering[] = false
         return Consume(false)
     end
 
-    onmousedownoutside(mouseevents) do state
-        if tbox.reset_on_defocus[]
-            _reset_to_stored(cursorindex, tbox)
-        end
-        defocus!(tbox)
-        return Consume(false)
-    end
-
-    function appendchar!(c)
-        return _insertchar!(c, length(tbox.displayed_string[]), displayed_chars, tbox, cursorindex)
-    end
-
-    on(topscene, events(scene).unicode_input; priority = 60) do char
-        if tbox.focused[] && is_allowed(char, tbox.restriction[])
-            _insertchar!(char, cursorindex[] + 1, displayed_chars, tbox, cursorindex)
-            return Consume(true)
-        end
-        return Consume(false)
-    end
-
-
-    on(topscene, events(scene).keyboardbutton; priority = 60) do event
-        if tbox.focused[]
-            ctrl_v = (Keyboard.left_control | Keyboard.right_control) & Keyboard.v
-            if ispressed(scene, ctrl_v)
-                local content::String = ""
-                try
-                    content = clipboard()
-                catch err
-                    @warn "Accessing the clipboard failed: $err"
-                    return Consume(false)
-                end
-
-                if all(char -> is_allowed(char, tbox.restriction[]), content)
-                    foreach(char -> _insertchar!(char, cursorindex[] + 1, displayed_chars, tbox, cursorindex), content)
-                    return Consume(true)
-                else
-                    return Consume(false)
-                end
-            end
-
-            if event.action != Keyboard.release
-                key = event.key
-                if key == Keyboard.backspace
-                    _removechar!(cursorindex[], displayed_chars, tbox, cursorindex)
-                elseif key == Keyboard.delete
-                    _removechar!(cursorindex[] + 1, displayed_chars, tbox, cursorindex)
-                elseif key == Keyboard.enter || key == Keyboard.kp_enter
-                    # don't do anything for invalid input which should stay red
-                    if displayed_is_valid[]
-                        # submit the written text
-                        tbox.stored_string[] = tbox.displayed_string[]
-                        if tbox.defocus_on_submit[]
-                            defocus!(tbox)
-                        end
-                    end
-                elseif key == Keyboard.escape
-                    if tbox.reset_on_defocus[]
-                        _reset_to_stored(cursorindex, tbox)
-                    end
+    # ── Focus on click ───────────────────────────────────────────────────────
+    # Listen at priority 70, *above* EditableText's priority 60, so we set
+    # `focused` before the recipe inspects it (the recipe runs in
+    # `manage_focus = false` mode and only places a cursor when already focused).
+    on(topscene, events(scene).mousebutton, priority = 70) do event
+        event.button == Mouse.left || return Consume(false)
+        if event.action == Mouse.press
+            inside = Makie.is_mouseinside(scene)
+            if inside
+                tbox.focused[] || focus!(tbox)
+            else
+                if tbox.focused[]
+                    tbox.reset_on_defocus[] && _reset_to_stored!(tbox)
                     defocus!(tbox)
-                elseif key == Keyboard.right
-                    _cursor_forward(tbox, cursorindex)
-                elseif key == Keyboard.left
-                    _cursor_backward(cursorindex)
                 end
             end
-            return Consume(true)
         end
-
         return Consume(false)
     end
+
+    # ── Reset on Escape ──────────────────────────────────────────────────────
+    on(topscene, events(scene).keyboardbutton, priority = 70) do event
+        # Higher priority than EditableText (60) so we get to handle escape
+        # *and* let it pass through to the recipe's defocus path.
+        if tbox.focused[] && event.action == Keyboard.press && event.key == Keyboard.escape
+            if tbox.reset_on_defocus[]
+                _reset_to_stored!(tbox)
+            end
+            # EditableText also defocuses on escape; we let it through.
+        end
+        return Consume(false)
+    end
+
+    # ── Horizontal scroll when content exceeds the visible width ─────────────
+    # The inner `scene` holds the editor; translating it horizontally keeps the
+    # caret in view as the user types or moves past the right edge. We compute
+    # the caret's position in *text-layout* coordinates from the glyph data so
+    # the listener is invariant to the scene translation it produces — listening
+    # on the rendered caret plot would be a feedback loop because
+    # `markerspace_positions` depend on the scene's model matrix.
+    function _caret_layout_x()
+        head = isempty(et.cursors[]) ? 0 : et.cursors[][1].head
+        origins = text_plot.glyph_origins[]
+        head <= 0 && return 0.0f0
+        if head < length(origins)
+            return Float32(origins[head + 1][1])
+        elseif head == length(origins) && !isempty(origins)
+            extents = text_plot.glyph_extents[]
+            scales = text_plot.text_scales[]
+            return Float32(origins[end][1] + extents[end].hadvance * scales[end][1])
+        else
+            return 0.0f0
+        end
+    end
+
+    onany(topscene, et.cursors, text_plot.glyph_origins, scenearea) do _cs, _origins, area
+        typeof(tbox.width[]) <: Number || return
+        l, r, _b, _t = tbox.textpadding[]
+        # The text starts `l` pixels in; the right edge of the visible text region
+        # is `area.widths[1] - r`. Keep the caret inside that strip.
+        caret_x = l + _caret_layout_x()
+        tx = Float32(scene.transformation.translation[][1])
+        rel_x = caret_x + tx
+        right = Float32(area.widths[1]) - r
+        offset = if rel_x < l
+            l - rel_x
+        elseif rel_x > right
+            right - rel_x
+        else
+            0.0f0
+        end
+        offset == 0 || translate!(Accum, scene, offset, 0, 0)
+
+        # When the text shrinks past the right edge, pull it back so the box
+        # isn't padded with empty space.
+        origins = text_plot.glyph_origins[]
+        isempty(origins) && return
+        extents = text_plot.glyph_extents[]
+        scales = text_plot.text_scales[]
+        text_right = Float32(l + origins[end][1] + extents[end].hadvance * scales[end][1])
+        gap = right - (text_right + Float32(scene.transformation.translation[][1]))
+        tx2 = Float32(scene.transformation.translation[][1])
+        if tx2 < 0 && gap > 0
+            translate!(Accum, scene, min(gap, -tx2), 0, 0)
+        end
+        return
+    end
+
+    # Trigger initial autosize and bbox so the layout settles.
+    notify(tbox.displayed_string)
+    tbox.layoutobservables.suggestedbbox[] = tbox.layoutobservables.suggestedbbox[]
+
     return tbox
+end
+
+function _reset_to_stored!(tbox::Textbox)
+    tbox.displayed_string[] = isnothing(tbox.stored_string[]) ? "" : tbox.stored_string[]
+    return
 end
 
 function validate_textbox(str, validator::Function)
@@ -324,17 +264,11 @@ end
 
 function validate_textbox(str, validator::Regex)
     m = match(validator, str)
-    # check that the validator matches the whole string
     return !isnothing(m) && m.match == str
 end
 
-function is_allowed(char, restriction::Nothing)
-    return true
-end
-
-function is_allowed(char, restriction::Function)
-    return allowed::Bool = restriction(char)
-end
+is_allowed(_, ::Nothing) = true
+is_allowed(char, restriction::Function) = restriction(char)::Bool
 
 """
     reset!(tb::Textbox)
@@ -342,7 +276,7 @@ Resets the stored_string of the given `Textbox` to `nothing` without triggering 
 """
 function reset!(tb::Textbox)
     tb.stored_string.val = nothing
-    tb.displayed_string = tb.placeholder[]
+    tb.displayed_string = ""
     defocus!(tb)
     return nothing
 end
@@ -374,27 +308,7 @@ end
 Focuses an `Textbox` and makes it ready to receive keyboard input.
 """
 function focus!(tb::Textbox)
-    if !tb.focused[]
-        tb.focused = true
-
-        cursoranim = Animations.Loop(
-            Animations.Animation(
-                [0, 1.0],
-                [Colors.alphacolor(COLOR_ACCENT[], 0), Colors.alphacolor(COLOR_ACCENT[], 1)],
-                Animations.sineio(n = 2, yoyo = true, postwait = 0.2)
-            ),
-            0.0, 0.0, 1000
-        )
-
-        if !isnothing(tb.cursoranimtask)
-            Animations.stop(tb.cursoranimtask)
-            tb.cursoranimtask = nothing
-        end
-
-        tb.cursoranimtask = Animations.animate_async(cursoranim; fps = 30) do t, color
-            tb.cursorcolor = color
-        end
-    end
+    tb.focused = true
     return nothing
 end
 
@@ -403,16 +317,6 @@ end
 Defocuses a `Textbox` so it doesn't receive keyboard input.
 """
 function defocus!(tb::Textbox)
-
-    if tb.displayed_string[] in (" ", "")
-        tb.displayed_string[] = tb.placeholder[]
-    end
-
-    if !isnothing(tb.cursoranimtask)
-        Animations.stop(tb.cursoranimtask)
-        tb.cursoranimtask = nothing
-    end
-    tb.cursorcolor = :transparent
     tb.focused = false
     return nothing
 end

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1669,8 +1669,9 @@ end
 end
 
 @Block Textbox begin
-    cursorindex::Observable{Int}
-    cursoranimtask
+    # `editor` exposes the embedded `EditableText` recipe so tests / advanced
+    # consumers can drive cursor and selection state directly. Internal.
+    editor::Any
     @attributes begin
         "The height setting of the textbox."
         height = Auto()
@@ -1735,7 +1736,7 @@ end
         "Restricts the allowed unicode input via is_allowed(char, restriction)."
         restriction = nothing
         "The color of the cursor."
-        cursorcolor = :transparent
+        cursorcolor = COLOR_ACCENT[]
     end
 end
 

--- a/Makie/src/recipes.jl
+++ b/Makie/src/recipes.jl
@@ -409,6 +409,22 @@ macro recipe(Tsym::Symbol, attrblock)
     return create_recipe_expr(Tsym, nothing, attrblock)
 end
 
+"""
+    @recipe_internal MyPlot ...
+
+Like `@recipe`, but does not `export` the generated `MyPlot` type alias or the
+`myplot` / `myplot!` constructors. Use for recipes whose API is still being
+worked out and which should only be reachable via the qualified `Makie.…` form
+until they stabilise.
+"""
+macro recipe_internal(Tsym::Symbol, attrblock)
+    return create_recipe_expr(Tsym, nothing, attrblock; export_recipe = false)
+end
+
+macro recipe_internal(Tsym::Symbol, args, attrblock)
+    return create_recipe_expr(Tsym, args, attrblock; export_recipe = false)
+end
+
 macro recipe(Tsym::Symbol, args, attrblock)
     return create_recipe_expr(Tsym, args, attrblock)
 end
@@ -471,7 +487,7 @@ function extract_docstring(str)
     end
 end
 
-function create_recipe_expr(Tsym, args, attrblock)
+function create_recipe_expr(Tsym, args, attrblock; export_recipe::Bool = true)
     funcname_sym = to_func_name(Tsym)
     funcname!_sym = Symbol("$(funcname_sym)!")
     funcname! = esc(funcname!_sym)
@@ -540,7 +556,7 @@ function create_recipe_expr(Tsym, args, attrblock)
         @doc docstring_modified $funcname_sym
         @doc "`$($(string(Tsym)))` is the plot type associated with plotting function `$($(string(funcname_sym)))`. Check the docstring for `$($(string(funcname_sym)))` for further information." $Tsym
         @doc "`$($(string(funcname!_sym)))` is the mutating variant of plotting function `$($(string(funcname_sym)))`. Check the docstring for `$($(string(funcname_sym)))` for further information." $funcname!_sym
-        export $PlotType, $funcname, $funcname!
+        $(export_recipe ? :(export $PlotType, $funcname, $funcname!) : nothing)
     end
 
     if !isempty(syms)

--- a/Makie/test/interactivity/DataInspector.jl
+++ b/Makie/test/interactivity/DataInspector.jl
@@ -6,8 +6,8 @@
         @test Makie.position2string(Vec(pi, pi)) == "x: 3.141593\ny: 3.141593"
         @test Makie.position2string(Vec(pi, pi, pi)) == "x: 3.141593\ny: 3.141593\nz: 3.141593"
 
-        @test Makie.bbox2string(Rect2(pi, pi, 1, 1)) == "Bounding Box:\n x: (3.142, 4.142)\n y: (3.142, 4.142)\n"
-        @test Makie.bbox2string(Rect3(Point3(pi), Vec3(1))) == "Bounding Box:\n x: (3.142, 4.142)\n y: (3.142, 4.142)\n z: (3.142, 4.142)\n"
+        @test Makie.bbox2string(Rect2(pi, pi, 1, 1)) == "Bounding Box:\n x: (3.142, 4.142)\n y: (3.142, 4.142)"
+        @test Makie.bbox2string(Rect3(Point3(pi), Vec3(1))) == "Bounding Box:\n x: (3.142, 4.142)\n y: (3.142, 4.142)\n z: (3.142, 4.142)"
 
         @test Makie.color2text(pi) == "3.142"
         @test Makie.color2text(:red) == "red"

--- a/Makie/test/interactivity/EditableText.jl
+++ b/Makie/test/interactivity/EditableText.jl
@@ -10,7 +10,7 @@ end
 
 function _hold(f, events, mod)
     push!(events.keyboardstate, mod)
-    try
+    return try
         f()
     finally
         delete!(events.keyboardstate, mod)

--- a/Makie/test/interactivity/EditableText.jl
+++ b/Makie/test/interactivity/EditableText.jl
@@ -1,0 +1,426 @@
+using Makie: EditCursor, EditableText, editabletext!
+using InteractiveUtils: clipboard
+
+# Helpers to drive the recipe via synthesized events.
+function _press_release(events, key)
+    events.keyboardbutton[] = Makie.KeyEvent(key, Keyboard.press)
+    events.keyboardbutton[] = Makie.KeyEvent(key, Keyboard.release)
+    return
+end
+
+function _hold(f, events, mod)
+    push!(events.keyboardstate, mod)
+    try
+        f()
+    finally
+        delete!(events.keyboardstate, mod)
+    end
+end
+
+function _make_editor(text = ""; cursors = [EditCursor(0)], focused = true, fontsize = 22, position = Point2f(20, 50))
+    f = Figure(size = (400, 100))
+    sc = Scene(f.scene; camera = campixel!)
+    et = editabletext!(sc, text; position = position, fontsize = fontsize, focused = focused, cursors = cursors)
+    Makie.update_state_before_display!(f)
+    return f, et
+end
+
+@testset "EditableText" begin
+    @testset "Word and line offsets" begin
+        chars = collect("hello world foo")
+        @test Makie.next_word_offset(chars, 0) == 5
+        @test Makie.next_word_offset(chars, 5) == 11
+        @test Makie.next_word_offset(chars, 14) == 15
+        @test Makie.prev_word_offset(chars, 15) == 12
+        @test Makie.prev_word_offset(chars, 12) == 6
+        @test Makie.prev_word_offset(chars, 6) == 0
+        @test Makie.word_at_offset(chars, 8) == (6, 11)
+        @test Makie.word_at_offset(chars, 5) == (0, 5)  # right at edge, prefers right side
+        @test Makie.word_at_offset(chars, 11) == (6, 11)  # right at edge, prefers left
+
+        ml = collect("abc\ndef\nxyz")
+        @test Makie.line_at_offset(ml, 0) == (0, 3)
+        @test Makie.line_at_offset(ml, 3) == (0, 3)
+        @test Makie.line_at_offset(ml, 4) == (4, 7)
+        @test Makie.line_at_offset(ml, 8) == (8, 11)
+    end
+
+    @testset "Cursor merging" begin
+        @test Makie.merge_cursors(EditCursor[]) == []
+        # Touching ranges merge
+        merged = Makie.merge_cursors([EditCursor(0, 3), EditCursor(3, 5)])
+        @test length(merged) == 1
+        @test Makie.sel_lo(merged[1]) == 0
+        @test Makie.sel_hi(merged[1]) == 5
+        # Non-overlapping stay separate, sorted by lo
+        merged = Makie.merge_cursors([EditCursor(7), EditCursor(2)])
+        @test length(merged) == 2
+        @test merged[1].head == 2
+        @test merged[2].head == 7
+    end
+
+    @testset "apply_edits — single cursor" begin
+        # Insert
+        new_text, new_cursors = Makie.apply_edits("hello", [EditCursor(2)], c -> Makie.EditOp(2:2, "X"))
+        @test new_text == "heXllo"
+        @test new_cursors == [EditCursor(3)]
+        # Delete (selection)
+        new_text, new_cursors = Makie.apply_edits("hello", [EditCursor(1, 4)], c -> Makie.EditOp(1:4, ""))
+        @test new_text == "ho"
+        @test new_cursors == [EditCursor(1)]
+    end
+
+    @testset "apply_edits — multi-cursor" begin
+        # Insert at two cursors → text grows, cursors track properly
+        new_text, new_cursors = Makie.apply_edits("hello world", [EditCursor(0), EditCursor(6)], c -> Makie.EditOp(Makie.sel_lo(c):Makie.sel_hi(c), "X"))
+        @test new_text == "Xhello Xworld"
+        @test [c.head for c in new_cursors] == [1, 8]
+
+        # Overlapping selections collapse — the second op's insert is dropped
+        # so we don't double-insert "X" in the overlap, and both cursors land
+        # on the same final position.
+        new_text, new_cursors = Makie.apply_edits(
+            "abcdefgh",
+            [EditCursor(0, 5), EditCursor(3, 7)],
+            c -> Makie.EditOp(Makie.sel_lo(c):Makie.sel_hi(c), "X"),
+        )
+        @test new_text == "Xh"
+        @test new_cursors == [EditCursor(1)]   # merge_cursors collapses duplicates
+    end
+
+    @testset "Type, backspace, delete" begin
+        f, et = _make_editor("Hi"; cursors = [EditCursor(0)])
+        ev = events(f)
+        ev.unicode_input[] = 'a'
+        @test et.text[] == "aHi"
+        @test et.cursors[] == [EditCursor(1)]
+        ev.unicode_input[] = 'b'
+        ev.unicode_input[] = 'c'
+        @test et.text[] == "abcHi"
+        _press_release(ev, Keyboard.backspace)
+        @test et.text[] == "abHi"
+        _press_release(ev, Keyboard.delete)
+        @test et.text[] == "abi"
+    end
+
+    @testset "Arrow movement" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0)])
+        ev = events(f)
+        _press_release(ev, Keyboard.right)
+        @test et.cursors[] == [EditCursor(1)]
+        _hold(ev, Keyboard.left_alt) do
+            _press_release(ev, Keyboard.right)
+        end
+        @test et.cursors[] == [EditCursor(5)]  # end of "hello"
+        _hold(ev, Keyboard.left_shift) do
+            _press_release(ev, Keyboard.right)
+        end
+        @test et.cursors[] == [EditCursor(5, 6)]  # extended into the space
+        _hold(ev, Keyboard.left_alt) do
+            _hold(ev, Keyboard.left_shift) do
+                _press_release(ev, Keyboard.right)
+            end
+        end
+        @test et.cursors[] == [EditCursor(5, 11)]  # extended to end of "world"
+    end
+
+    @testset "Vertical movement" begin
+        f, et = _make_editor("abcd\nefgh"; cursors = [EditCursor(7)])  # in line 2
+        ev = events(f)
+        _press_release(ev, Keyboard.up)
+        # Should land near offset 2 or 3 (line 1 closest x)
+        @test 1 <= et.cursors[][1].head <= 3
+        _press_release(ev, Keyboard.down)
+        # Back near offset 7 (line 2)
+        @test 6 <= et.cursors[][1].head <= 8
+    end
+
+    @testset "Word and line delete" begin
+        f, et = _make_editor("hello world foo"; cursors = [EditCursor(15)])
+        ev = events(f)
+        _hold(ev, Keyboard.left_alt) do
+            _press_release(ev, Keyboard.backspace)
+        end
+        @test et.text[] == "hello world "
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.backspace)
+        end
+        @test et.text[] == ""
+        @test et.cursors[] == [EditCursor(0)]
+    end
+
+    @testset "Newline insertion via enter" begin
+        f, et = _make_editor("abc"; cursors = [EditCursor(3)])
+        ev = events(f)
+        _press_release(ev, Keyboard.enter)
+        @test et.text[] == "abc\n"
+        ev.unicode_input[] = 'd'
+        @test et.text[] == "abc\nd"
+        @test et.cursors[][1].head == 5
+    end
+
+    @testset "Click positions cursor" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0)], focused = false)
+        ev = events(f)
+        # Click somewhere in the middle of the text — exact glyph positions depend on font metrics
+        # so we just check focus + that the cursor moved into the string.
+        ev.mouseposition[] = (60.0, 50.0)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+        @test et.focused[] == true
+        @test 0 < et.cursors[][1].head <= 11
+    end
+
+    @testset "Double-click selects word, triple-click selects line" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0)], focused = false)
+        ev = events(f)
+        ev.mouseposition[] = (90.0, 50.0)  # somewhere inside "world"
+        # double-click within the click-detection window
+        for i in 1:2
+            ev.tick[] = Makie.Tick(Makie.RegularRenderTick, i, 0.1 * i, 0.1)
+            ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+            ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+        end
+        c = et.cursors[][1]
+        @test (Makie.sel_lo(c), Makie.sel_hi(c)) == (6, 11)  # "world"
+        # triple-click — selects whole line (= all content here)
+        ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 3, 0.35, 0.1)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+        c = et.cursors[][1]
+        @test (Makie.sel_lo(c), Makie.sel_hi(c)) == (0, 11)
+    end
+
+    @testset "Cmd + double/triple click extends multi-cursor" begin
+        f, et = _make_editor("hello world foo bar"; cursors = [EditCursor(0)], focused = false)
+        ev = events(f)
+
+        # Plain click at offset 0 — single cursor, no selection.
+        ev.mouseposition[] = (22.0, 50.0)
+        ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 1, 0.1, 0.1)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+        @test length(et.cursors[]) == 1
+
+        # Cmd+double-click on a word elsewhere — should ADD the word selection
+        # to the existing cursors, not replace them.
+        ev.mouseposition[] = (90.0, 50.0)  # somewhere inside "world"
+        _hold(ev, Keyboard.left_super) do
+            for i in 2:3
+                ev.tick[] = Makie.Tick(Makie.RegularRenderTick, i, 0.1 * i, 0.1)
+                ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+                ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+            end
+        end
+        cursors = et.cursors[]
+        @test length(cursors) == 2
+        @test (Makie.sel_lo(cursors[2]), Makie.sel_hi(cursors[2])) == (6, 11)  # "world"
+
+        # Cmd+triple-click adds a line selection on top.
+        _hold(ev, Keyboard.left_super) do
+            ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 4, 0.4, 0.1)
+            ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+            ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+        end
+        # Adding a line selection (whole "hello world foo bar") swallows the
+        # earlier word selection at offsets (6, 11), so cursors collapse to a
+        # single (0, 19) range via `merge_cursors`.
+        @test length(et.cursors[]) == 1
+        @test (Makie.sel_lo(et.cursors[][1]), Makie.sel_hi(et.cursors[][1])) == (0, 19)
+    end
+
+    @testset "Selection rectangles hidden when defocused" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0, 5)], focused = true)
+        Makie.update_state_before_display!(f)
+        poly_plot = only(p for p in et.plots if p isa Poly)
+        @test poly_plot.visible[] == true
+        et.focused[] = false
+        @test poly_plot.visible[] == false
+        # Re-focus → reappears
+        et.focused[] = true
+        @test poly_plot.visible[] == true
+    end
+
+    @testset "Drag extends selection" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0)], focused = false)
+        ev = events(f)
+        ev.mouseposition[] = (90.0, 50.0)
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
+        anchor_offset = et.cursors[][1].head
+        ev.mouseposition[] = (40.0, 50.0)  # drag left
+        c = et.cursors[][1]
+        @test c.anchor == anchor_offset
+        @test c.head < anchor_offset
+        ev.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.release)
+    end
+
+    @testset "Multi-cursor typing" begin
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0), EditCursor(6)])
+        ev = events(f)
+        ev.unicode_input[] = 'X'
+        @test et.text[] == "Xhello Xworld"
+        @test [c.head for c in et.cursors[]] == [1, 8]
+    end
+
+    @testset "Multi-line selection rectangles" begin
+        # Check that a selection spanning three lines produces three rectangles.
+        f = Figure(size = (300, 200))
+        sc = Scene(f.scene; camera = campixel!)
+        et = editabletext!(
+            sc, "abc\ndef\nghi"; position = Point2f(20, 150), fontsize = 22,
+            focused = true, cursors = [EditCursor(1, 10)],
+        )
+        Makie.update_state_before_display!(f)
+        # Find the poly sub-plot by type; arg1 is its Vector{Rect2f} input.
+        rects = only(p for p in et.plots if p isa Poly).arg1[]
+        @test length(rects) == 3
+    end
+
+    @testset "Escape defocuses" begin
+        f, et = _make_editor("abc"; cursors = [EditCursor(0)])
+        ev = events(f)
+        @test et.focused[] == true
+        _press_release(ev, Keyboard.escape)
+        @test et.focused[] == false
+        # Subsequent keys are ignored
+        ev.unicode_input[] = 'q'
+        @test et.text[] == "abc"
+    end
+
+    @testset "Submit / multiline modes" begin
+        # multiline = true: Enter inserts \n, Cmd+Enter submits.
+        let
+            submitted = Ref{Union{Nothing, String}}(nothing)
+            f, et = _make_editor("abc"; cursors = [EditCursor(3)])
+            et.multiline[] = true
+            et.on_submit[] = text -> (submitted[] = text)
+            ev = events(f)
+            _press_release(ev, Keyboard.enter)
+            @test et.text[] == "abc\n"
+            @test submitted[] === nothing
+            _hold(ev, Keyboard.left_super) do
+                _press_release(ev, Keyboard.enter)
+            end
+            @test submitted[] == "abc\n"
+        end
+        # multiline = false: Enter submits, Shift+Enter inserts \n.
+        let
+            submitted = Ref{Union{Nothing, String}}(nothing)
+            f, et = _make_editor("abc"; cursors = [EditCursor(3)])
+            et.multiline[] = false
+            et.on_submit[] = text -> (submitted[] = text)
+            ev = events(f)
+            _press_release(ev, Keyboard.enter)
+            @test et.text[] == "abc"  # no newline inserted
+            @test submitted[] == "abc"
+            _hold(ev, Keyboard.left_shift) do
+                _press_release(ev, Keyboard.enter)
+            end
+            @test et.text[] == "abc\n"
+        end
+    end
+
+    @testset "input_filter rejects characters" begin
+        f, et = _make_editor(""; cursors = [EditCursor(0)])
+        et.input_filter[] = c -> isdigit(c)
+        ev = events(f)
+        ev.unicode_input[] = 'a'
+        @test et.text[] == ""
+        ev.unicode_input[] = '7'
+        @test et.text[] == "7"
+        # Newlines bypass the filter (Enter in multiline mode)
+        _press_release(ev, Keyboard.enter)
+        @test et.text[] == "7\n"
+    end
+
+    @testset "Copy / cut / paste" begin
+        # Round-trip via the system clipboard; on a CI box this still works
+        # because Julia's `clipboard(text)` and `clipboard()` use the same
+        # in-process fallback.
+        f, et = _make_editor("hello world"; cursors = [EditCursor(0, 5)])
+        ev = events(f)
+
+        # Cmd+C copies the selection to the clipboard, leaving text/cursors alone.
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.c)
+        end
+        @test et.text[] == "hello world"
+        @test et.cursors[] == [EditCursor(0, 5)]
+        @test clipboard() == "hello"
+
+        # Cmd+X cuts: clipboard gets the selection, text loses it.
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.x)
+        end
+        @test et.text[] == " world"
+        @test clipboard() == "hello"
+
+        # Cmd+V pastes at every cursor.
+        clipboard("XX")
+        et.cursors[] = [EditCursor(0), EditCursor(3)]
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.v)
+        end
+        @test et.text[] == "XX woXXrld"
+
+        # Paste filters chars through `input_filter` (single-line semantics).
+        clipboard("a\nb\nc")
+        f2, et2 = _make_editor(""; cursors = [EditCursor(0)])
+        et2.input_filter[] = c -> c != '\n'
+        _hold(events(f2), Keyboard.left_super) do
+            _press_release(events(f2), Keyboard.v)
+        end
+        @test et2.text[] == "abc"
+    end
+
+    @testset "Cmd+D selects next occurrence; Cmd+Shift+D selects previous" begin
+        f, et = _make_editor("hello world hello world"; cursors = [EditCursor(2)], focused = true)
+        ev = events(f)
+
+        # First Cmd+D expands the bare cursor to the word it sits in.
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.d)
+        end
+        @test length(et.cursors[]) == 1
+        @test (Makie.sel_lo(et.cursors[][1]), Makie.sel_hi(et.cursors[][1])) == (0, 5)
+
+        # Next Cmd+D adds the next occurrence of "hello" as a new cursor.
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.d)
+        end
+        @test length(et.cursors[]) == 2
+        @test (Makie.sel_lo(et.cursors[][end]), Makie.sel_hi(et.cursors[][end])) == (12, 17)
+
+        # No more "hello" occurrences forward — Cmd+D is a no-op.
+        _hold(ev, Keyboard.left_super) do
+            _press_release(ev, Keyboard.d)
+        end
+        @test length(et.cursors[]) == 2
+
+        # Cmd+Shift+D from a "world" position finds the previous "world".
+        et.cursors[] = [EditCursor(18, 23)]   # the second "world"
+        _hold(ev, Keyboard.left_super) do
+            _hold(ev, Keyboard.left_shift) do
+                _press_release(ev, Keyboard.d)
+            end
+        end
+        @test length(et.cursors[]) == 2
+        offsets = Set((Makie.sel_lo(c), Makie.sel_hi(c)) for c in et.cursors[])
+        @test (6, 11) in offsets
+        @test (18, 23) in offsets
+    end
+
+    @testset "Cursor blink driven by render ticks" begin
+        f, et = _make_editor("abc"; cursors = [EditCursor(1)])
+        ev = events(f)
+        # Just before the post-edit pause expires — cursor should still be solid (alpha 1)
+        ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 1, 0.1, 0.05)
+        # After the pause, in the "off" half of the blink cycle — alpha goes to 0
+        # We can't easily inspect alpha (it's a closure-local Observable) but we
+        # can at least verify ticking doesn't crash and the cursor segments are
+        # always there (positions are independent of alpha).
+        ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 2, 1.0, 0.9)
+        ev.tick[] = Makie.Tick(Makie.RegularRenderTick, 3, 1.5, 0.5)
+        @test length(only(p for p in et.plots if p isa LineSegments).arg1[]) == 2  # one cursor → 2 endpoints
+    end
+end

--- a/Makie/test/runtests.jl
+++ b/Makie/test/runtests.jl
@@ -77,6 +77,7 @@ end
         include("interactivity/Axis.jl")
         include("interactivity/Axis3.jl")
         include("interactivity/DataInspector.jl")
+        include("interactivity/EditableText.jl")
     end
 
     include("boundingboxes.jl")

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -735,14 +735,14 @@ end
 
     tb2 = Makie.Textbox(f[2, 1], width = 100)
     Makie.set!(tb2, "1234567890qwertyuiop")
-    tb2.cursorindex[] = 20
+    tb2.editor.cursors[] = [Makie.EditCursor(20)]
     Makie.focus!(tb2)
     send(e, Keyboard.backspace)
     Makie.defocus!(tb2)
 
     tb3 = Makie.Textbox(f[3, 1], width = 100)
     Makie.set!(tb3, "1234567890qwertyuiop")
-    tb3.cursorindex[] = 20
+    tb3.editor.cursors[] = [Makie.EditCursor(20)]
     Makie.focus!(tb3)
     click(e, 259, 173) # between 7 and 8
     send(e, Keyboard.left)
@@ -751,8 +751,8 @@ end
 
     tb4 = Makie.Textbox(f[4, 1], width = 100)
     Makie.set!(tb4, "1234567890qwertyuiop")
-    tb4.cursorindex[] = 20
-    tb4.cursorindex[] = 10
+    tb4.editor.cursors[] = [Makie.EditCursor(20)]
+    tb4.editor.cursors[] = [Makie.EditCursor(10)]
     Makie.focus!(tb4)
     for _ in 1:8
         send(e, Keyboard.backspace)

--- a/WGLMakie/src/html-widgets.jl
+++ b/WGLMakie/src/html-widgets.jl
@@ -416,7 +416,11 @@ function replace_widget!(textbox::Makie.Textbox)
     )
 
     # Add number-specific attributes for numeric validators
-    input_attrs = Dict(:type => input_type, :value => string(initial_value))
+    input_attrs = Dict(
+        :type => input_type,
+        :value => string(initial_value),
+        :placeholder => textbox.placeholder[],
+    )
     if input_type == "number"
         input_attrs[:step] = "any"  # Allow any decimal precision
     end

--- a/WGLMakie/test/html-widgets.jl
+++ b/WGLMakie/test/html-widgets.jl
@@ -257,15 +257,17 @@ using Electron, WGLMakie, Bonito, Test
                 return {
                     exists: node !== null,
                     type: node ? node.type : "",
-                    value: node ? node.value : ""
+                    value: node ? node.value : "",
+                    placeholder: node ? node.placeholder : ""
                 }
             })()"""
         )
 
         @test textbox_props["exists"] == true
         @test textbox_props["type"] == "text"
-        # Initial value is the placeholder text
-        @test textbox_props["value"] == "Enter text..."
+        # Empty input shows the placeholder via the native HTML attribute
+        @test textbox_props["value"] == ""
+        @test textbox_props["placeholder"] == "Enter text..."
 
         # Test entering text
         evaljs_value(

--- a/docs/fake_interaction.jl
+++ b/docs/fake_interaction.jl
@@ -10,9 +10,13 @@ export LeftClick
 export LeftDown
 export LeftUp
 export RightClick, MiddleClick
+export TypeText
+export KeyPress
+export KeyDown, KeyUp
 export Lazy
 export Wait
 export relative_pos
+export textbox_offset_pos
 
 @recipe(Cursor) do scene
     Theme(
@@ -123,6 +127,67 @@ duration(::MiddleClick, _) = 0.15
 mouseevents_start(l::MiddleClick) = [Makie.MouseButtonEvent(Mouse.middle, Mouse.press)]
 mouseevents_end(l::MiddleClick) = [Makie.MouseButtonEvent(Mouse.middle, Mouse.release)]
 
+"""
+    TypeText(text; char_duration = 0.06)
+
+Emits each character of `text` as a `unicode_input` event, spaced `char_duration`
+seconds apart. Total event duration is `length(text) * char_duration`.
+"""
+struct TypeText
+    text::String
+    char_duration::Float64
+end
+TypeText(text::AbstractString; char_duration = 0.06) = TypeText(String(text), char_duration)
+duration(t::TypeText, _) = max(length(t.text) * t.char_duration, 0.05)
+
+function unicode_inputs_frame(t::TypeText, time, prev_time)
+    chars = Char[]
+    for (i, c) in enumerate(t.text)
+        scheduled = (i - 0.5) * t.char_duration
+        if prev_time < scheduled <= time
+            push!(chars, c)
+        end
+    end
+    return chars
+end
+
+"""
+    KeyPress(key; duration = 0.08)
+
+Presses `key` at the start of the event and releases it at the end.
+"""
+struct KeyPress
+    key::Keyboard.Button
+    duration::Float64
+end
+KeyPress(key::Keyboard.Button; duration = 0.08) = KeyPress(key, duration)
+duration(k::KeyPress, _) = k.duration
+keyboardevents_start(k::KeyPress) = [Makie.KeyEvent(k.key, Keyboard.press)]
+keyboardevents_end(k::KeyPress) = [Makie.KeyEvent(k.key, Keyboard.release)]
+
+"""
+    KeyDown(key)
+
+Presses `key` without releasing it. Use to hold a modifier across subsequent
+events; pair with [`KeyUp`](@ref).
+"""
+struct KeyDown
+    key::Keyboard.Button
+end
+duration(::KeyDown, _) = 0.0
+keyboardevents_start(k::KeyDown) = [Makie.KeyEvent(k.key, Keyboard.press)]
+
+"""
+    KeyUp(key)
+
+Releases a key previously held with [`KeyDown`](@ref).
+"""
+struct KeyUp
+    key::Keyboard.Button
+end
+duration(::KeyUp, _) = 0.0
+keyboardevents_start(k::KeyUp) = [Makie.KeyEvent(k.key, Keyboard.release)]
+
 
 mouseevents_start(obj) = []
 mouseevents_end(obj) = []
@@ -130,6 +195,9 @@ mouseevents_frame(obj, t) = []
 mousepositions_start(obj, startpos) = []
 mousepositions_end(obj, startpos) = []
 mousepositions_frame(obj, startpos, t) = []
+keyboardevents_start(obj) = []
+keyboardevents_end(obj) = []
+unicode_inputs_frame(obj, time, prev_time) = []
 
 function alpha_blend(fg::Makie.RGBA, bg::Makie.RGB)
     r = (fg.r * fg.alpha + bg.r * (1 - fg.alpha))
@@ -210,22 +278,31 @@ function interaction_record(func, figlike, filepath, events::AbstractVector; fps
             for mouseevent in mouseevents
                 content_scene.events.mousebutton[] = mouseevent
             end
+            for keyevent in keyboardevents_start(event)
+                content_scene.events.keyboardbutton[] = keyevent
+            end
             mousepositions = mousepositions_start(event, event_startposition)
             for mouseposition in mousepositions
                 content_scene.events.mouseposition[] = tuple(mouseposition...)
                 cursor_position[] = mouseposition
             end
 
+            prev_t_in_event = 0.0
             while t < t_event + current_duration
-                mouseevents = mouseevents_frame(event, t - t_event)
+                t_in_event = t - t_event
+                mouseevents = mouseevents_frame(event, t_in_event)
                 for mouseevent in mouseevents
                     content_scene.events.mousebutton[] = mouseevent
                 end
-                mousepositions = mousepositions_frame(event, event_startposition, t - t_event)
+                mousepositions = mousepositions_frame(event, event_startposition, t_in_event)
                 for mouseposition in mousepositions
                     content_scene.events.mouseposition[] = tuple(mouseposition...)
                     cursor_position[] = mouseposition
                 end
+                for c in unicode_inputs_frame(event, t_in_event, prev_t_in_event)
+                    content_scene.events.unicode_input[] = c
+                end
+                prev_t_in_event = t_in_event
 
                 func(i_frame, t)
                 # img[] = rotr90(Makie.colorbuffer(figlike, update = false))
@@ -252,6 +329,9 @@ function interaction_record(func, figlike, filepath, events::AbstractVector; fps
             for mouseevent in mouseevents
                 content_scene.events.mousebutton[] = mouseevent
             end
+            for keyevent in keyboardevents_end(event)
+                content_scene.events.keyboardbutton[] = keyevent
+            end
             mousepositions = mousepositions_end(event, event_startposition)
             for mouseposition in mousepositions
                 content_scene.events.mouseposition[] = tuple(mouseposition...)
@@ -268,5 +348,39 @@ end
 interaction_record(figlike, filepath, events::AbstractVector; kwargs...) = interaction_record((args...) -> nothing, figlike, filepath, events; kwargs...)
 
 relative_pos(block, rel) = Point2f(block.layoutobservables.computedbbox[].origin .+ rel .* block.layoutobservables.computedbbox[].widths)
+
+"""
+    textbox_offset_pos(tb::Textbox, offset::Int)
+
+Pixel position of cursor `offset` (0-based) inside `tb`'s text. Suitable for
+[`MouseTo`](@ref) inside a [`Lazy`](@ref) so that the textbox's glyph layout is
+queried at recording time.
+"""
+function textbox_offset_pos(tb, offset::Integer)
+    editor = tb.editor
+    text_plot = first(p for p in editor.plots if p isa Makie.Text)
+    origins = text_plot.glyph_origins[]
+    n = length(origins)
+    bbox = tb.layoutobservables.computedbbox[]
+    sa_origin = round.(Int, Tuple(bbox.origin))
+    block_local = Tuple(only(text_plot.markerspace_positions[]))[1:2]
+    if n == 0
+        y = bbox.origin[2] + 0.5 * bbox.widths[2]
+        x = sa_origin[1] + block_local[1]
+        return Point2f(x, y)
+    end
+    off = clamp(Int(offset), 0, n)
+    glyph_idx = off < n ? off + 1 : n
+    local_x = if off < n
+        origins[off + 1][1]
+    else
+        adv = Float32(text_plot.glyph_extents[][n].hadvance) * text_plot.text_scales[][n][1]
+        origins[n][1] + adv
+    end
+    local_y = origins[glyph_idx][2]
+    x = sa_origin[1] + block_local[1] + local_x
+    y = sa_origin[2] + block_local[2] + local_y
+    return Point2f(x, y)
+end
 
 end

--- a/docs/src/reference/blocks/textbox.md
+++ b/docs/src/reference/blocks/textbox.md
@@ -1,6 +1,6 @@
 # Textbox
 
-The `Textbox` supports entry of a simple, single-line string, with optional validation logic.
+The `Textbox` provides an editable text field with optional validation.
 
 ```@figure
 
@@ -10,6 +10,102 @@ Textbox(f[2, 1], width = 300)
 
 f
 ```
+
+## Editing
+
+```@example textbox
+using GLMakie
+GLMakie.activate!() # hide
+
+fig = Figure(size = (600, 200))
+tb = Textbox(fig[1, 1], width = 400, height = 60, fontsize = 20, placeholder = "Click to edit...")
+fig
+nothing # hide
+```
+
+```@setup textbox
+using ..FakeInteraction
+
+evts = [
+    MouseTo(Point2f(550, 20), 0.0),
+    Wait(0.4),
+    Lazy(_ -> MouseTo(relative_pos(tb, (0.4, 0.5)))),
+    Wait(0.4),
+    LeftClick(),
+    Wait(0.3),
+    TypeText("the quick brown fox", char_duration = 0.07),
+    Wait(0.7),
+
+    # Click after "brown" → backspace to "the quick fox"
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 15))),
+    Wait(0.3),
+    LeftClick(),
+    Wait(0.3),
+    KeyPress(Keyboard.backspace), KeyPress(Keyboard.backspace), KeyPress(Keyboard.backspace),
+    KeyPress(Keyboard.backspace), KeyPress(Keyboard.backspace), KeyPress(Keyboard.backspace),
+    Wait(0.7),
+
+    # Drag-select "quick" → replace with "slow"
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 4))),
+    Wait(0.3),
+    LeftDown(),
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 9), 0.5)),
+    LeftUp(),
+    Wait(0.5),
+    TypeText("slow", char_duration = 0.07),
+    Wait(0.8),
+
+    # Triple-click → select line
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 4))),
+    Wait(0.3),
+    LeftClick(),
+    LeftClick(),
+    LeftClick(),
+    Wait(0.7),
+
+    # Click at end → Shift+Enter for newline → type second line
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 12))),
+    Wait(0.3),
+    LeftClick(),
+    Wait(0.4),
+    KeyDown(Keyboard.left_shift),
+    KeyPress(Keyboard.enter),
+    KeyUp(Keyboard.left_shift),
+    Wait(0.3),
+    TypeText("the smart dog", char_duration = 0.07),
+    Wait(0.7),
+
+    # Click before "fox" → cmd+click before "dog" to add a second cursor
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 9))),
+    Wait(0.3),
+    LeftClick(),
+    Wait(0.4),
+    Lazy(_ -> MouseTo(textbox_offset_pos(tb, 23))),
+    Wait(0.3),
+    KeyDown(Keyboard.left_super),
+    LeftClick(),
+    KeyUp(Keyboard.left_super),
+    Wait(0.5),
+
+    # Type at both cursors simultaneously
+    TypeText("happy ", char_duration = 0.07),
+    Wait(1.4),
+]
+
+interaction_record(fig, "textbox_example.mp4", evts)
+```
+
+```@raw html
+<video autoplay loop muted playsinline src="./textbox_example.mp4" width="600"/>
+```
+
+- Drag to select; double-click for the word at the cursor; triple-click for the line.
+- Hold ⌘ (or Ctrl) while clicking to add an extra cursor. ⌘+double-click and ⌘+triple-click add a word or line selection.
+- Arrow keys move the caret; Shift extends the selection; ⌥ (Alt) moves by whole words.
+- ⌥+Backspace / ⌘+Backspace delete the previous word / line; ⌥+Delete / ⌘+Delete are the forward equivalents.
+- ⌘+A selects all. ⌘+C / ⌘+X / ⌘+V copy / cut / paste; paste is filtered through `restriction`.
+- ⌘+D selects the next occurrence of the current selection; ⌘+Shift+D the previous one.
+- Enter submits (subject to `validator`); Shift+Enter forces a newline; Escape defocuses.
 
 ## Validation
 

--- a/docs/src/reference/blocks/textbox.md
+++ b/docs/src/reference/blocks/textbox.md
@@ -2,29 +2,13 @@
 
 The `Textbox` provides an editable text field with optional validation.
 
-```@figure
-
-f = Figure()
-Textbox(f[1, 1], placeholder = "Enter a string...")
-Textbox(f[2, 1], width = 300)
-
-f
-```
-
-## Editing
-
-```@example textbox
+```@setup textbox
 using GLMakie
-GLMakie.activate!() # hide
+GLMakie.activate!()
+using ..FakeInteraction
 
 fig = Figure(size = (600, 200))
 tb = Textbox(fig[1, 1], width = 400, height = 60, fontsize = 20, placeholder = "Click to edit...")
-fig
-nothing # hide
-```
-
-```@setup textbox
-using ..FakeInteraction
 
 evts = [
     MouseTo(Point2f(550, 20), 0.0),
@@ -98,6 +82,8 @@ interaction_record(fig, "textbox_example.mp4", evts)
 ```@raw html
 <video autoplay loop muted playsinline src="./textbox_example.mp4" width="600"/>
 ```
+
+## Editing
 
 - Drag to select; double-click for the word at the cursor; triple-click for the line.
 - Hold ⌘ (or Ctrl) while clicking to add an extra cursor. ⌘+double-click and ⌘+triple-click add a word or line selection.


### PR DESCRIPTION
## Summary

Adds an internal `EditableText` recipe and refactors `Textbox` to use it. The
recipe is the editing primitive: it owns a mutable `text::String` and a
`cursors::Vector{EditCursor}`, derives selection rectangles and the blinking
caret from the inner `text!` plot's glyph data, and handles all the mouse and
keyboard interactions.

`Textbox` keeps its public surface and gains all the editing capabilities of the recipe for free.

The recipe itself is private for now so it can be iterated on more freely. A new `@recipe_internal` macro
was needed to not automatically export.

## What's new in Textbox

- Drag selection, double-click for word, triple-click for line
- Multi-cursor: Cmd+click, Cmd+double-click (word), Cmd+triple-click (line)
- Cmd+D / Cmd+Shift+D — add the next / previous occurrence of the current selection
- Alt+arrow / Alt+Backspace / Cmd+Backspace / Cmd+Delete for word- and line-scale movement & deletion
- Copy / cut / paste (Cmd+C, Cmd+X, Cmd+V) with paste filtered through the same `restriction`
- Cmd+A to select all, Escape to defocus
- Smooth cursor blink driven by render ticks (no `Animations.animate_async`)

## Other changes

- `text_layouting.jl`: a trailing `'\n'` now contributes a full empty line to
  the glyph collection's bbox / alignment. Previously `"abc\n"` was laid out
  identically to `"abc"`.
- `Textbox.cursorindex` and `Textbox.cursoranimtask` fields are removed (both
  were internal). `Textbox.editor` is added as a (non-attribute) handle to the
  embedded `EditableText` for tests / advanced consumers.
- `cursorcolor` is now actually wired through to the recipe (was dead before).

## Example

<video src="https://github.com/user-attachments/assets/efae159c-09c9-450c-88d2-fc4e77843330"/>


## Checks

- `Makie/test/interactivity/EditableText.jl` (90 tests) covers: word/line
  offset helpers, cursor merging, `apply_edits` overlap collapsing, typing,
  backspace, delete (per-char / per-word / per-line variants), arrow movement,
  vertical movement, click & drag, single/double/triple click, Cmd+click and
  Cmd+double/triple-click multi-cursor, Cmd+D / Cmd+Shift+D occurrence search,
  copy / cut / paste round-trip, multiline + submit modes, `input_filter`,
  escape, selection-rectangle visibility on focus change, cursor blink ticks.
- Updated reference test `Textbox` uses `tb.editor.cursors[]` in place of the
  removed `tb.cursorindex[]`; existing visual coverage is preserved.
- Manually exercised in GLMakie via the demo above.
