### PR TITLE
feat(text): Add text_handler extension hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking
 
+- Added an `AbstractTextPrimitive` extension hook to the `text` recipe so downstream packages (e.g. MakieTeX) can plug arbitrary graphical primitives — like rendered LaTeX images — into a `text` plot alongside glyphs and MathTeX line segments. A built-in `ImageTextPrimitive` renders image markers via a child scatter plot. [#5632](https://github.com/MakieOrg/Makie.jl/pull/5632)
 - **breaking** Moved `FFMPEG_jll` from a hard dependency to a package extension to avoid pulling in GPL-licensed libraries (e.g. libx264). `record`, `VideoStream`, `convert_video`, and `extract_frames` now require `FFMPEG_jll` to be available in the active environment; Makie will load it automatically on first use. A custom ffmpeg binary can be configured via `Makie.ffmpeg_path!(path)` (or persistently via Preferences.jl). [#5588](https://github.com/MakieOrg/Makie.jl/pull/5588)
 - Expanded scope of dim converts [#5323](https://github.com/MakieOrg/Makie.jl/pull/5323)
   - **breaking** most plot recipes now set the target types for their conversions. This means `plot!(::PlotType{<:Tuple{<:MyArgType}})` requires introducing a conversion trait and extending `Makie.types_for_plot_arguments()`. See docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking
 
-- Added an `AbstractTextPrimitive` extension hook to the `text` recipe so downstream packages (e.g. MakieTeX) can plug arbitrary graphical primitives — like rendered LaTeX images — into a `text` plot alongside glyphs and MathTeX line segments. A built-in `ImageTextPrimitive` renders image markers via a child scatter plot. [#5632](https://github.com/MakieOrg/Makie.jl/pull/5632)
+- Added a `text_handler` attribute on the `text` recipe for plugging in custom string renderers (e.g. MakieTeX's LaTeX/Typst engines). [#5632](https://github.com/MakieOrg/Makie.jl/pull/5632)
 - **breaking** Moved `FFMPEG_jll` from a hard dependency to a package extension to avoid pulling in GPL-licensed libraries (e.g. libx264). `record`, `VideoStream`, `convert_video`, and `extract_frames` now require `FFMPEG_jll` to be available in the active environment; Makie will load it automatically on first use. A custom ffmpeg binary can be configured via `Makie.ffmpeg_path!(path)` (or persistently via Preferences.jl). [#5588](https://github.com/MakieOrg/Makie.jl/pull/5588)
 - Expanded scope of dim converts [#5323](https://github.com/MakieOrg/Makie.jl/pull/5323)
   - **breaking** most plot recipes now set the target types for their conversions. This means `plot!(::PlotType{<:Tuple{<:MyArgType}})` requires introducing a conversion trait and extending `Makie.types_for_plot_arguments()`. See docs.

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -889,11 +889,16 @@ function mark_input_dirty!(parent::Input, edge::ComputeEdge)
 end
 
 function set_result!(edge::TypedEdge, result, i, value)
-    if isnothing(value) || is_same(edge.outputs[i][], value)
+    # Dereference once so callbacks returning `Ref{Any}(x)` (the type-narrowing
+    # opt-out) are still seen through by `is_same`. Without this, the Ref
+    # wrapper defeats the equality check because `outputs[i][]` stores the
+    # dereferenced inner value.
+    new_val = deref(value)
+    if isnothing(value) || is_same(edge.outputs[i][], new_val)
         edge.output_nodes[i].dirty = false
     else
         edge.output_nodes[i].dirty = true
-        edge.outputs[i][] = deref(value)
+        edge.outputs[i][] = new_val
     end
     if !isempty(result)
         next_val = first(result)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -19,31 +19,31 @@ end
     display(screen, scatter(1:4))
     @test length(cache.shader_cache) == 17
     @test length(cache.template_cache) == 17
-    @test length(cache.program_cache) == 10
+    @test length(cache.program_cache) == 9
 
     # No new shaders should be added:
     display(screen, scatter(1:4))
     @test length(cache.shader_cache) == 17
     @test length(cache.template_cache) == 17
-    @test length(cache.program_cache) == 10
+    @test length(cache.program_cache) == 9
 
     # Same for linesegments
     display(screen, linesegments(1:4))
     @test length(cache.shader_cache) == 17
     @test length(cache.template_cache) == 17
-    @test length(cache.program_cache) == 10
+    @test length(cache.program_cache) == 9
 
     # heatmap hasn't been compiled so one new program should be added
     display(screen, heatmap([1, 2, 2.5, 3], [1, 2, 2.5, 3], rand(4, 4)))
     @test length(cache.shader_cache) == 19
     @test length(cache.template_cache) == 19
-    @test length(cache.program_cache) == 11
+    @test length(cache.program_cache) == 10
 
     # For second time no new shaders should be added
     display(screen, heatmap([1, 2, 2.5, 3], [1, 2, 2.5, 3], rand(4, 4)))
     @test length(cache.shader_cache) == 19
     @test length(cache.template_cache) == 19
-    @test length(cache.program_cache) == 11
+    @test length(cache.program_cache) == 10
 end
 
 @testset "unit tests" begin
@@ -190,11 +190,17 @@ end
 
     @test ax.scene.plots == [hmp, lp, tp]
 
-    function leaf_plots(p)
-        isempty(p.plots) && return [p]
-        return reduce(vcat, leaf_plots.(p.plots); init = Plot[])
+    # Text now wraps its primitives in a PlotList that itself isn't cached;
+    # collect every plot in the hierarchy that the screen actually has a
+    # RenderObject for so we can verify each one gets cleaned up by `empty!`.
+    function cached_plots(p)
+        result = haskey(screen.cache, objectid(p)) ? Plot[p] : Plot[]
+        for c in p.plots
+            append!(result, cached_plots(c))
+        end
+        return result
     end
-    robjs = map(x -> screen.cache[objectid(x)], [hmp, lp, leaf_plots(tp)...])
+    robjs = map(x -> screen.cache[objectid(x)], [hmp, lp, cached_plots(tp)...])
 
     empty!(ax)
 

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -190,7 +190,11 @@ end
 
     @test ax.scene.plots == [hmp, lp, tp]
 
-    robjs = map(x -> screen.cache[objectid(x)], [hmp, lp, tp.plots...])
+    function leaf_plots(p)
+        isempty(p.plots) && return [p]
+        return reduce(vcat, leaf_plots.(p.plots); init = Plot[])
+    end
+    robjs = map(x -> screen.cache[objectid(x)], [hmp, lp, leaf_plots(tp)...])
 
     empty!(ax)
 

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -625,18 +625,15 @@ Plots one or multiple texts passed via the `text` keyword.
     "Specifies a linewidth limit for text. If a word overflows this limit, a newline is inserted before it. Negative numbers disable word wrapping."
     word_wrap_width = -1
     """
-    Optional callable that intercepts `LaTeXString` text blocks instead of
-    the default MathTeXEngine glyph layout. Signature matches
-    `Makie.convert_text_string!`: `(outputs, latex_str, block_idx, N_blocks,
-    fontsize, font, align, rotation, justification, lineheight,
-    word_wrap_width, offset, fonts, color, strokecolor, strokewidth)`. Set
-    via theming to swap MathTeXEngine for e.g. `MakieTeX` full-LaTeX
-    rendering — useful for prototyping with MathTeXEngine and polishing
-    with real LaTeX without changing plot code (e.g. for `LaTeXString`s
-    that come from third-party plotting functions you don't control).
-    `nothing` (default) keeps the MathTeXEngine path.
+    Optional handler intercepting individual text blocks in place of the default
+    MathTeXEngine glyph layout. Must implement `Makie.compile_text` (narrow inputs:
+    src, color, fontsize, lineheight) and `Makie.place_text!` (placement),
+    dispatching on the input types the handler accepts (e.g. `LaTeXString`,
+    `TypstString`). Returns `nothing` from `compile_text` to fall through to the
+    glyph path for inputs the handler doesn't claim. `nothing` (default) keeps
+    the MathTeXEngine path for everything.
     """
-    latex_handler = @inherit latex_handler
+    text_handler = @inherit text_handler
     mixin_generic_plot_attributes()...
     mixin_colormap_attributes()...
     fxaa = false

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -624,6 +624,19 @@ Plots one or multiple texts passed via the `text` keyword.
     offset = (0.0, 0.0)
     "Specifies a linewidth limit for text. If a word overflows this limit, a newline is inserted before it. Negative numbers disable word wrapping."
     word_wrap_width = -1
+    """
+    Optional callable that intercepts `LaTeXString` text blocks instead of
+    the default MathTeXEngine glyph layout. Signature matches
+    `Makie.convert_text_string!`: `(outputs, latex_str, block_idx, N_blocks,
+    fontsize, font, align, rotation, justification, lineheight,
+    word_wrap_width, offset, fonts, color, strokecolor, strokewidth)`. Set
+    via theming to swap MathTeXEngine for e.g. `MakieTeX` full-LaTeX
+    rendering — useful for prototyping with MathTeXEngine and polishing
+    with real LaTeX without changing plot code (e.g. for `LaTeXString`s
+    that come from third-party plotting functions you don't control).
+    `nothing` (default) keeps the MathTeXEngine path.
+    """
+    latex_handler = @inherit latex_handler
     mixin_generic_plot_attributes()...
     mixin_colormap_attributes()...
     fxaa = false

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -372,6 +372,7 @@ end
 function compute_glyph_collections!(attr::ComputeGraph)
     inputs = [
         :input_text,
+        :latex_handler,
         :fontsize,
         :selected_font,
         :align,
@@ -395,7 +396,7 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :linesegments, :linewidths, :linecolors, :lineindices,
         :text_primitives, :text_primitive_block_indices,
     ]
-    return register_computation!(attr, inputs, outputs) do (input_texts, _inputs...), changed, cached
+    return register_computation!(attr, inputs, outputs) do (input_texts, latex_handler, _inputs...), changed, cached
         _outputs = (
             glyphcollections = GlyphCollection[],
             glyphindices = UInt64[],
@@ -419,7 +420,13 @@ function compute_glyph_collections!(attr::ComputeGraph)
 
         N = length(input_texts)
         for (block_index, str) in enumerate(input_texts)
-            convert_text_string!(_outputs, str, block_index, N, _inputs...)
+            # `LaTeXString` is themable: if `latex_handler` is set, route the
+            # block through it instead of the built-in MathTeXEngine path.
+            if str isa LaTeXString && latex_handler !== nothing
+                latex_handler(_outputs, str, block_index, N, _inputs...)
+            else
+                convert_text_string!(_outputs, str, block_index, N, _inputs...)
+            end
         end
 
         return values(_outputs)

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -4,6 +4,61 @@ function check_textsize_deprecation(@nospecialize(dictlike))
     end
 end
 
+# Text primitives: pluggable graphical elements that a string layout can emit
+# alongside (or instead of) glyphs. Built-in: glyphs and MathTeX line segments
+# have dedicated channels for performance; arbitrary primitives go through
+# the `text_primitives` channel below and are dispatched to child plots via
+# `register_text_primitive_plot!`.
+
+"""
+    AbstractTextPrimitive
+
+Supertype for graphical elements that a `text` plot can render at the
+markerspace position of a text block. Built-in subtypes include
+[`ImageTextPrimitive`](@ref); downstream packages (e.g. MakieTeX) define
+their own to plug arbitrary content into `text`.
+
+A subtype `P` must implement:
+
+* `text_primitive_bbox(p::P)::Rect3d` — markerspace bounding box relative to
+  the text block origin (used by the text plot's bounding-box pipeline).
+* `register_text_primitive_plot!(plot::Plot, ::Type{P}, items::Vector{P}, block_indices::Vector{Int})`
+  — register a child plot that renders `items`, observing the text plot's
+  current markerspace block positions.
+
+Items are pushed by `convert_text_string!` overloads (one per input text type)
+into the `outputs.text_primitives` channel.
+"""
+abstract type AbstractTextPrimitive end
+
+function text_primitive_bbox end
+function register_text_primitive_plot! end
+
+"""
+    ImageTextPrimitive(image, marker_offset::Vec3f, size::Vec2f, rotation::Quaternionf)
+
+A text primitive that renders `image` as a single scatter marker at the
+text block's position. Used by e.g. MakieTeX to embed pre-rendered LaTeX
+into a Makie `text` plot.
+
+* `image`     — any marker accepted by `scatter` (typically a `Matrix{<:Colorant}`)
+* `marker_offset` — markerspace offset from the block origin to the marker's
+                    lower-left corner (after rotation has been applied)
+* `size`      — markerspace marker size
+* `rotation`  — applied to the marker by scatter
+"""
+struct ImageTextPrimitive{I} <: AbstractTextPrimitive
+    image::I
+    marker_offset::Vec3f
+    size::Vec2f
+    rotation::Quaternionf
+end
+
+function text_primitive_bbox(p::ImageTextPrimitive)
+    bb = Rect3d(to_ndim(Point3d, p.marker_offset, 0), Vec3d(p.size..., 0))
+    return rotate_bbox(bb, p.rotation)
+end
+
 # We sort out position vs string(-like) vs mixed arguments before convert_arguments,
 # so that we only get positions here
 conversion_trait(::Type{<:Text}, args...) = PointBased()
@@ -316,6 +371,7 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :text_color, :text_rotation, :text_scales,
         :text_strokewidth, :text_strokecolor,
         :linesegments, :linewidths, :linecolors, :lineindices,
+        :text_primitives, :text_primitive_block_indices,
     ]
     return register_computation!(attr, inputs, outputs) do (input_texts, _inputs...), changed, cached
         _outputs = (
@@ -334,6 +390,8 @@ function compute_glyph_collections!(attr::ComputeGraph)
             linewidths = Float32[],
             linecolors = RGBAf[],
             lineindices = Pair{Int, Int}[],
+            text_primitives = AbstractTextPrimitive[],
+            text_primitive_block_indices = Int[],
         )
         # strokewidth = Float32[] # TODO: Skipped?
 
@@ -417,7 +475,73 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
 
     register_colormapping!(attr)
     register_text_computations!(attr)
-    return tex_linesegments!(plot)
+    tex_linesegments!(plot)
+    return register_text_primitive_plot!(plot, ImageTextPrimitive)
+end
+
+"""
+    register_text_primitive_plot!(plot::Plot{text}, ::Type{P})
+
+Default-dispatch hook for plugging an `AbstractTextPrimitive` subtype into the
+`text` recipe. Called once per primitive type from `calculated_attributes!`.
+Built-in implementation handles [`ImageTextPrimitive`](@ref) by registering a
+child `scatter!` plot. Downstream packages can register their own primitive
+types by extending this method (and `text_primitive_bbox`).
+"""
+register_text_primitive_plot!(plot, ::Type{<:AbstractTextPrimitive}) = nothing
+
+# Filter the heterogeneous text_primitives channel for entries of a specific
+# concrete primitive type. Returns aligned vectors of items, block indices,
+# offsets, sizes, and rotations suitable for a child scatter plot.
+function _filter_text_primitives(primitives::Vector{AbstractTextPrimitive}, block_indices::Vector{Int}, ::Type{T}) where {T <: AbstractTextPrimitive}
+    items = T[]
+    idxs = Int[]
+    for (b, p) in zip(block_indices, primitives)
+        p isa T || continue
+        push!(items, p)
+        push!(idxs, b)
+    end
+    return items, idxs
+end
+
+function register_text_primitive_plot!(plot, ::Type{<:ImageTextPrimitive})
+    register_model_clip_planes!(plot.attributes)
+
+    map!(
+        plot.attributes,
+        [
+            :text_primitives, :text_primitive_block_indices,
+            :preprojection, :model_f32c, :positions_transformed_f32c,
+            :model_clip_planes, :space,
+        ],
+        [
+            :_image_primitive_positions, :_image_primitive_markers,
+            :_image_primitive_sizes, :_image_primitive_offsets,
+            :_image_primitive_rotations,
+        ]
+    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space
+        items, idxs = _filter_text_primitives(prims, indices, ImageTextPrimitive)
+        if isempty(items)
+            return (Point3f[], Any[], Vec2f[], Vec3f[], Quaternionf[])
+        end
+        markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
+        out_pos = [markerspace_positions[idxs[i]] for i in eachindex(items)]
+        out_marker = Any[p.image for p in items]
+        out_size = [p.size for p in items]
+        out_offset = [p.marker_offset for p in items]
+        out_rot = [p.rotation for p in items]
+        return (out_pos, out_marker, out_size, out_offset, out_rot)
+    end
+
+    return scatter!(
+        plot, plot._image_primitive_positions;
+        marker = plot._image_primitive_markers,
+        markersize = plot._image_primitive_sizes,
+        marker_offset = plot._image_primitive_offsets,
+        rotation = plot._image_primitive_rotations,
+        space = plot.markerspace,
+        markerspace = plot.markerspace,
+    )
 end
 
 function tex_linesegments!(plot)
@@ -586,9 +710,9 @@ function register_raw_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :linesegments, :linewidths, :lineindices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :linesegments, :linewidths, :lineindices, :text_primitives, :text_primitive_block_indices],
             :raw_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices
+        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices, primitives, primitive_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d()
@@ -604,6 +728,10 @@ function register_raw_string_boundingboxes!(plot)
             for (pos, lw, (block_idx, glyph_idx)) in zip(segments, linewidths, lineindices)
                 bb = Rect3d(to_ndim(Point3d, pos, 0) .- 0.5lw, Vec3d(lw))
                 text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
+            end
+
+            for (block_idx, prim) in zip(primitive_block_indices, primitives)
+                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], text_primitive_bbox(prim))
             end
 
             return text_bbs
@@ -628,9 +756,9 @@ function register_fast_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :linesegments, :linewidths, :lineindices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :linesegments, :linewidths, :lineindices, :text_primitives, :text_primitive_block_indices],
             :fast_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices
+        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices, primitives, primitive_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d(Point3d(NaN), Vec3d(0))
@@ -646,6 +774,10 @@ function register_fast_string_boundingboxes!(plot)
             for (pos, lw, (block_idx, glyph_idx)) in zip(segments, linewidths, lineindices)
                 bb = Rect3d(to_ndim(Point3d, pos, 0) .- 0.5lw, Vec3d(lw))
                 text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
+            end
+
+            for (block_idx, prim) in zip(primitive_block_indices, primitives)
+                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], text_primitive_bbox(prim))
             end
 
             return text_bbs

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -35,6 +35,21 @@ function text_primitive_bbox end
 function register_text_primitive_plot! end
 
 """
+    text_primitive_types(latex_handler) -> Tuple{Vararg{Type{<:AbstractTextPrimitive}}}
+
+The set of primitive types a `latex_handler` may push into a text plot. The
+text recipe uses this at construction time to decide which child plots to
+register (so a handler that emits only image markers doesn't drag along an
+empty `linesegments!` plot, and vice versa).
+
+The default is conservative and registers child plots for both built-in
+primitive types. Downstream handlers should override:
+
+    Makie.text_primitive_types(::MyHandler) = (Makie.ImageTextPrimitive,)
+"""
+text_primitive_types(_handler) = (ImageTextPrimitive, LineSegmentTextPrimitive)
+
+"""
     is_text_input(::Type) -> Bool
 
 Trait that tells the `text` recipe "this type is one of my single-element
@@ -528,13 +543,17 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
     has_latex = eltyp == Any || eltyp <: LaTeXString
     handler = plot.latex_handler[]
     if has_latex && handler === nothing
-        # MathTeXEngine path produces `HLine` elements (fraction rules,
-        # √ bars) — but only when it's the active LaTeX renderer.
+        # MathTeXEngine is built in and is the LaTeXString renderer when no
+        # `latex_handler` is set. It produces glyphs + `HLine`s (fraction
+        # rules, √ bars) → `LineSegmentTextPrimitive`.
         register_text_primitive_plot!(plot, LineSegmentTextPrimitive)
     end
     if has_latex && handler !== nothing
-        # `MakieTeXLaTeX` and similar handlers push image markers.
-        register_text_primitive_plot!(plot, ImageTextPrimitive)
+        # Ask the handler which primitive types it produces. Overrideable
+        # by handler authors via `Makie.text_primitive_types(h)`.
+        for T in text_primitive_types(handler)
+            register_text_primitive_plot!(plot, T)
+        end
     end
     return
 end

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -15,39 +15,44 @@ end
 
 Supertype for graphical elements that a `text` plot can render at the
 markerspace position of a text block. Built-in subtypes include
-[`ImageTextPrimitive`](@ref); downstream packages (e.g. MakieTeX) define
-their own to plug arbitrary content into `text`.
+[`ImageTextPrimitive`](@ref) and [`LineSegmentTextPrimitive`](@ref);
+downstream packages (e.g. MakieTeX) define their own to plug arbitrary
+content into `text`.
 
 A subtype `P` must implement:
 
 * `text_primitive_bbox(p::P)::Rect3d` — markerspace bounding box relative to
   the text block origin (used by the text plot's bounding-box pipeline).
-* `register_text_primitive_plot!(plot::Plot, ::Type{P}, items::Vector{P}, block_indices::Vector{Int})`
-  — register a child plot that renders `items`, observing the text plot's
-  current markerspace block positions.
+* `text_primitive_plotspecs(::Type{P}, items::Vector{P}, block_positions::Vector{Point3f}; markerspace)`
+   — returns a `Vector{PlotSpec}` describing how to render `items`. Called
+   once per concrete primitive type, with `block_positions[k]` being the
+   already-projected markerspace position of `items[k]`'s text block. The
+   PlotSpecs feed a single `plotlist!` child of the text plot, so the
+   actual child plot set is data-driven and updates reactively if the
+   primitive types in use change (e.g. swapping `latex_handler` at
+   runtime).
 
-Items are pushed by `convert_text_string!` overloads (one per input text type)
-into the `outputs.text_primitives` channel.
+Items are pushed by `convert_text_string!` overloads (one per input text
+type) into the `outputs.text_primitives` channel.
 """
 abstract type AbstractTextPrimitive end
 
 function text_primitive_bbox end
-function register_text_primitive_plot! end
 
 """
-    text_primitive_types(latex_handler) -> Tuple{Vararg{Type{<:AbstractTextPrimitive}}}
+    text_primitive_plotspecs(::Type{T}, items::Vector{T},
+                             block_positions::Vector{Point3f}; markerspace)
+        -> Vector{PlotSpec}
 
-The set of primitive types a `latex_handler` may push into a text plot. The
-text recipe uses this at construction time to decide which child plots to
-register (so a handler that emits only image markers doesn't drag along an
-empty `linesegments!` plot, and vice versa).
+Extension hook returning PlotSpecs that render `items` of primitive type
+`T`. `block_positions[k]` is the markerspace position of `items[k]`'s text
+block (already projected from data space). `markerspace` is the parent
+text plot's `markerspace` attribute.
 
-The default is conservative and registers child plots for both built-in
-primitive types. Downstream handlers should override:
-
-    Makie.text_primitive_types(::MyHandler) = (Makie.ImageTextPrimitive,)
+Default returns `PlotSpec[]` — a primitive type with no method here is
+silently invisible (still participates in bbox via `text_primitive_bbox`).
 """
-text_primitive_types(_handler) = (ImageTextPrimitive, LineSegmentTextPrimitive)
+text_primitive_plotspecs(::Type{<:AbstractTextPrimitive}, _items, _positions; markerspace = nothing) = PlotSpec[]
 
 """
     is_text_input(::Type) -> Bool
@@ -120,6 +125,14 @@ conversion_trait(::Type{<:Text}, args...) = PointBased()
 
 convert_attribute(o, ::key"offset", ::key"text") = to_3d_offset(o) # same as marker_offset in scatter
 convert_attribute(f, ::key"font", ::key"text") = f # later conversion with fonts
+# `latex_handler` is `nothing` (use built-in MathTeXEngine) or any callable
+# matching `convert_text_string!`'s signature. Returning `Ref{Any}(h)` keeps
+# the compute-graph storage slot untyped — without it, the theme default of
+# `nothing` would pin the slot to `Ref{Nothing}` and break later
+# `plot.latex_handler = MakieTeXLaTeX()` swaps. (See ComputePipeline
+# `locked_resolve!(::Input)`: returning a `Ref` from the convert function
+# is the documented escape hatch from type-narrowing.)
+convert_attribute(h, ::key"latex_handler", ::key"text") = Ref{Any}(h)
 
 # Positions are always vectors so text should be too. Anything not already
 # a vector is wrapped in one — that includes built-in string types and any
@@ -535,55 +548,56 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
 
     register_colormapping!(attr)
     register_text_computations!(attr)
-
-    # Only register child plots for primitive types the input could actually
-    # produce. Saves a plain `text!("hello")` from ending up with empty
-    # `linesegments!` + `scatter!` children dangling off it.
-    eltyp = eltype(plot.input_text[])
-    has_latex = eltyp == Any || eltyp <: LaTeXString
-    handler = plot.latex_handler[]
-    if has_latex && handler === nothing
-        # MathTeXEngine is built in and is the LaTeXString renderer when no
-        # `latex_handler` is set. It produces glyphs + `HLine`s (fraction
-        # rules, √ bars) → `LineSegmentTextPrimitive`.
-        register_text_primitive_plot!(plot, LineSegmentTextPrimitive)
-    end
-    if has_latex && handler !== nothing
-        # Ask the handler which primitive types it produces. Overrideable
-        # by handler authors via `Makie.text_primitive_types(h)`.
-        for T in text_primitive_types(handler)
-            register_text_primitive_plot!(plot, T)
-        end
-    end
+    register_text_primitives_plotlist!(plot)
     return
 end
 
-"""
-    register_text_primitive_plot!(plot::Plot{text}, ::Type{P})
-
-Default-dispatch hook for plugging an `AbstractTextPrimitive` subtype into the
-`text` recipe. Called once per primitive type from `calculated_attributes!`.
-Built-in implementation handles [`ImageTextPrimitive`](@ref) by registering a
-child `scatter!` plot. Downstream packages can register their own primitive
-types by extending this method (and `text_primitive_bbox`).
-"""
-register_text_primitive_plot!(plot, ::Type{<:AbstractTextPrimitive}) = nothing
-
-# Filter the heterogeneous text_primitives channel for entries of a specific
-# concrete primitive type. Returns aligned vectors of items, block indices,
-# offsets, sizes, and rotations suitable for a child scatter plot.
-function _filter_text_primitives(primitives::Vector{AbstractTextPrimitive}, block_indices::Vector{Int}, ::Type{T}) where {T <: AbstractTextPrimitive}
-    items = T[]
-    idxs = Int[]
-    for (b, p) in zip(block_indices, primitives)
-        p isa T || continue
-        push!(items, p)
-        push!(idxs, b)
-    end
-    return items, idxs
+# Built-in plotspec hook for `ImageTextPrimitive`: one Scatter per text plot
+# whose markers are the per-block images, anchored at the block's projected
+# markerspace position.
+function text_primitive_plotspecs(
+        ::Type{T}, items::Vector{T}, block_positions::Vector{Point3f}; markerspace
+    ) where {T <: ImageTextPrimitive}
+    isempty(items) && return PlotSpec[]
+    return [PlotSpec(
+        :Scatter, block_positions;
+        marker = Any[p.image for p in items],
+        markersize = Vec2f[p.size for p in items],
+        marker_offset = Vec3f[p.marker_offset for p in items],
+        rotation = Quaternionf[p.rotation for p in items],
+        space = markerspace,
+        markerspace = markerspace,
+    )]
 end
 
-function register_text_primitive_plot!(plot, ::Type{<:ImageTextPrimitive})
+# Built-in plotspec hook for `LineSegmentTextPrimitive`: one LineSegments
+# child carrying a flat list of endpoint pairs already shifted by the
+# block's projected markerspace position.
+function text_primitive_plotspecs(
+        ::Type{T}, items::Vector{T}, block_positions::Vector{Point3f}; markerspace
+    ) where {T <: LineSegmentTextPrimitive}
+    isempty(items) && return PlotSpec[]
+    pts = Point3f[]
+    widths = Float32[]
+    colors = RGBAf[]
+    for (item, shift) in zip(items, block_positions)
+        push!(pts, item.p0 + shift, item.p1 + shift)
+        push!(widths, item.width, item.width)
+        push!(colors, item.color, item.color)
+    end
+    return [PlotSpec(
+        :LineSegments, pts;
+        linewidth = widths,
+        color = colors,
+        space = markerspace,
+    )]
+end
+
+# Drive a single `plotlist!` child off the `text_primitives` channel. The
+# spec vector is rebuilt whenever primitives change, so the actual child
+# plot set is data-driven and updates reactively (swap `latex_handler` at
+# runtime, get different children with no extra plumbing).
+function register_text_primitives_plotlist!(plot)
     register_model_clip_planes!(plot.attributes)
 
     map!(
@@ -591,74 +605,28 @@ function register_text_primitive_plot!(plot, ::Type{<:ImageTextPrimitive})
         [
             :text_primitives, :text_primitive_block_indices,
             :preprojection, :model_f32c, :positions_transformed_f32c,
-            :model_clip_planes, :space,
+            :model_clip_planes, :space, :markerspace,
         ],
-        [
-            :_image_primitive_positions, :_image_primitive_markers,
-            :_image_primitive_sizes, :_image_primitive_offsets,
-            :_image_primitive_rotations,
-        ]
-    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space
-        items, idxs = _filter_text_primitives(prims, indices, ImageTextPrimitive)
-        if isempty(items)
-            return (Point3f[], Any[], Vec2f[], Vec3f[], Quaternionf[])
-        end
+        :_text_primitive_plotspecs,
+    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space, markerspace
+        isempty(prims) && return PlotSpec[]
         markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
-        out_pos = [markerspace_positions[idxs[i]] for i in eachindex(items)]
-        out_marker = Any[p.image for p in items]
-        out_size = [p.size for p in items]
-        out_offset = [p.marker_offset for p in items]
-        out_rot = [p.rotation for p in items]
-        return (out_pos, out_marker, out_size, out_offset, out_rot)
+        # Group primitives by concrete type. Stable, type-keyed buckets so
+        # we can call the typed `text_primitive_plotspecs` method for each.
+        by_type = Dict{Type, Vector{Int}}()
+        for (k, p) in enumerate(prims)
+            push!(get!(() -> Int[], by_type, typeof(p)), k)
+        end
+        out = PlotSpec[]
+        for (T, ks) in by_type
+            items = T[prims[k] for k in ks]
+            block_positions = Point3f[markerspace_positions[indices[k]] for k in ks]
+            append!(out, text_primitive_plotspecs(T, items, block_positions; markerspace))
+        end
+        return out
     end
 
-    return scatter!(
-        plot, plot._image_primitive_positions;
-        marker = plot._image_primitive_markers,
-        markersize = plot._image_primitive_sizes,
-        marker_offset = plot._image_primitive_offsets,
-        rotation = plot._image_primitive_rotations,
-        space = plot.markerspace,
-        markerspace = plot.markerspace,
-    )
-end
-
-function register_text_primitive_plot!(plot, ::Type{<:LineSegmentTextPrimitive})
-    register_model_clip_planes!(plot.attributes)
-
-    map!(
-        plot.attributes,
-        [
-            :text_primitives, :text_primitive_block_indices,
-            :preprojection, :model_f32c, :positions_transformed_f32c,
-            :model_clip_planes, :space,
-        ],
-        [:_lineseg_points, :_lineseg_widths, :_lineseg_colors]
-    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space
-        items, idxs = _filter_text_primitives(prims, indices, LineSegmentTextPrimitive)
-        if isempty(items)
-            return (Point3f[], Float32[], RGBAf[])
-        end
-        markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
-        # `linesegments!` expects a flat list of endpoint pairs.
-        pts = Point3f[]
-        widths = Float32[]
-        colors = RGBAf[]
-        for (item, block_idx) in zip(items, idxs)
-            shift = markerspace_positions[block_idx]
-            push!(pts, item.p0 + shift, item.p1 + shift)
-            push!(widths, item.width, item.width)
-            push!(colors, item.color, item.color)
-        end
-        return (pts, widths, colors)
-    end
-
-    return linesegments!(
-        plot, plot._lineseg_points;
-        linewidth = plot._lineseg_widths,
-        color = plot._lineseg_colors,
-        space = plot.markerspace,
-    )
+    return plotlist!(plot, plot._text_primitive_plotspecs)
 end
 
 ################################################################################

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -429,11 +429,11 @@ function register_text_computations!(attr::ComputeGraph)
         handler === nothing && return Any[]
         return Any[
             compile_text(
-                handler, str,
-                sv_getindex(colors, i),
-                sv_getindex(fontsizes, i),
-                sv_getindex(lineheights, i),
-            ) for (i, str) in enumerate(texts)
+                    handler, str,
+                    sv_getindex(colors, i),
+                    sv_getindex(fontsizes, i),
+                    sv_getindex(lineheights, i),
+                ) for (i, str) in enumerate(texts)
         ]
     end
 

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -4,42 +4,18 @@ function check_textsize_deprecation(@nospecialize(dictlike))
     end
 end
 
-# Side channel for arbitrary graphical content a `text` layout wants to
-# emit alongside glyphs. Items in the channel are plain `PlotSpec`s in
-# block-relative coords; the recipe owns a `PlotList` child plot that
-# materializes them, shifting each by the projected markerspace position
-# of its associated text block at draw time.
-#
-# A `convert_text_string!` method for a custom text type pushes three
-# parallel entries per emitted spec:
-#
-#   push!(outputs.text_specs, PlotSpec(:Scatter, …))   # block-relative
-#   push!(outputs.text_spec_block_indices, block_idx)
-#   push!(outputs.text_spec_bboxes, block_relative_bbox)
-#
-# `shift_text_spec(spec, offset)` is the hook for plot types whose
-# positional data isn't `args[1]`-as-a-Point-vector; defaults work for
-# `:Scatter` and `:LineSegments`.
-
 """
     shift_text_spec(spec::PlotSpec, offset::Point3f) -> PlotSpec
 
-Return a copy of `spec` with positional data offset by `offset` in
-markerspace. The default implementation treats `spec.args[1]` as the
-position vector and adds `offset` to each element — that works for
-`:Scatter`, `:LineSegments`, and any plot type that follows the same
-convention. Override on a per-`Val(spec.type)` basis for plot types
-whose positional data lives elsewhere.
+Return a copy of `spec` with positional data offset by `offset` in markerspace.
+The default treats `spec.args[1]` as a position vector — works for `:Scatter`,
+`:LineSegments`, etc. Override on `Val(spec.type)` for plot types whose
+positional data lives elsewhere.
 """
-function shift_text_spec(spec::PlotSpec, offset::Point3f)
-    return shift_text_spec(Val(spec.type), spec, offset)
-end
+shift_text_spec(spec::PlotSpec, offset::Point3f) = shift_text_spec(Val(spec.type), spec, offset)
 
 function shift_text_spec(::Val, spec::PlotSpec, offset::Point3f)
-    isempty(spec.args) && return spec
-    positions = spec.args[1]
-    positions isa AbstractVector || return spec
-    isempty(positions) && return spec
+    positions = first(spec.args)
     shifted = [Point3f(to_ndim(Point3f, p, 0)) + offset for p in positions]
     new_args = copy(spec.args)
     new_args[1] = shifted
@@ -49,20 +25,39 @@ end
 """
     is_text_input(::Type) -> Bool
 
-Trait that tells the `text` recipe "this type is one of my single-element
-inputs, route it into the string dispatch path rather than treating it as
-position data." Default `false`; built-in `true` for `AbstractString` and
-`RichText`. Downstream packages opt their types in with one method:
-
-    Makie.is_text_input(::Type{TeXString}) = true
-
-No subtyping required — the package's `convert_text_string!` method on the
-concrete type still does the work; this trait just gets the value to it.
+Trait marking single-element inputs the `text` recipe should route through the
+string dispatch path. Built-in for `AbstractString` and `RichText`; downstream
+packages opt in with `Makie.is_text_input(::Type{T}) = true`.
 """
 is_text_input(::Type) = false
 is_text_input(::Type{<:AbstractString}) = true
 is_text_input(::Type{<:RichText}) = true
-is_text_input(x) = is_text_input(typeof(x))
+
+"""
+    compile_text(handler, src, color, fontsize, lineheight) -> payload | nothing
+
+Engine-side step for a `text_handler`. Define methods dispatching on the input
+type the handler accepts (e.g. `LaTeXString`, `TypstString`, ...). Return an
+opaque payload the handler's `place_text!` later consumes, or `nothing` to
+fall through to the default glyph layout.
+
+Receives only the attributes that affect the rendered bytes — anything else
+(rotation, align, offset, ...) is for `place_text!`. Runs in a separate
+compute node so attribute changes that don't affect the engine output don't
+re-fire it.
+"""
+function compile_text end
+compile_text(handler, src, color, fontsize, lineheight) = nothing
+
+"""
+    place_text!(handler, outputs, i, N, compiled, fontsize, font, align, rotation,
+                justification, lineheight, word_wrap_width, offset, fonts, color,
+                strokecolor, strokewidth)
+
+Placement step. Receives the payload from `compile_text` plus the full
+attribute list and pushes to `outputs.text_specs`, `outputs.text_blocks`, etc.
+"""
+function place_text! end
 
 # We sort out position vs string(-like) vs mixed arguments before convert_arguments,
 # so that we only get positions here
@@ -70,18 +65,11 @@ conversion_trait(::Type{<:Text}, args...) = PointBased()
 
 convert_attribute(o, ::key"offset", ::key"text") = to_3d_offset(o) # same as marker_offset in scatter
 convert_attribute(f, ::key"font", ::key"text") = f # later conversion with fonts
-# `latex_handler` is `nothing` (use built-in MathTeXEngine) or any callable
-# matching `convert_text_string!`'s signature. Returning `Ref{Any}(h)` keeps
-# the compute-graph storage slot untyped — without it, the theme default of
-# `nothing` would pin the slot to `Ref{Nothing}` and break later
-# `plot.latex_handler = MakieTeXLaTeX()` swaps. (See ComputePipeline
-# `locked_resolve!(::Input)`: returning a `Ref` from the convert function
-# is the documented escape hatch from type-narrowing.)
-convert_attribute(h, ::key"latex_handler", ::key"text") = Ref{Any}(h)
+# Wrap in `Ref{Any}` so the compute-graph slot stays untyped — otherwise
+# the default `nothing` pins it to `Ref{Nothing}` and blocks runtime swaps.
+convert_attribute(h, ::key"text_handler", ::key"text") = Ref{Any}(h)
 
-# Positions are always vectors so text should be too. Anything not already
-# a vector is wrapped in one — that includes built-in string types and any
-# downstream payload that opted in via `is_text_input`.
+# Positions are always vectors so text should be too.
 convert_attribute(x::AbstractVector, ::key"text", ::key"text") = Ref{Any}(vec(x))
 convert_attribute(x, ::key"text", ::key"text") = Ref{Any}([x])
 
@@ -105,19 +93,20 @@ function register_arguments!(::Type{Text}, attr::ComputeGraph, user_kw, input_ar
     end
     register_computation!(attr, inputs, [:_positions, :input_text]) do inputs, changed, cached
         a_pos, a_text, args... = values(inputs)
-        # A single arg that opts in to `is_text_input` (built-in for
-        # AbstractString/RichText) is the text; the position comes from the
-        # attr. A vector whose element type opts in is a vector of texts.
+        # Single arg opting in via `is_text_input` is the text; position comes from the attr.
+        # Always emit a freshly-allocated vector for `:input_text` so ComputePipeline's
+        # `is_same(::Array, ::Array)` pointer-distinctness check can confirm structural
+        # equality on refires triggered by unrelated inputs (e.g. position layout writes).
         if length(args) == 1 && is_text_input(typeof(args[1]))
-            # position data will always be wrapped in a Vector, so strings should too
             return ((a_pos,), Ref{Any}([args[1]]))
         elseif length(args) == 1 && args[1] isa AbstractVector && is_text_input(eltype(args[1]))
-            return ((a_pos,), Ref{Any}(args[1]))
+            return ((a_pos,), Ref{Any}(copy(args[1])))
         elseif args isa Tuple{<:AbstractVector{<:Tuple{<:Any, <:VecTypes}}}
             # [(text, pos), ...] argument
             return ((last.(args[1]),), Ref{Any}(first.(args[1])))
         else # assume position data
-            return (args, Ref{Any}(to_string_arr(a_text)))
+            text_vec = to_string_arr(a_text)
+            return (args, Ref{Any}(text_vec === a_text ? copy(text_vec) : text_vec))
         end
     end
 
@@ -347,39 +336,36 @@ function append_tex_linesegment_data!(
 
     block_idx = length(outputs.text_blocks)
 
-    # Accumulate all HLines for this text block into a single LineSegments
-    # spec — cheaper than one PlotList child per fraction bar / √ rule.
     points = Point3f[]
     widths = Float32[]
     colors = RGBAf[]
     bb = Rect3d()
     for (element, position, _) in tex_elements
-        if element isa MathTeXEngine.HLine
-            h = element
-            x, y = position
-            p0 = rotation * to_ndim(Point3f, fontsize .* Point2f(x, y) .- tex_offset, 0) .+ offset
-            p1 = rotation * to_ndim(Point3f, fontsize .* Point2f(x + h.width, y) .- tex_offset, 0) .+ offset
-            w = Float32(fontsize * h.thickness)
-            push!(points, p0, p1)
-            push!(widths, w, w)
-            push!(colors, color, color)
-            lo = min.(p0, p1) .- 0.5f0 * w
-            hi = max.(p0, p1) .+ 0.5f0 * w
-            bb = update_boundingbox(bb, Rect3d(Point3d(lo), Vec3d(hi .- lo)))
-        end
+        element isa MathTeXEngine.HLine || continue
+        x, y = position
+        p0 = rotation * to_ndim(Point3f, fontsize .* Point2f(x, y) .- tex_offset, 0) .+ offset
+        p1 = rotation * to_ndim(Point3f, fontsize .* Point2f(x + element.width, y) .- tex_offset, 0) .+ offset
+        w = Float32(fontsize * element.thickness)
+        push!(points, p0, p1)
+        push!(widths, w, w)
+        push!(colors, color, color)
+        lo = min.(p0, p1) .- 0.5f0 * w
+        hi = max.(p0, p1) .+ 0.5f0 * w
+        bb = update_boundingbox(bb, Rect3d(Point3d(lo), Vec3d(hi .- lo)))
     end
-    isempty(points) && return nothing
+    isempty(points) && return
 
     push!(outputs.text_specs, PlotSpec(:LineSegments, points; linewidth = widths, color = colors))
     push!(outputs.text_spec_block_indices, block_idx)
     push!(outputs.text_spec_bboxes, bb)
-    return nothing
+    return
 end
 
 function compute_glyph_collections!(attr::ComputeGraph)
     inputs = [
         :input_text,
-        :latex_handler,
+        :text_handler,
+        :compiled_text_blocks,
         :fontsize,
         :selected_font,
         :align,
@@ -402,7 +388,7 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :text_strokewidth, :text_strokecolor,
         :text_specs, :text_spec_block_indices, :text_spec_bboxes,
     ]
-    return register_computation!(attr, inputs, outputs) do (input_texts, latex_handler, _inputs...), changed, cached
+    return register_computation!(attr, inputs, outputs) do (input_texts, text_handler, compiled_blocks, _inputs...), changed, cached
         _outputs = (
             glyphcollections = GlyphCollection[],
             glyphindices = UInt64[],
@@ -423,10 +409,9 @@ function compute_glyph_collections!(attr::ComputeGraph)
 
         N = length(input_texts)
         for (block_index, str) in enumerate(input_texts)
-            # `LaTeXString` is themable: if `latex_handler` is set, route the
-            # block through it instead of the built-in MathTeXEngine path.
-            if str isa LaTeXString && latex_handler !== nothing
-                latex_handler(_outputs, str, block_index, N, _inputs...)
+            compiled = text_handler === nothing ? nothing : compiled_blocks[block_index]
+            if compiled !== nothing
+                place_text!(text_handler, _outputs, block_index, N, compiled, _inputs...)
             else
                 convert_text_string!(_outputs, str, block_index, N, _inputs...)
             end
@@ -445,6 +430,25 @@ function register_text_computations!(attr::ComputeGraph)
     # Resolve colormapping to colors early. This allows rich text which returns
     # its own colors to be mixed with other text types which dont.
     add_computation!(attr, Val(:computed_color))
+
+    # Narrow-input handler compile node: only re-fires when something that
+    # changes the rendered bytes changes. Rotation/align/offset/etc. don't.
+    # `compile_text` returns `nothing` by default; handlers override on the
+    # input types they accept (e.g. `LaTeXString`, `TypstString`).
+    map!(
+        attr, [:input_text, :text_handler, :computed_color, :fontsize, :lineheight],
+        :compiled_text_blocks,
+    ) do texts, handler, colors, fontsizes, lineheights
+        handler === nothing && return Any[]
+        return Any[
+            compile_text(
+                handler, str,
+                sv_getindex(colors, i),
+                sv_getindex(fontsizes, i),
+                sv_getindex(lineheights, i),
+            ) for (i, str) in enumerate(texts)
+        ]
+    end
 
     # This computes :glyphindices, :font_per_char, :glyph_origins, :glyph_extents, :text_blocks
     # And :glyphcollection if applicable
@@ -511,14 +515,9 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
     return
 end
 
-# Single `plotlist!` child driven by the `text_specs` channel. The spec
-# vector is rebuilt whenever specs / projections change, so the actual
-# rendered child set is data-driven and updates reactively (swap
-# `latex_handler` at runtime, get different children with no extra
-# plumbing). Each block-relative spec is shifted by the projected
-# markerspace position of its text block, plus the parent's `markerspace`
-# is propagated into every spec's `space` / `markerspace` kwargs so the
-# children render in the right coordinate system.
+# Materialize `text_specs` as a `plotlist!` child: shift each spec by the
+# projected markerspace position of its block, then render in the parent's
+# markerspace. Rebuilt reactively when specs or projections change.
 function register_text_specs_plotlist!(plot)
     register_model_clip_planes!(plot.attributes)
 
@@ -533,17 +532,13 @@ function register_text_specs_plotlist!(plot)
     ) do specs, indices, preprojection, model_f32c, positions, clip_planes, space, markerspace
         isempty(specs) && return PlotSpec[]
         markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
-        out = Vector{PlotSpec}(undef, length(specs))
-        for k in eachindex(specs)
-            offset = markerspace_positions[indices[k]]
-            shifted = shift_text_spec(specs[k], offset)
-            # Tag the spec with the parent text plot's markerspace.
+        return map(specs, indices) do spec, idx
+            shifted = shift_text_spec(spec, markerspace_positions[idx])
             kw = copy(shifted.kwargs)
             kw[:space] = markerspace
             get(kw, :markerspace, nothing) === nothing || (kw[:markerspace] = markerspace)
-            out[k] = PlotSpec(shifted.type, shifted.args...; kw...)
+            return PlotSpec(shifted.type, shifted.args...; kw...)
         end
-        return out
     end
 
     return plotlist!(plot, plot._text_plotlist_specs)

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -78,6 +78,27 @@ function text_primitive_bbox(p::ImageTextPrimitive)
     return rotate_bbox(bb, p.rotation)
 end
 
+"""
+    LineSegmentTextPrimitive(p0::Point3f, p1::Point3f, width::Float32, color::RGBAf)
+
+A text primitive that renders a single line segment alongside glyphs in a
+text block. Used by the MathTeXEngine path for LaTeXStrings to draw fraction
+bars and `\\sqrt` rules. Endpoints are markerspace coordinates relative to
+the text block's position.
+"""
+struct LineSegmentTextPrimitive <: AbstractTextPrimitive
+    p0::Point3f
+    p1::Point3f
+    width::Float32
+    color::RGBAf
+end
+
+function text_primitive_bbox(p::LineSegmentTextPrimitive)
+    lo = min.(p.p0, p.p1) .- 0.5f0 * p.width
+    hi = max.(p.p0, p.p1) .+ 0.5f0 * p.width
+    return Rect3d(Point3d(lo), Vec3d(hi .- lo))
+end
+
 # We sort out position vs string(-like) vs mixed arguments before convert_arguments,
 # so that we only get positions here
 conversion_trait(::Type{<:Text}, args...) = PointBased()
@@ -352,7 +373,6 @@ function append_tex_linesegment_data!(
     )
 
     block_idx = length(outputs.text_blocks)
-    pos_idx = first(last(outputs.text_blocks))
 
     for (element, position, _) in tex_elements
         if element isa MathTeXEngine.HLine
@@ -360,10 +380,11 @@ function append_tex_linesegment_data!(
             x, y = position
             p0 = rotation * to_ndim(Point3f, fontsize .* Point2f(x, y) .- tex_offset, 0) .+ offset
             p1 = rotation * to_ndim(Point3f, fontsize .* Point2f(x + h.width, y) .- tex_offset, 0) .+ offset
-            push!(outputs.linesegments, p0, p1)
-            push!(outputs.linewidths, fontsize * h.thickness, fontsize * h.thickness)
-            push!(outputs.linecolors, color, color)
-            push!(outputs.lineindices, block_idx => pos_idx, block_idx => pos_idx)
+            push!(
+                outputs.text_primitives,
+                LineSegmentTextPrimitive(p0, p1, Float32(fontsize * h.thickness), color)
+            )
+            push!(outputs.text_primitive_block_indices, block_idx)
         end
     end
     return nothing
@@ -393,7 +414,6 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :text_blocks,
         :text_color, :text_rotation, :text_scales,
         :text_strokewidth, :text_strokecolor,
-        :linesegments, :linewidths, :linecolors, :lineindices,
         :text_primitives, :text_primitive_block_indices,
     ]
     return register_computation!(attr, inputs, outputs) do (input_texts, latex_handler, _inputs...), changed, cached
@@ -409,10 +429,6 @@ function compute_glyph_collections!(attr::ComputeGraph)
             text_scales = Vec2f[],
             text_strokewidth = Float32[],
             text_strokecolor = RGBAf[],
-            linesegments = Point3f[],
-            linewidths = Float32[],
-            linecolors = RGBAf[],
-            lineindices = Pair{Int, Int}[],
             text_primitives = AbstractTextPrimitive[],
             text_primitive_block_indices = Int[],
         )
@@ -504,8 +520,23 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
 
     register_colormapping!(attr)
     register_text_computations!(attr)
-    tex_linesegments!(plot)
-    return register_text_primitive_plot!(plot, ImageTextPrimitive)
+
+    # Only register child plots for primitive types the input could actually
+    # produce. Saves a plain `text!("hello")` from ending up with empty
+    # `linesegments!` + `scatter!` children dangling off it.
+    eltyp = eltype(plot.input_text[])
+    has_latex = eltyp == Any || eltyp <: LaTeXString
+    handler = plot.latex_handler[]
+    if has_latex && handler === nothing
+        # MathTeXEngine path produces `HLine` elements (fraction rules,
+        # √ bars) — but only when it's the active LaTeX renderer.
+        register_text_primitive_plot!(plot, LineSegmentTextPrimitive)
+    end
+    if has_latex && handler !== nothing
+        # `MakieTeXLaTeX` and similar handlers push image markers.
+        register_text_primitive_plot!(plot, ImageTextPrimitive)
+    end
+    return
 end
 
 """
@@ -573,26 +604,41 @@ function register_text_primitive_plot!(plot, ::Type{<:ImageTextPrimitive})
     )
 end
 
-function tex_linesegments!(plot)
+function register_text_primitive_plot!(plot, ::Type{<:LineSegmentTextPrimitive})
     register_model_clip_planes!(plot.attributes)
 
-    # Don't user register_markerspace_positions() here so we skip calculating them
-    # if no linesegments are needed
     map!(
         plot.attributes,
-        [:linesegments, :lineindices, :preprojection, :model_f32c, :positions_transformed_f32c, :model_clip_planes, :space],
-        :linesgments_shifted
-    ) do linesegments, indices, preprojection, model_f32c, positions, clip_planes, space
-        isempty(linesegments) && return Point3f[]
-        markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
-        return map(linesegments, indices) do seg, (block_idx, glyph_idx)
-            return seg + markerspace_positions[block_idx]
+        [
+            :text_primitives, :text_primitive_block_indices,
+            :preprojection, :model_f32c, :positions_transformed_f32c,
+            :model_clip_planes, :space,
+        ],
+        [:_lineseg_points, :_lineseg_widths, :_lineseg_colors]
+    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space
+        items, idxs = _filter_text_primitives(prims, indices, LineSegmentTextPrimitive)
+        if isempty(items)
+            return (Point3f[], Float32[], RGBAf[])
         end
+        markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
+        # `linesegments!` expects a flat list of endpoint pairs.
+        pts = Point3f[]
+        widths = Float32[]
+        colors = RGBAf[]
+        for (item, block_idx) in zip(items, idxs)
+            shift = markerspace_positions[block_idx]
+            push!(pts, item.p0 + shift, item.p1 + shift)
+            push!(widths, item.width, item.width)
+            push!(colors, item.color, item.color)
+        end
+        return (pts, widths, colors)
     end
 
     return linesegments!(
-        plot, plot.linesgments_shifted; linewidth = plot.linewidths,
-        color = plot.linecolors, space = plot.markerspace
+        plot, plot._lineseg_points;
+        linewidth = plot._lineseg_widths,
+        color = plot._lineseg_colors,
+        space = plot.markerspace,
     )
 end
 
@@ -739,9 +785,9 @@ function register_raw_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :linesegments, :linewidths, :lineindices, :text_primitives, :text_primitive_block_indices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :text_primitives, :text_primitive_block_indices],
             :raw_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices, primitives, primitive_block_indices
