### PR TITLE
Validate Figure and Legend keyword arguments

### DIFF
--- a/Makie/src/figures.jl
+++ b/Makie/src/figures.jl
@@ -120,6 +120,7 @@ function Figure(; kwargs...)
 
     kwargs_dict = Dict(kwargs)
     padding = pop!(kwargs_dict, :figure_padding, theme(:figure_padding))
+    _check_figure_kwargs(kwargs_dict)
     scene = Scene(; camera = campixel!, clear = true, kwargs_dict...)
     padding = convert(Observable{Any}, padding)
     alignmode = lift(Outside ∘ to_rectsides, padding)
@@ -143,6 +144,56 @@ function Figure(; kwargs...)
     # if connected correctly
     layout.parent = f
     return f
+end
+
+function InvalidAttributeError(::Type{Figure}, attributes::Set{Symbol})
+    return InvalidAttributeError(Figure, "figure", attributes)
+end
+
+function attribute_names(::Type{Figure})
+    nameset = Set{Symbol}(keys(current_default_theme()))
+    union!(nameset, (:figure_padding, :resolution))
+    union!(nameset, _scene_kwarg_names())
+    union!(nameset, _registered_plot_or_block_names())
+    return nameset
+end
+
+function _scene_kwarg_names()
+    return (
+        :viewport, :events, :clear, :transform_func, :camera, :camera_controls,
+        :transformation, :plots, :children, :current_screens, :parent, :visible,
+        :ssao, :lights, :theme, :deregister_callbacks,
+    )
+end
+
+function _registered_plot_or_block_names()
+    nameset = Set{Symbol}()
+    union!(nameset, _registered_val_method_names(symbol_to_plot))
+    union!(nameset, _registered_val_method_names(symbol_to_block))
+    return nameset
+end
+
+function _registered_val_method_names(f)
+    nameset = Set{Symbol}()
+    for method in methods(f)
+        sig = Base.unwrap_unionall(method.sig)
+        length(sig.parameters) == 2 || continue
+        valtype = sig.parameters[2]
+        valtype isa DataType || continue
+        valtype <: Val || continue
+        name = valtype.parameters[1]
+        name isa Symbol || continue
+        push!(nameset, name)
+    end
+    return nameset
+end
+
+function _check_figure_kwargs(kwdict::Dict)
+    badnames = setdiff(keys(kwdict), attribute_names(Figure))
+    if !isempty(badnames)
+        throw(InvalidAttributeError(Figure, badnames))
+    end
+    return
 end
 
 export Figure, current_axis, current_figure, current_axis!, current_figure!

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -958,7 +958,9 @@ function Legend(
     )
 
     scene = get_topscene(fig_or_scene)
-    legend_defaults = block_defaults(:Legend, Dict{Symbol, Any}(kwargs), scene)
+    kwdict = Dict{Symbol, Any}(kwargs)
+    _check_remaining_kwargs(Legend, kwdict)
+    legend_defaults = block_defaults(:Legend, kwdict, scene)
     entry_groups = to_entry_group(Attributes(legend_defaults), contents, labels, title)
     entrygroups = Observable(entry_groups)
     legend_defaults[:entrygroups] = entrygroups
@@ -992,7 +994,9 @@ function Legend(
     )
 
     scene = get_scene(fig_or_scene)
-    legend_defaults = block_defaults(:Legend, Dict{Symbol, Any}(kwargs), scene)
+    kwdict = Dict{Symbol, Any}(kwargs)
+    _check_remaining_kwargs(Legend, kwdict)
+    legend_defaults = block_defaults(:Legend, kwdict, scene)
     entry_groups = to_entry_group(legend_defaults, contentgroups, labelgroups, titles)
     entrygroups = Observable(entry_groups)
     legend_defaults[:entrygroups] = entrygroups

--- a/Makie/test/pipeline.jl
+++ b/Makie/test/pipeline.jl
@@ -166,6 +166,12 @@ import Makie: _attribute_docs
     @test_throws InvalidAttributeError mesh(rand(Point3f, 3); does_not_exist = 123)
 end
 
+@testset "validated attributes for figures" begin
+    @test_throws InvalidAttributeError Figure(does_not_exist = 123)
+    @test Figure(size = (400, 300), backgroundcolor = :transparent) isa Figure
+    @test Figure(Axis = (; xticklabelsize = 35)) isa Figure
+end
+
 import Makie: find_nearby_attributes, attribute_names, textdiff
 
 @testset "attribute suggestions" begin
@@ -220,6 +226,8 @@ end
     @test_throws InvalidAttributeError Toggle(fig[1, 1], does_not_exist = 123)
     @test_throws InvalidAttributeError Menu(fig[1, 1], does_not_exist = 123)
     @test_throws InvalidAttributeError Legend(fig[1, 1], does_not_exist = 123)
+    @test_throws InvalidAttributeError Legend(fig[1, 1], [LineElement()], ["x"], does_not_exist = 123)
+    @test_throws InvalidAttributeError Legend(fig[1, 1], [[LineElement()]], [["x"]], ["title"], does_not_exist = 123)
     @test_throws InvalidAttributeError LScene(fig[1, 1], does_not_exist = 123)
     @test_throws InvalidAttributeError Textbox(fig[1, 1], does_not_exist = 123)
     @test_throws InvalidAttributeError PolarAxis(fig[1, 1], does_not_exist = 123)


### PR DESCRIPTION
## Summary
- reject unknown `Figure` keyword arguments before forwarding to `Scene` theme kwargs
- validate specialized `Legend` constructors before applying block defaults
- add regression coverage for `Figure` and both specialized `Legend` paths

Fixes #4217.

## Tests
- `JULIA_PKG_PRECOMPILE_AUTO=0 /tmp/codex-julia/julia-1.10.10/bin/julia --project=Makie/test -e ...` targeted smoke assertions for invalid `Figure` kwargs, both invalid specialized `Legend` kwargs, and valid `Figure` theme kwargs.

If accepted for the bounty mentioned in #4217, PayPal receive link: https://paypal.me/mikeshipley