### PR TITLE
Include TeX rule elements in LaTeXString alignment bounds

### DIFF
--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -796,6 +796,10 @@ function texelems_and_glyph_collection(
         )
     end
 
+    tex_bboxes = map(all_els) do (element, position, scale)
+        tex_element_bbox(element, position, scale, first(fontscale_px))
+    end
+
     basepositions = [to_ndim(Vec3f, fs, 0) .* to_ndim(Point3f, x[2], 0) for x in els]
 
     if word_wrap_width > 0
@@ -826,11 +830,13 @@ function texelems_and_glyph_collection(
         end
     end
 
-    bb = isempty(bboxes) ? BBox(0, 0, 0, 0) : begin
-            mapreduce(union, zip(bboxes, basepositions)) do (b, pos)
+    bb = if word_wrap_width > 0
+        isempty(bboxes) ? BBox(0, 0, 0, 0) : mapreduce(union, zip(bboxes, basepositions)) do (b, pos)
                 Rect2f(Rect3f(b) + pos)
         end
-        end
+    else
+        isempty(tex_bboxes) ? BBox(0, 0, 0, 0) : mapreduce(identity, union, tex_bboxes)
+    end
 
     xshift = get_xshift(minimum(bb)[1], maximum(bb)[1], halign)
     yshift = get_yshift(minimum(bb)[2], maximum(bb)[2], valign, default = 0.0f0)
@@ -852,6 +858,14 @@ function texelems_and_glyph_collection(
     )
 
     return all_els, pre_align_gl, Point2f(xshift, yshift)
+end
+
+function tex_element_bbox(element, position, scale, fontsize)
+    x0 = fontsize * (position[1] + scale * MathTeXEngine.leftinkbound(element))
+    x1 = fontsize * (position[1] + scale * MathTeXEngine.rightinkbound(element))
+    y0 = fontsize * (position[2] + scale * MathTeXEngine.bottominkbound(element))
+    y1 = fontsize * (position[2] + scale * MathTeXEngine.topinkbound(element))
+    return Rect2f(Point2f(x0, y0), Vec2f(x1 - x0, y1 - y0))
 end
 
 iswhitespace(l::LaTeXString) = iswhitespace(replace(l.s, '$' => ""))


### PR DESCRIPTION
# Description

Fixes LaTeXString alignment for expressions whose visible extent includes MathTeXEngine rule elements, such as fraction bars and radical bars.

Previously Makie computed LaTeXString alignment bounds from `TeXChar` glyph boxes only. That meant non-glyph TeX elements such as `HLine`/`VLine` contributed to rendering but not to the alignment box, so centered or rotated labels could be visibly offset. This PR computes the alignment bbox from all generated MathTeXEngine elements while keeping glyph rendering itself restricted to `TeXChar`s.

The word-wrapping path keeps using the existing post-wrap glyph bbox, because wrapped text positions are adjusted inside Makie after MathTeXEngine element generation. That keeps ordinary word wrapping unchanged while fixing normal LaTeX element alignment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Existing reference image tests cover the affected LaTeX/text layout behavior

## Tests

- `env JULIA_PKG_PRECOMPILE_AUTO=0 julia --color=yes --project=monorepo -e 'using Pkg; Pkg.status(["MathTeXEngine", "Makie"]); Pkg.test("Makie")'`
- Result with registered `MathTeXEngine v0.6.8`: `6230` passed, `2` broken.
- Result with local MathTeXEngine spacing branch developed as an integration check: `6230` passed, `2` broken.
- Targeted CairoMakie text reference render with registered MathTeXEngine: all `27/27` text scenes rendered; comparison reports expected reference diffs in `13` LaTeX/text images because bbox alignment now includes rendered TeX rule elements.
- `Word Wrapping.png` passes in the targeted reference comparison after keeping the wrapped-text bbox path unchanged.
- `julia --project=@runic -m Runic --check -d Makie/src/basic_recipes/text.jl`
- Result: no formatting diff.

## Notes

The failing targeted reference comparisons are expected image-baseline changes for LaTeX/text scenes such as `latex strings`, `latex ticks`, `latex updates`, and `new text bounding boxes`. They should be reviewed with the normal Makie reference-image update workflow rather than treated as a functional test failure.