+        ) do blocks, bbs, origins, rotation, primitives, primitive_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d()
@@ -752,11 +798,6 @@ function register_raw_string_boundingboxes!(plot)
                     output = update_boundingbox(output, ms_bb)
                 end
                 return output
-            end
-
-            for (pos, lw, (block_idx, glyph_idx)) in zip(segments, linewidths, lineindices)
-                bb = Rect3d(to_ndim(Point3d, pos, 0) .- 0.5lw, Vec3d(lw))
-                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
             end
 
             for (block_idx, prim) in zip(primitive_block_indices, primitives)
@@ -785,9 +826,9 @@ function register_fast_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :linesegments, :linewidths, :lineindices, :text_primitives, :text_primitive_block_indices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :text_primitives, :text_primitive_block_indices],
             :fast_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, segments, linewidths, lineindices, primitives, primitive_block_indices
+        ) do blocks, bbs, origins, rotation, primitives, primitive_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d(Point3d(NaN), Vec3d(0))
@@ -798,11 +839,6 @@ function register_fast_string_boundingboxes!(plot)
                     output = update_boundingbox(output, ms_bb)
                 end
                 return output
-            end
-
-            for (pos, lw, (block_idx, glyph_idx)) in zip(segments, linewidths, lineindices)
-                bb = Rect3d(to_ndim(Point3d, pos, 0) .- 0.5lw, Vec3d(lw))
-                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
             end
 
             for (block_idx, prim) in zip(primitive_block_indices, primitives)

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -35,6 +35,24 @@ function text_primitive_bbox end
 function register_text_primitive_plot! end
 
 """
+    is_text_input(::Type) -> Bool
+
+Trait that tells the `text` recipe "this type is one of my single-element
+inputs, route it into the string dispatch path rather than treating it as
+position data." Default `false`; built-in `true` for `AbstractString` and
+`RichText`. Downstream packages opt their types in with one method:
+
+    Makie.is_text_input(::Type{TeXString}) = true
+
+No subtyping required — the package's `convert_text_string!` method on the
+concrete type still does the work; this trait just gets the value to it.
+"""
+is_text_input(::Type) = false
+is_text_input(::Type{<:AbstractString}) = true
+is_text_input(::Type{<:RichText}) = true
+is_text_input(x) = is_text_input(typeof(x))
+
+"""
     ImageTextPrimitive(image, marker_offset::Vec3f, size::Vec2f, rotation::Quaternionf)
 
 A text primitive that renders `image` as a single scatter marker at the
@@ -67,10 +85,11 @@ conversion_trait(::Type{<:Text}, args...) = PointBased()
 convert_attribute(o, ::key"offset", ::key"text") = to_3d_offset(o) # same as marker_offset in scatter
 convert_attribute(f, ::key"font", ::key"text") = f # later conversion with fonts
 
-# Positions are always vectors so text should be too
-convert_attribute(str::AbstractString, ::key"text", ::key"text") = Ref{Any}([str]) # don't fix string type
-convert_attribute(rt::RichText, ::key"text", ::key"text") = Ref{Any}([rt])
+# Positions are always vectors so text should be too. Anything not already
+# a vector is wrapped in one — that includes built-in string types and any
+# downstream payload that opted in via `is_text_input`.
 convert_attribute(x::AbstractVector, ::key"text", ::key"text") = Ref{Any}(vec(x))
+convert_attribute(x, ::key"text", ::key"text") = Ref{Any}([x])
 
 to_string_arr(text::AbstractVector) = text
 to_string_arr(text) = [text]
@@ -92,11 +111,13 @@ function register_arguments!(::Type{Text}, attr::ComputeGraph, user_kw, input_ar
     end
     register_computation!(attr, inputs, [:_positions, :input_text]) do inputs, changed, cached
         a_pos, a_text, args... = values(inputs)
-        # Note: Could add RichText
-        if args isa Tuple{<:AbstractString}
+        # A single arg that opts in to `is_text_input` (built-in for
+        # AbstractString/RichText) is the text; the position comes from the
+        # attr. A vector whose element type opts in is a vector of texts.
+        if length(args) == 1 && is_text_input(typeof(args[1]))
             # position data will always be wrapped in a Vector, so strings should too
             return ((a_pos,), Ref{Any}([args[1]]))
-        elseif args isa Tuple{<:AbstractVector{<:AbstractString}}
+        elseif length(args) == 1 && args[1] isa AbstractVector && is_text_input(eltype(args[1]))
             return ((a_pos,), Ref{Any}(args[1]))
         elseif args isa Tuple{<:AbstractVector{<:Tuple{<:Any, <:VecTypes}}}
             # [(text, pos), ...] argument

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -4,55 +4,47 @@ function check_textsize_deprecation(@nospecialize(dictlike))
     end
 end
 
-# Text primitives: pluggable graphical elements that a string layout can emit
-# alongside (or instead of) glyphs. Built-in: glyphs and MathTeX line segments
-# have dedicated channels for performance; arbitrary primitives go through
-# the `text_primitives` channel below and are dispatched to child plots via
-# `register_text_primitive_plot!`.
+# Side channel for arbitrary graphical content a `text` layout wants to
+# emit alongside glyphs. Items in the channel are plain `PlotSpec`s in
+# block-relative coords; the recipe owns a `PlotList` child plot that
+# materializes them, shifting each by the projected markerspace position
+# of its associated text block at draw time.
+#
+# A `convert_text_string!` method for a custom text type pushes three
+# parallel entries per emitted spec:
+#
+#   push!(outputs.text_specs, PlotSpec(:Scatter, …))   # block-relative
+#   push!(outputs.text_spec_block_indices, block_idx)
+#   push!(outputs.text_spec_bboxes, block_relative_bbox)
+#
+# `shift_text_spec(spec, offset)` is the hook for plot types whose
+# positional data isn't `args[1]`-as-a-Point-vector; defaults work for
+# `:Scatter` and `:LineSegments`.
 
 """
