### PR TITLE
ci: add slash-command dispatch for PR comments

### DIFF
--- a/.github/workflows/command-router.yaml
+++ b/.github/workflows/command-router.yaml
@@ -1,0 +1,66 @@
+# Routes slash commands from pull request comments to per-command workflows.
+#
+# Dispatched by command-trigger.yaml, which has already verified that the comment
+# was written by someone with write access — so this workflow may assume its
+# caller is trusted. Because it runs on the PR's head ref, this file and the
+# command workflows it calls can be edited and tested within a PR before merging.
+#
+# To add a command, write a reusable (workflow_call) workflow and add a job here
+# that calls it, gated on the parsed command. See the commented benchmark example
+# below.
+name: Commands
+on:
+  workflow_dispatch:
+    inputs:
+      comment_body:
+        description: Full body of the triggering comment
+        required: true
+      comment_id:
+        description: ID of the triggering comment (for reactions/replies)
+        required: true
+      pr_number:
+        description: PR the comment was made on
+        required: true
+      head_sha:
+        description: PR head commit
+        required: true
+      base_ref:
+        description: PR base branch
+        required: true
+
+# Minimal by default; each called command workflow widens scope via its own
+# `permissions:` block. Don't rely on the repository's default token scope here.
+permissions:
+  contents: read
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.cmd.outputs.command }}
+    steps:
+      - name: Extract command
+        id: cmd
+        env:
+          COMMENT_BODY: ${{ inputs.comment_body }}
+        run: |
+          set -euo pipefail
+          command=$(printf '%s' "$COMMENT_BODY" | awk 'NR==1 {print $1}')
+          echo "command=$command" >> "$GITHUB_OUTPUT"
+          echo "Parsed command: $command"
+
+  # Per-command workflows are wired in here in follow-up PRs, e.g.:
+  #
+  # benchmark:
+  #   needs: parse
+  #   if: needs.parse.outputs.command == '/benchmark'
+  #   uses: ./.github/workflows/benchmark.yaml
+  #   with:
+  #     comment_body: ${{ inputs.comment_body }}
+  #     comment_id: ${{ inputs.comment_id }}
+  #     pr_number: ${{ inputs.pr_number }}
+  #     head_sha: ${{ inputs.head_sha }}
+  #     base_ref: ${{ inputs.base_ref }}
+  #   # Forward only the secrets a command actually needs, never `secrets: inherit`.
+  #   secrets:
+  #     BENCHMARK_KEY: ${{ secrets.BENCHMARK_KEY }}

--- a/.github/workflows/command-trigger.yaml
+++ b/.github/workflows/command-trigger.yaml
@@ -1,0 +1,91 @@
+# Entry point for slash commands written as pull request comments (e.g.
+# `/benchmark 100`). Runs from the default branch only.
+#
+# Its single responsibility is the security gate. It fires for any PR comment
+# that starts with `/` and dispatches command-router.yaml on the PR's head ref,
+# forwarding the raw comment body — but only if the commenter has write access.
+# Everything that decides what a command does lives in the router and the
+# per-command workflows, which run from the head ref and are therefore editable
+# and testable within a PR. Because the gate is enforced here, on the default
+# branch, an outside contributor can never cause any of those head-ref workflows
+# to run.
+#
+# Commands over fork PRs are deliberately unsupported, and must stay that way.
+# This is enforced twice: workflow_dispatch can only target a ref in this repo
+# (a fork's branch is not one), and the dispatch step below also rejects any PR
+# whose head is a fork. Do not loosen either guard. Running a command against a
+# fork would mean executing fork-controlled content while a privileged, secret-
+# bearing run is in flight, which is the classic pwn-request hole; a fork owner
+# could also force-push between a maintainer's review and the command to swap in
+# code that was never reviewed. If a maintainer needs to benchmark (or otherwise
+# run a command against) contributor code, they copy that branch into this repo
+# and push it to a dedicated PR, which makes them the trusted author of the ref
+# the command runs on.
+name: Command Trigger
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dispatch:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write         # dispatch the router workflow
+      issues: write          # react to the triggering comment
+      pull-requests: read
+    steps:
+      - name: Check write access
+        id: perm
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          # Use the legacy `.permission` field on purpose: it collapses the role
+          # set to admin/write/read/none, and `write` already covers the maintain
+          # role. Do not switch to `.role_name` without updating these values.
+          # `|| echo none` keeps the gate fail-closed if the API call errors.
+          level=$(gh api "/repos/${{ github.repository }}/collaborators/$COMMENTER/permission" --jq '.permission' 2>/dev/null || echo none)
+          case "$level" in
+            admin|write) echo "authorized=true" >> "$GITHUB_OUTPUT" ;;
+            *)           echo "authorized=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Acknowledge command
+        if: steps.perm.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          set -euo pipefail
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -f "content=eyes"
+
+      - name: Dispatch router
+        if: steps.perm.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          data=$(gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER")
+          # Forks are intentionally unsupported (see file header); push the branch
+          # into this repo and open a dedicated PR to run commands against it.
+          if [ "$(echo "$data" | jq -r .head.repo.full_name)" != "${{ github.repository }}" ]; then
+            echo "::error::Slash commands only run on branches in ${{ github.repository }}, not forks. Push the branch here and open a PR to benchmark it."
+            exit 1
+          fi
+          gh workflow run command-router.yaml \
+            --ref "$(echo "$data" | jq -r .head.ref)" \
+            -f comment_body="$COMMENT_BODY" \
+            -f comment_id="$COMMENT_ID" \
+            -f pr_number="$PR_NUMBER" \
+            -f head_sha="$(echo "$data" | jq -r .head.sha)" \
+            -f base_ref="$(echo "$data" | jq -r .base.ref)"


### PR DESCRIPTION
Wiring for running commands from PR comments, e.g. `/benchmark 100`. This is just the plumbing, no command does anything yet; a follow-up will add a benchmark command and remove the old always-on benchmark workflow.

The point of the split is that `issue_comment` workflows only ever run their version on the default branch, so anything triggered that way can't be tested in a PR. So we can't put the full workflows inside, which is why there are two workflows (following this idea https://github.com/orgs/community/discussions/59389#discussioncomment-16312157):

- `command-trigger.yaml` runs on `issue_comment` from the default branch and does nothing but enforce trust: it fires for any PR comment starting with `/`, checks the commenter has write access (via the collaborator-permission API, rather than `author_association`, which reports org/repo relationship rather than actual push access - an org member can be read-only, an outside collaborator can have write), and dispatches the router on the PR head ref. Because the gate lives here, an outside contributor can never cause any head-ref workflow to run.
- `command-router.yaml` is dispatched on the head ref, so it and the per-command workflows it will call are editable and testable inside a PR. It parses the leading command word and routes; the command list is empty for now.

Forks are intentionally unsupported, running a command against fork-controlled content is dangerous and a fork owner could force-push between review and trigger by a maintainer. A maintainer who wants to benchmark contributor code should push their own copy of the branch and open a dedicated PR instead.