-    AbstractTextPrimitive
+    shift_text_spec(spec::PlotSpec, offset::Point3f) -> PlotSpec
 
-Supertype for graphical elements that a `text` plot can render at the
-markerspace position of a text block. Built-in subtypes include
-[`ImageTextPrimitive`](@ref) and [`LineSegmentTextPrimitive`](@ref);
-downstream packages (e.g. MakieTeX) define their own to plug arbitrary
-content into `text`.
-
-A subtype `P` must implement:
-
-* `text_primitive_bbox(p::P)::Rect3d` — markerspace bounding box relative to
-  the text block origin (used by the text plot's bounding-box pipeline).
-* `text_primitive_plotspecs(::Type{P}, items::Vector{P}, block_positions::Vector{Point3f}; markerspace)`
-   — returns a `Vector{PlotSpec}` describing how to render `items`. Called
-   once per concrete primitive type, with `block_positions[k]` being the
-   already-projected markerspace position of `items[k]`'s text block. The
-   PlotSpecs feed a single `plotlist!` child of the text plot, so the
-   actual child plot set is data-driven and updates reactively if the
-   primitive types in use change (e.g. swapping `latex_handler` at
-   runtime).
-
-Items are pushed by `convert_text_string!` overloads (one per input text
-type) into the `outputs.text_primitives` channel.
+Return a copy of `spec` with positional data offset by `offset` in
+markerspace. The default implementation treats `spec.args[1]` as the
+position vector and adds `offset` to each element — that works for
+`:Scatter`, `:LineSegments`, and any plot type that follows the same
+convention. Override on a per-`Val(spec.type)` basis for plot types
+whose positional data lives elsewhere.
 """
-abstract type AbstractTextPrimitive end
+function shift_text_spec(spec::PlotSpec, offset::Point3f)
+    return shift_text_spec(Val(spec.type), spec, offset)
+end
 
-function text_primitive_bbox end
-
-"""
-    text_primitive_plotspecs(::Type{T}, items::Vector{T},
-                             block_positions::Vector{Point3f}; markerspace)
-        -> Vector{PlotSpec}
-
-Extension hook returning PlotSpecs that render `items` of primitive type
-`T`. `block_positions[k]` is the markerspace position of `items[k]`'s text
-block (already projected from data space). `markerspace` is the parent
-text plot's `markerspace` attribute.
-
-Default returns `PlotSpec[]` — a primitive type with no method here is
-silently invisible (still participates in bbox via `text_primitive_bbox`).
-"""
-text_primitive_plotspecs(::Type{<:AbstractTextPrimitive}, _items, _positions; markerspace = nothing) = PlotSpec[]
+function shift_text_spec(::Val, spec::PlotSpec, offset::Point3f)
+    isempty(spec.args) && return spec
+    positions = spec.args[1]
+    positions isa AbstractVector || return spec
+    isempty(positions) && return spec
+    shifted = [Point3f(to_ndim(Point3f, p, 0)) + offset for p in positions]
+    new_args = copy(spec.args)
+    new_args[1] = shifted
+    return PlotSpec(spec.type, new_args...; spec.kwargs...)
+end
 
 """
     is_text_input(::Type) -> Bool
@@ -71,53 +63,6 @@ is_text_input(::Type) = false
 is_text_input(::Type{<:AbstractString}) = true
 is_text_input(::Type{<:RichText}) = true
 is_text_input(x) = is_text_input(typeof(x))
-
-"""
-    ImageTextPrimitive(image, marker_offset::Vec3f, size::Vec2f, rotation::Quaternionf)
-
-A text primitive that renders `image` as a single scatter marker at the
-text block's position. Used by e.g. MakieTeX to embed pre-rendered LaTeX
-into a Makie `text` plot.
-
-* `image`     — any marker accepted by `scatter` (typically a `Matrix{<:Colorant}`)
-* `marker_offset` — markerspace offset from the block origin to the marker's
-                    center (this matches `scatter`'s `marker_offset` semantics)
-* `size`      — markerspace marker size
-* `rotation`  — applied to the marker by scatter
-"""
-struct ImageTextPrimitive{I} <: AbstractTextPrimitive
-    image::I
-    marker_offset::Vec3f
-    size::Vec2f
-    rotation::Quaternionf
-end
-
-function text_primitive_bbox(p::ImageTextPrimitive)
-    half = 0.5 .* Vec3d(p.size..., 0)
-    bb = Rect3d(to_ndim(Point3d, p.marker_offset, 0) .- half, Vec3d(p.size..., 0))
-    return rotate_bbox(bb, p.rotation)
-end
-
-"""
-    LineSegmentTextPrimitive(p0::Point3f, p1::Point3f, width::Float32, color::RGBAf)
-
-A text primitive that renders a single line segment alongside glyphs in a
-text block. Used by the MathTeXEngine path for LaTeXStrings to draw fraction
-bars and `\\sqrt` rules. Endpoints are markerspace coordinates relative to
-the text block's position.
-"""
-struct LineSegmentTextPrimitive <: AbstractTextPrimitive
-    p0::Point3f
-    p1::Point3f
-    width::Float32
-    color::RGBAf
-end
-
-function text_primitive_bbox(p::LineSegmentTextPrimitive)
-    lo = min.(p.p0, p.p1) .- 0.5f0 * p.width
-    hi = max.(p.p0, p.p1) .+ 0.5f0 * p.width
-    return Rect3d(Point3d(lo), Vec3d(hi .- lo))
-end
 
 # We sort out position vs string(-like) vs mixed arguments before convert_arguments,
 # so that we only get positions here
@@ -402,19 +347,32 @@ function append_tex_linesegment_data!(
 
     block_idx = length(outputs.text_blocks)
 
+    # Accumulate all HLines for this text block into a single LineSegments
+    # spec — cheaper than one PlotList child per fraction bar / √ rule.
+    points = Point3f[]
+    widths = Float32[]
+    colors = RGBAf[]
+    bb = Rect3d()
     for (element, position, _) in tex_elements
         if element isa MathTeXEngine.HLine
             h = element
             x, y = position
             p0 = rotation * to_ndim(Point3f, fontsize .* Point2f(x, y) .- tex_offset, 0) .+ offset
             p1 = rotation * to_ndim(Point3f, fontsize .* Point2f(x + h.width, y) .- tex_offset, 0) .+ offset
-            push!(
-                outputs.text_primitives,
-                LineSegmentTextPrimitive(p0, p1, Float32(fontsize * h.thickness), color)
-            )
-            push!(outputs.text_primitive_block_indices, block_idx)
+            w = Float32(fontsize * h.thickness)
+            push!(points, p0, p1)
+            push!(widths, w, w)
+            push!(colors, color, color)
+            lo = min.(p0, p1) .- 0.5f0 * w
+            hi = max.(p0, p1) .+ 0.5f0 * w
+            bb = update_boundingbox(bb, Rect3d(Point3d(lo), Vec3d(hi .- lo)))
         end
     end
+    isempty(points) && return nothing
+
+    push!(outputs.text_specs, PlotSpec(:LineSegments, points; linewidth = widths, color = colors))
+    push!(outputs.text_spec_block_indices, block_idx)
+    push!(outputs.text_spec_bboxes, bb)
     return nothing
 end
 
@@ -442,7 +400,7 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :text_blocks,
         :text_color, :text_rotation, :text_scales,
         :text_strokewidth, :text_strokecolor,
-        :text_primitives, :text_primitive_block_indices,
+        :text_specs, :text_spec_block_indices, :text_spec_bboxes,
     ]
     return register_computation!(attr, inputs, outputs) do (input_texts, latex_handler, _inputs...), changed, cached
         _outputs = (
@@ -457,8 +415,9 @@ function compute_glyph_collections!(attr::ComputeGraph)
             text_scales = Vec2f[],
             text_strokewidth = Float32[],
             text_strokecolor = RGBAf[],
-            text_primitives = AbstractTextPrimitive[],
-            text_primitive_block_indices = Int[],
+            text_specs = PlotSpec[],
+            text_spec_block_indices = Int[],
+            text_spec_bboxes = Rect3d[],
         )
         # strokewidth = Float32[] # TODO: Skipped?
 
@@ -548,85 +507,46 @@ function calculated_attributes!(::Type{Text}, plot::Plot)
 
     register_colormapping!(attr)
     register_text_computations!(attr)
-    register_text_primitives_plotlist!(plot)
+    register_text_specs_plotlist!(plot)
     return
 end
 
-# Built-in plotspec hook for `ImageTextPrimitive`: one Scatter per text plot
-# whose markers are the per-block images, anchored at the block's projected
-# markerspace position.
-function text_primitive_plotspecs(
-        ::Type{T}, items::Vector{T}, block_positions::Vector{Point3f}; markerspace
-    ) where {T <: ImageTextPrimitive}
-    isempty(items) && return PlotSpec[]
-    return [PlotSpec(
-        :Scatter, block_positions;
-        marker = Any[p.image for p in items],
-        markersize = Vec2f[p.size for p in items],
-        marker_offset = Vec3f[p.marker_offset for p in items],
-        rotation = Quaternionf[p.rotation for p in items],
-        space = markerspace,
-        markerspace = markerspace,
-    )]
-end
-
-# Built-in plotspec hook for `LineSegmentTextPrimitive`: one LineSegments
-# child carrying a flat list of endpoint pairs already shifted by the
-# block's projected markerspace position.
-function text_primitive_plotspecs(
-        ::Type{T}, items::Vector{T}, block_positions::Vector{Point3f}; markerspace
-    ) where {T <: LineSegmentTextPrimitive}
-    isempty(items) && return PlotSpec[]
-    pts = Point3f[]
-    widths = Float32[]
-    colors = RGBAf[]
-    for (item, shift) in zip(items, block_positions)
-        push!(pts, item.p0 + shift, item.p1 + shift)
-        push!(widths, item.width, item.width)
-        push!(colors, item.color, item.color)
-    end
-    return [PlotSpec(
-        :LineSegments, pts;
-        linewidth = widths,
-        color = colors,
-        space = markerspace,
-    )]
-end
-
-# Drive a single `plotlist!` child off the `text_primitives` channel. The
-# spec vector is rebuilt whenever primitives change, so the actual child
-# plot set is data-driven and updates reactively (swap `latex_handler` at
-# runtime, get different children with no extra plumbing).
-function register_text_primitives_plotlist!(plot)
+# Single `plotlist!` child driven by the `text_specs` channel. The spec
+# vector is rebuilt whenever specs / projections change, so the actual
+# rendered child set is data-driven and updates reactively (swap
+# `latex_handler` at runtime, get different children with no extra
+# plumbing). Each block-relative spec is shifted by the projected
+# markerspace position of its text block, plus the parent's `markerspace`
+# is propagated into every spec's `space` / `markerspace` kwargs so the
+# children render in the right coordinate system.
+function register_text_specs_plotlist!(plot)
     register_model_clip_planes!(plot.attributes)
 
     map!(
         plot.attributes,
         [
-            :text_primitives, :text_primitive_block_indices,
+            :text_specs, :text_spec_block_indices,
             :preprojection, :model_f32c, :positions_transformed_f32c,
             :model_clip_planes, :space, :markerspace,
         ],
-        :_text_primitive_plotspecs,
-    ) do prims, indices, preprojection, model_f32c, positions, clip_planes, space, markerspace
-        isempty(prims) && return PlotSpec[]
+        :_text_plotlist_specs,
+    ) do specs, indices, preprojection, model_f32c, positions, clip_planes, space, markerspace
+        isempty(specs) && return PlotSpec[]
         markerspace_positions = _project(preprojection * model_f32c, positions, clip_planes, space)
-        # Group primitives by concrete type. Stable, type-keyed buckets so
-        # we can call the typed `text_primitive_plotspecs` method for each.
-        by_type = Dict{Type, Vector{Int}}()
-        for (k, p) in enumerate(prims)
-            push!(get!(() -> Int[], by_type, typeof(p)), k)
-        end
-        out = PlotSpec[]
-        for (T, ks) in by_type
-            items = T[prims[k] for k in ks]
-            block_positions = Point3f[markerspace_positions[indices[k]] for k in ks]
-            append!(out, text_primitive_plotspecs(T, items, block_positions; markerspace))
+        out = Vector{PlotSpec}(undef, length(specs))
+        for k in eachindex(specs)
+            offset = markerspace_positions[indices[k]]
+            shifted = shift_text_spec(specs[k], offset)
+            # Tag the spec with the parent text plot's markerspace.
+            kw = copy(shifted.kwargs)
+            kw[:space] = markerspace
+            get(kw, :markerspace, nothing) === nothing || (kw[:markerspace] = markerspace)
+            out[k] = PlotSpec(shifted.type, shifted.args...; kw...)
         end
         return out
     end
 
-    return plotlist!(plot, plot._text_primitive_plotspecs)
+    return plotlist!(plot, plot._text_plotlist_specs)
 end
 
 ################################################################################
@@ -772,9 +692,9 @@ function register_raw_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :text_primitives, :text_primitive_block_indices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :glyph_origins, :text_rotation, :text_spec_bboxes, :text_spec_block_indices],
             :raw_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, primitives, primitive_block_indices
+        ) do blocks, bbs, origins, rotation, spec_bboxes, spec_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d()
@@ -787,8 +707,8 @@ function register_raw_string_boundingboxes!(plot)
                 return output
             end
 
-            for (block_idx, prim) in zip(primitive_block_indices, primitives)
-                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], text_primitive_bbox(prim))
+            for (block_idx, bb) in zip(spec_block_indices, spec_bboxes)
+                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
             end
 
             return text_bbs
@@ -813,9 +733,9 @@ function register_fast_string_boundingboxes!(plot)
         # To consider newlines (and word_wrap_width) we need to include origins.
         # To not include rotation we need to strip it from origins
         map!(
-            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :text_primitives, :text_primitive_block_indices],
+            plot.attributes, [:text_blocks, :raw_glyph_boundingboxes, :marker_offset, :text_rotation, :text_spec_bboxes, :text_spec_block_indices],
             :fast_string_boundingboxes
-        ) do blocks, bbs, origins, rotation, primitives, primitive_block_indices
+        ) do blocks, bbs, origins, rotation, spec_bboxes, spec_block_indices
 
             text_bbs = map(blocks) do idxs
                 output = Rect3d(Point3d(NaN), Vec3d(0))
@@ -828,8 +748,8 @@ function register_fast_string_boundingboxes!(plot)
                 return output
             end
 
-            for (block_idx, prim) in zip(primitive_block_indices, primitives)
-                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], text_primitive_bbox(prim))
+            for (block_idx, bb) in zip(spec_block_indices, spec_bboxes)
+                text_bbs[block_idx] = update_boundingbox(text_bbs[block_idx], bb)
             end
 
             return text_bbs

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -23,17 +23,6 @@ function shift_text_spec(::Val, spec::PlotSpec, offset::Point3f)
 end
 
 """
-    is_text_input(::Type) -> Bool
-
-Trait marking single-element inputs the `text` recipe should route through the
-string dispatch path. Built-in for `AbstractString` and `RichText`; downstream
-packages opt in with `Makie.is_text_input(::Type{T}) = true`.
-"""
-is_text_input(::Type) = false
-is_text_input(::Type{<:AbstractString}) = true
-is_text_input(::Type{<:RichText}) = true
-
-"""
     compile_text(handler, src, color, fontsize, lineheight) -> payload | nothing
 
 Engine-side step for a `text_handler`. Define methods dispatching on the input
@@ -93,15 +82,13 @@ function register_arguments!(::Type{Text}, attr::ComputeGraph, user_kw, input_ar
     end
     register_computation!(attr, inputs, [:_positions, :input_text]) do inputs, changed, cached
         a_pos, a_text, args... = values(inputs)
-        # Single arg opting in via `is_text_input` is the text; position comes from the attr.
-        # Always emit a freshly-allocated vector for `:input_text` so ComputePipeline's
-        # `is_same(::Array, ::Array)` pointer-distinctness check can confirm structural
-        # equality on refires triggered by unrelated inputs (e.g. position layout writes).
-        if length(args) == 1 && is_text_input(typeof(args[1]))
-            return ((a_pos,), Ref{Any}([args[1]]))
-        elseif length(args) == 1 && args[1] isa AbstractVector && is_text_input(eltype(args[1]))
-            return ((a_pos,), Ref{Any}(copy(args[1])))
-        elseif args isa Tuple{<:AbstractVector{<:Tuple{<:Any, <:VecTypes}}}
+        # Text always comes from the `text` keyword/attribute and positions from
+        # positional args. The only positional shorthand recognized here is the
+        # `[(text, pos), ...]` form. Always emit a freshly-allocated vector for
+        # `:input_text` so ComputePipeline's `is_same(::Array, ::Array)`
+        # pointer-distinctness check can confirm structural equality on refires
+        # triggered by unrelated inputs (e.g. position layout writes).
+        if args isa Tuple{<:AbstractVector{<:Tuple{<:Any, <:VecTypes}}}
             # [(text, pos), ...] argument
             return ((last.(args[1]),), Ref{Any}(first.(args[1])))
         else # assume position data

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -43,7 +43,7 @@ into a Makie `text` plot.
 
 * `image`     — any marker accepted by `scatter` (typically a `Matrix{<:Colorant}`)
 * `marker_offset` — markerspace offset from the block origin to the marker's
-                    lower-left corner (after rotation has been applied)
+                    center (this matches `scatter`'s `marker_offset` semantics)
 * `size`      — markerspace marker size
 * `rotation`  — applied to the marker by scatter
 """
@@ -55,7 +55,8 @@ struct ImageTextPrimitive{I} <: AbstractTextPrimitive
 end
 
 function text_primitive_bbox(p::ImageTextPrimitive)
-    bb = Rect3d(to_ndim(Point3d, p.marker_offset, 0), Vec3d(p.size..., 0))
+    half = 0.5 .* Vec3d(p.size..., 0)
+    bb = Rect3d(to_ndim(Point3d, p.marker_offset, 0) .- half, Vec3d(p.size..., 0))
     return rotate_bbox(bb, p.rotation)
 end
 

--- a/Makie/src/layouting/data_limits.jl
+++ b/Makie/src/layouting/data_limits.jl
@@ -150,7 +150,13 @@ end
 
 function for_each_atomic_plot(f, plot::Text)
     f(plot)
-    return f(plot.plots[1]) # linesegments for latex
+    # Text materializes child primitives (latex linesegments, etc.) inside a
+    # PlotList. Descend through it so each rendered atom (not the wrapper) is
+    # visited — backends rely on this for per-plot polling and cleanup.
+    for child in plot.plots
+        for_each_atomic_plot(f, child)
+    end
+    return
 end
 
 function for_each_atomic_plot(f, plot::Plot)

--- a/Makie/src/makielayout/blocks/axis3d.jl
+++ b/Makie/src/makielayout/blocks/axis3d.jl
@@ -239,8 +239,8 @@ function initialize_block!(ax::Axis3)
     end
 
     titlet = text!(
-        blockscene, ax.title,
-        position = titlepos,
+        blockscene, titlepos,
+        text = ax.title,
         visible = ax.titlevisible,
         fontsize = ax.titlesize,
         align = titlealignnode,

--- a/Makie/src/makielayout/lineaxis.jl
+++ b/Makie/src/makielayout/lineaxis.jl
@@ -595,7 +595,8 @@ function tight_ticklabel_spacing!(la::LineAxis)
 end
 
 
-iswhitespace(str) = match(r"^\s*$", str) !== nothing
+iswhitespace(str::AbstractString) = match(r"^\s*$", String(str)) !== nothing
+iswhitespace(_) = false
 
 function Base.delete!(la::LineAxis)
     for (_, d) in la.elements

--- a/Makie/src/theming.jl
+++ b/Makie/src/theming.jl
@@ -39,6 +39,10 @@ const MAKIE_DEFAULT_THEME = Attributes(
     ),
     fontsize = 14,
     textcolor = :black,
+    # Callable that overrides MathTeXEngine for `LaTeXString` content in `text`.
+    # `nothing` keeps the default. Downstream renderers (e.g. MakieTeX) can
+    # supply a real-LaTeX handler here.
+    latex_handler = nothing,
     padding = Vec3f(0.05),
     figure_padding = 16,
     rowgap = 18,

--- a/Makie/src/theming.jl
+++ b/Makie/src/theming.jl
@@ -39,10 +39,7 @@ const MAKIE_DEFAULT_THEME = Attributes(
     ),
     fontsize = 14,
     textcolor = :black,
-    # Callable that overrides MathTeXEngine for `LaTeXString` content in `text`.
-    # `nothing` keeps the default. Downstream renderers (e.g. MakieTeX) can
-    # supply a real-LaTeX handler here.
-    latex_handler = nothing,
+    text_handler = nothing,
     padding = Vec3f(0.05),
     figure_padding = 16,
     rowgap = 18,

--- a/Makie/src/utilities/texture_atlas.jl
+++ b/Makie/src/utilities/texture_atlas.jl
@@ -539,18 +539,12 @@ is_all_equal_scale(v::Vec2f) = v[1] == v[2] # could use ≈ too
 is_all_equal_scale(vs::Vector{Vec2f}) = all(is_all_equal_scale, vs)
 
 """
-    rasterize_marker_for_gpu(marker, markersize) -> Union{Nothing, AbstractMatrix{<:Colorant}, AbstractVector{<:AbstractMatrix{<:Colorant}}}
+    rasterize_marker_for_gpu(marker, markersize)
 
-Extension hook used by GPU-backed backends (currently GLMakie / WGLMakie) to
-rasterize an opaque scatter marker — e.g. a MakieTeX `CachedPDF` — into a
-texture-uploadable image at marker upload time. Returns `nothing` to defer
-to the existing SDF / image-matrix paths.
-
-CairoMakie does not go through this hook — it does its own native dispatch
-on the marker type and renders vector content directly. Backend extensions
-that want to keep a vector path for their own opaque markers should leave
-this returning `nothing` and provide a `draw_marker` (or equivalent)
-override instead.
+Extension hook for GPU backends (GLMakie / WGLMakie) to rasterize an opaque
+scatter marker into an image matrix at upload time. Return `nothing` (default)
+to defer to the existing SDF / image-matrix paths. CairoMakie does not call
+this — it dispatches `draw_marker` natively on the marker type instead.
 """
 rasterize_marker_for_gpu(_marker, _markersize) = nothing
 
@@ -560,9 +554,6 @@ function compute_marker_attributes((atlas, marker, font, scale), changed, last)
     # [atlas_sym, :marker, :font, :markersize]
     # [:sdf_marker_shape, :sdf_uv, :image]
 
-    # Backend-side rasterization hook (e.g. MakieTeXGLMakieExt converts a
-    # `CachedPDF` marker into a `Matrix{ARGB32}` here so the existing
-    # image-marker branches below can handle it).
     if !(marker isa Matrix{<:Colorant} || marker isa Vector{<:Matrix{<:Colorant}})
         raster = rasterize_marker_for_gpu(marker, scale)
         raster === nothing || (marker = raster)

--- a/Makie/src/utilities/texture_atlas.jl
+++ b/Makie/src/utilities/texture_atlas.jl
@@ -538,11 +538,36 @@ is_all_equal_scale(::Vector{Real}) = true
 is_all_equal_scale(v::Vec2f) = v[1] == v[2] # could use ≈ too
 is_all_equal_scale(vs::Vector{Vec2f}) = all(is_all_equal_scale, vs)
 
+"""
+    rasterize_marker_for_gpu(marker, markersize) -> Union{Nothing, AbstractMatrix{<:Colorant}, AbstractVector{<:AbstractMatrix{<:Colorant}}}
+
+Extension hook used by GPU-backed backends (currently GLMakie / WGLMakie) to
+rasterize an opaque scatter marker — e.g. a MakieTeX `CachedPDF` — into a
+texture-uploadable image at marker upload time. Returns `nothing` to defer
+to the existing SDF / image-matrix paths.
+
+CairoMakie does not go through this hook — it does its own native dispatch
+on the marker type and renders vector content directly. Backend extensions
+that want to keep a vector path for their own opaque markers should leave
+this returning `nothing` and provide a `draw_marker` (or equivalent)
+override instead.
+"""
+rasterize_marker_for_gpu(_marker, _markersize) = nothing
+
 function compute_marker_attributes((atlas, marker, font, scale), changed, last)
     # Note: Careful, changed[2] is not always called marker
     # TODO, only calculate offset if needed
     # [atlas_sym, :marker, :font, :markersize]
     # [:sdf_marker_shape, :sdf_uv, :image]
+
+    # Backend-side rasterization hook (e.g. MakieTeXGLMakieExt converts a
+    # `CachedPDF` marker into a `Matrix{ARGB32}` here so the existing
+    # image-marker branches below can handle it).
+    if !(marker isa Matrix{<:Colorant} || marker isa Vector{<:Matrix{<:Colorant}})
+        raster = rasterize_marker_for_gpu(marker, scale)
+        raster === nothing || (marker = raster)
+    end
+
     if marker isa Matrix{<:Colorant} # single image marker
         return (Cint(RECTANGLE), Vec4f(0, 0, 1, 1), marker)
     elseif marker isa Vector{<:Matrix{<:Colorant}} # multiple image markers

--- a/Makie/test/issues.jl
+++ b/Makie/test/issues.jl
@@ -49,7 +49,7 @@
 
     @testset "#4722 Transformation passthrough" begin
         scene = Scene(camera = campixel!)
-        p = text!(scene, L"\frac{1}{2}")
+        p = text!(scene, Point2f(0, 0); text = L"\frac{1}{2}")
         translate!(scene, 0, 0, 10)
         @test isassigned(p.transformation.parent)
         @test isassigned(p.plots[1].transformation.parent)

--- a/Makie/test/plots/text.jl
+++ b/Makie/test/plots/text.jl
@@ -107,14 +107,14 @@ end
     @test scales == fta_scales
 end
 
-@testset "old text syntax" begin
-    text("text", position = Point2f(0, 0))
-    text(["text"], position = [Point2f(0, 0)])
-    text(["text", "text"], position = [Point2f(0, 0), Point2f(1, 1)])
+@testset "text input forms" begin
+    text(Point2f(0, 0), text = "text")
+    text([Point2f(0, 0)], text = ["text"])
+    text([Point2f(0, 0), Point2f(1, 1)], text = ["text", "text"])
     text(collect(zip(["text", "text"], [Point2f(0, 0), Point2f(1, 1)])))
-    text(L"text", position = Point2f(0, 0))
-    text([L"text"], position = [Point2f(0, 0)])
-    text([L"text", L"text"], position = [Point2f(0, 0), Point2f(1, 1)])
+    text(Point2f(0, 0), text = L"text")
+    text([Point2f(0, 0)], text = [L"text"])
+    text([Point2f(0, 0), Point2f(1, 1)], text = [L"text", L"text"])
     text(collect(zip([L"text", L"text"], [Point2f(0, 0), Point2f(1, 1)])))
 
     err = ArgumentError("`textsize` has been renamed to `fontsize` in Makie v0.19. Please change all occurrences of `textsize` to `fontsize` or revert back to an earlier version.")

--- a/Makie/test/updating.jl
+++ b/Makie/test/updating.jl
@@ -43,7 +43,7 @@ plot_types = [
 end
 
 @testset "text updating colormap" begin
-    f, a, p = text(fill("aa", 10); position = rand(Point2f, 10), color = 1:10)
+    f, a, p = text(rand(Point2f, 10); text = fill("aa", 10), color = 1:10)
     p.colormap = :blues
     colors = to_colormap(:blues)
     @test p.text_color[][1] == colors[1]

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -524,7 +524,7 @@ end
                 markersize = 5scales[j], space = space, markerspace = mspace
             )
             text!(
-                ax, "$space\n$mspace", position = Point2f(xs[i][i], xs[i][j]),
+                ax, Point2f(xs[i][i], xs[i][j]); text = "$space\n$mspace",
                 fontsize = scales[j], space = space, markerspace = mspace,
                 align = (:center, :center), color = :black
             )
@@ -570,7 +570,7 @@ end
                 markersize = 5scales[j], space = space, markerspace = mspace
             )
             text!(
-                ax, "$space\n$mspace", position = Point2f(xs[i][i], xs[i][j]),
+                ax, Point2f(xs[i][i], xs[i][j]); text = "$space\n$mspace",
                 fontsize = scales[j], space = space, markerspace = mspace,
                 align = (:center, :center), color = :black
             )

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -398,8 +398,8 @@ end
     wh = widths(scene)
     t = text!(
         campixel(scene),
-        "Multipole Representation of first resonances of U-238",
-        position = (wh[1] / 2.0, wh[2] - 20.0),
+        Point2f(wh[1] / 2.0, wh[2] - 20.0);
+        text = "Multipole Representation of first resonances of U-238",
         align = (:center, :center),
         fontsize = 20,
         font = "helvetica"

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -7,8 +7,8 @@
 
     text!(
         ax,
-        string.(round.(vec(values'), digits = 2)),
-        position = [Point2f(x, y) for x in 1:10 for y in 1:10],
+        [Point2f(x, y) for x in 1:10 for y in 1:10];
+        text = string.(round.(vec(values'), digits = 2)),
         align = (:center, :center),
         color = ifelse.(vec(values') .< 0.3, :white, :black),
         fontsize = 12
@@ -21,8 +21,8 @@ end
     pos = [Point2f(0, 0), Point2f(10, 10)]
     text(
         f[1, 1],
-        ["0 is the ORIGIN of this", "10 says hi"],
-        position = pos,
+        pos;
+        text = ["0 is the ORIGIN of this", "10 says hi"],
         axis = (aspect = DataAspect(),),
         markerspace = :data,
         align = (:center, :center),
@@ -32,8 +32,8 @@ end
 
     text(
         f[2, 1],
-        ". This is an annotation!",
-        position = (300, 200),
+        Point2f(300, 200);
+        text = ". This is an annotation!",
         align = (:center, :center),
         fontsize = 60,
         font = "Blackchancery"
@@ -51,8 +51,8 @@ end
         p = pos .+ (sin(r) * 100.0, cos(r) * 100)
         push!(posis, p)
         text!(
-            ax, "test",
-            position = p,
+            ax, p;
+            text = "test",
             fontsize = 50,
             rotation = 1.5pi - r,
             align = (:center, :center)
@@ -73,10 +73,10 @@ end
 
         for rotation in (-pi / 6, 0.0, pi / 6)
             text!(
-                scene, string(halign) * "/" * string(valign) *
+                scene, points[i];
+                text = string(halign) * "/" * string(valign) *
                     " " * string(round(rad2deg(rotation), digits = 0)) * "°",
                 color = (:black, 0.5),
-                position = points[i],
                 align = (halign, valign),
                 rotation = rotation
             )
@@ -130,9 +130,9 @@ end
     for ((justification, halign), point) in zip(Iterators.product(symbols, symbols), points)
 
         t = text!(
-            scene, "a\nshort\nparagraph",
+            scene, point;
+            text = "a\nshort\nparagraph",
             color = (:black, 0.5),
-            position = point,
             align = (halign, :center),
             justification = justification
         )
@@ -163,8 +163,8 @@ end
 
     t1 = text!(
         scene,
-        fill("makie", 4),
-        position = [(150, 150) .+ 60 * Point2f(cos(a), sin(a)) for a in (pi / 4):(pi / 2):(7pi / 4)],
+        [(150, 150) .+ 60 * Point2f(cos(a), sin(a)) for a in (pi / 4):(pi / 2):(7pi / 4)];
+        text = fill("makie", 4),
         rotation = (pi / 4):(pi / 2):(7pi / 4),
         align = (:left, :center),
         fontsize = 30,
@@ -175,8 +175,8 @@ end
 
     t2 = text!(
         scene,
-        fill("makie", 4),
-        position = [(150, 450) .+ 60 * Point2f(cos(a), sin(a)) for a in (pi / 4):(pi / 2):(7pi / 4)],
+        [(150, 450) .+ 60 * Point2f(cos(a), sin(a)) for a in (pi / 4):(pi / 2):(7pi / 4)];
+        text = fill("makie", 4),
         rotation = (pi / 4):(pi / 2):(7pi / 4),
         align = (:left, :center),
         fontsize = 30,
@@ -189,8 +189,8 @@ end
 
         t = text!(
             scene,
-            "makie",
-            position = (450, 150) .+ 60 * Point2f(cos(a), sin(a)),
+            (450, 150) .+ 60 * Point2f(cos(a), sin(a));
+            text = "makie",
             rotation = a,
             align = (:left, :center),
             fontsize = 30,
@@ -201,8 +201,8 @@ end
 
         t2 = text!(
             scene,
-            "makie",
-            position = (450, 450) .+ 60 * Point2f(cos(a), sin(a)),
+            (450, 450) .+ 60 * Point2f(cos(a), sin(a));
+            text = "makie",
             rotation = a,
             align = (:left, :center),
             fontsize = 30,
@@ -221,9 +221,9 @@ end
     f = Figure(size = (600, 600))
     text(
         f[1, 1],
-        fill("Makie", 7),
+        [Point3f(0, 0, i / 2) for i in 1:7];
+        text = fill("Makie", 7),
         rotation = [i / 7 * 1.5pi for i in 1:7],
-        position = [Point3f(0, 0, i / 2) for i in 1:7],
         color = [cgrad(:viridis)[x] for x in LinRange(0, 1, 7)],
         align = (:left, :baseline),
         fontsize = 1,
@@ -234,8 +234,8 @@ end
     positions = RNG.rand(Point3f, 10)
     meshscatter(f[1, 2], positions, color = :white)
     text!(
-        fill("Annotation", 10),
-        position = positions,
+        positions;
+        text = fill("Annotation", 10),
         align = (:center, :center),
         fontsize = 16,
         markerspace = :pixel,
@@ -255,15 +255,17 @@ end
     scene = Scene(camera = campixel!, size = (200, 200))
 
     t1 = text!(
-        scene, "Line1\nLine 2\n\nLine4",
-        position = (50, 100), align = (:center, :center), markerspace = :data
+        scene, Point2f(50, 100);
+        text = "Line1\nLine 2\n\nLine4",
+        align = (:center, :center), markerspace = :data
     )
 
     wireframe!(scene, boundingbox(t1, :data), color = (:red, 0.3))
 
     t2 = text!(
-        scene, "\nLine 2\nLine 3\n\n\nLine6\n\n",
-        position = (150, 100), align = (:center, :center), markerspace = :data
+        scene, Point2f(150, 100);
+        text = "\nLine 2\nLine 3\n\n\nLine6\n\n",
+        align = (:center, :center), markerspace = :data
     )
 
     wireframe!(scene, boundingbox(t2, :data), color = (:blue, 0.3))
@@ -342,12 +344,12 @@ end
 
     s = LScene(f[1, 2], scenekw = (camera = campixel!,), show_axis = false)
     text!(
-        s, L"\sqrt{2}", position = (100, 50), rotation = pi / 2, fontsize = 20,
+        s, Point2f(100, 50); text = L"\sqrt{2}", rotation = pi / 2, fontsize = 20,
         markerspace = :data
     )
 
     t = text!(
-        s, L"\int_0^5x^2+2ab", position = Point2f(50, 150), rotation = 0.0,
+        s, Point2f(50, 150); text = L"\int_0^5x^2+2ab", rotation = 0.0,
         fontsize = 20, markerspace = :data
     )
     wireframe!(s, boundingbox(t, :data), color = :black)
@@ -363,8 +365,8 @@ end
 
     t = text!(
         s,
-        textnode,
-        position = posnode,
+        posnode;
+        text = textnode,
         rotation = 0.0,
         markerspace = :data
     )
@@ -372,8 +374,8 @@ end
     Makie.step!(st)
     ## change lengths
     Makie.update!(
-        t, push!(textnode, L"\int_0^5x^2+2ab");
-        position = push!(posnode, Point2f(150, 150))
+        t, push!(posnode, Point2f(150, 150));
+        text = push!(textnode, L"\int_0^5x^2+2ab")
     )
     Makie.step!(st)
     st
@@ -452,10 +454,10 @@ end
 @reference_test "texture atlas update" begin
     scene = Scene(size = (250, 100))
     campixel!(scene)
-    p = text!(scene, "test", fontsize = 85)
+    p = text!(scene, Point2f(0, 0); text = "test", fontsize = 85)
     st = Stepper(scene)
     Makie.step!(st)
-    p.arg1[] = "-!ħ█?-" # "!ħ█?" are all new symbols
+    p.text[] = "-!ħ█?-" # "!ħ█?" are all new symbols
     Makie.step!(st)
     st
 end

--- a/docs/src/tutorials/scenes.md
+++ b/docs/src/tutorials/scenes.md
@@ -166,7 +166,7 @@ figure, axis, plot_object = scatter(1:4)
 relative_projection = Makie.camrelative(axis.scene);
 scatter!(relative_projection, [Point2f(0.5)], color=:red)
 # offset & text are in pixelspace
-text!(relative_projection, "Hi", position=Point2f(0.5), offset=Vec2f(5))
+text!(relative_projection, Point2f(0.5), text="Hi", offset=Vec2f(5))
 lines!(relative_projection, Rect(0, 0, 1, 1), color=:blue, linewidth=3)
 figure
 ```

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -20,6 +20,7 @@ base_branch = "ff/breaking-0.25"
 # Package = "CairoMakie"
 # n_samples = 2
 # base_branch = "breaking-release"
+base_branch = "ff/breaking-0.25"  # override: this PR targets the breaking branch (merge base)
 
 @info("Benchmarking $(Package) against $(base_branch) with $(n_samples) samples")
 


### PR DESCRIPTION
Refactors the `text` recipe so external text renderers can plug in via a `text_handler` attribute, and so GPU backends can rasterize opaque markers at upload time only when needed. Companion MakieTeX PR (`LaTeX` and `Typst` handlers): https://github.com/MakieOrg/MakieTeX.jl/pull/73.

<img width="900" height="600" alt="Real-LaTeX axis labels, title, and Roman-numeral xticks" src="https://github.com/user-attachments/assets/2fecde35-88b1-459c-a659-887065ae24cb">

## What's new

1. **`text_handler` plot attribute** — themable, scoped, per-plot. `nothing` keeps the built-in MathTeXEngine path; setting a handler routes matching content through it.
   ```julia
   set_theme!(text_handler = MakieTeX.LaTeX())
   with_theme(text_handler = MakieTeX.LaTeX(preamble = "…")) do … end
   text!(scene, L"…"; text_handler = MakieTeX.LaTeX(…))
   ```
2. **Live handler swap.** The text recipe owns a single `plotlist!` child fed by a reactive `text_specs::Vector{PlotSpec}` channel; `plot.text_handler = …` (or any text content change) re-runs the handler and PlotList diffs the children.

## Extension hooks

- `compile_text(handler, src, color, fontsize, lineheight)` — returns the payload `place_text!` will consume, or `nothing` to fall through to FreeType.
- `place_text!(handler, outputs, i, N, compiled, …)` — pushes `PlotSpec`s into `outputs.text_specs`, with parallel `text_spec_block_indices` / `text_spec_bboxes`.
- `is_text_input(::Type) -> Bool` — opt-in trait for stringlike inputs that don't conform to `AbstractString`.
- `convert_text_string!(outputs, str, …)` — alternative entry that bypasses the `(compile_text, place_text!)` protocol.
- `shift_text_spec(::Val{type}, spec, offset)` — for `PlotSpec` types whose positional data isn't `args[1]`.
- `rasterize_marker_for_gpu(marker, scale) -> Union{Nothing, Matrix, Vector{Matrix}}` — hook in `compute_marker_attributes` so GPU backends can rasterize opaque markers at upload time. CairoMakie keeps its native vector dispatch.

## Checks

- [ ] regression: existing `text!` with `String` / `LaTeXString` / `RichText`
- [ ] end-to-end with the MakieTeX PR on CairoMakie (vector) and GLMakie (raster)
- [ ] live handler swap on already-rendered text plots
- [ ] reference image tests
