### PR TITLE
force highp precision, fix sprite NaN cull, fix wglerror ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed WGLMakie scatter/sprite markers disappearing in 3D scenes when camera distances produce uniform values outside `mediump` (f16) range. WGLMakie now forces `highp` precision for all vertex/fragment uniforms.
 - Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Added decade-aware automatic ticks for `pseudolog10` and `Symlog10` axes via new `PseudologTicks` and `SymlogTicks` types. `LogTicks` is no longer accepted with these scales (it placed ticks at wrong positions). `Symlog10` is now a callable struct exposing its `lower`/`upper`/`linscale` parameters. Closes [#5270](https://github.com/MakieOrg/Makie.jl/issues/5270) [#5625](https://github.com/MakieOrg/Makie.jl/pull/5625)

--- a/WGLMakie/assets/sprites.vert
+++ b/WGLMakie/assets/sprites.vert
@@ -147,9 +147,14 @@ void main(){
     // add padding for AA, stroke and glow (non native distancefields don't need
     // AA padding but CIRCLE etc do)
     float ppu = get_px_per_unit();
-    vec2 padded_bbox_size = bbox_radius + (
+    float bbox_buf = (
         ANTIALIAS_RADIUS + max(0.0, get_strokewidth() * ppu) + max(0.0, get_glowwidth() * ppu)
     ) / viewport_from_sprite_scale;
+    // Multiply the buffer by sign(bbox_radius) so that markersize == 0 cleanly
+    // collapses the padded bbox to zero (0*Inf == NaN propagates to gl_Position
+    // and gets culled). Without this, markersize == 0 would produce visible AA
+    // padding, matching GLMakie's geometry shader behavior.
+    vec2 padded_bbox_size = bbox_radius + sign(bbox_radius) * bbox_buf;
     vec2 uv_pad_scale = padded_bbox_size / bbox_radius;
 
     frag_color = tovec4(get_vertex_color());

--- a/WGLMakie/src/javascript/Lines.js
+++ b/WGLMakie/src/javascript/Lines.js
@@ -40,6 +40,8 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
 
         return `precision highp float;
             precision highp int;
+            precision highp sampler2D;
+            precision highp sampler3D;
 
             ${attribute_decl}
 
@@ -240,6 +242,8 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
 
         return `precision highp float;
             precision highp int;
+            precision highp sampler2D;
+            precision highp sampler3D;
 
             ${attribute_decl}
 
@@ -740,8 +744,8 @@ function lines_fragment_shader(uniforms, attributes) {
 
     precision highp int;
     precision highp float;
-    precision mediump sampler2D;
-    precision mediump sampler3D;
+    precision highp sampler2D;
+    precision highp sampler3D;
 
     in highp vec3 f_quad_sdf;
     in vec2 f_truncation;

--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -23206,6 +23206,8 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
     if (is_linesegments) {
         return `precision highp float;
             precision highp int;
+            precision highp sampler2D;
+            precision highp sampler3D;
 
             ${attribute_decl}
 
@@ -23401,6 +23403,8 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
     } else {
         return `precision highp float;
             precision highp int;
+            precision highp sampler2D;
+            precision highp sampler3D;
 
             ${attribute_decl}
 
@@ -23897,8 +23901,8 @@ function lines_fragment_shader(uniforms, attributes) {
 
     precision highp int;
     precision highp float;
-    precision mediump sampler2D;
-    precision mediump sampler3D;
+    precision highp sampler2D;
+    precision highp sampler3D;
 
     in highp vec3 f_quad_sdf;
     in vec2 f_truncation;
@@ -25088,7 +25092,7 @@ function create_scene(wrapper, canvas, canvas_width, scenes, comm, width, height
     const gl = renderer.getContext();
     const err = gl.getError();
     if (err != gl.NO_ERROR) {
-        throw new Error("WebGL error: " + WGL.wglerror(gl, err));
+        throw new Error("WebGL error: " + wglerror(gl, err));
     }
     return renderer;
 }

--- a/WGLMakie/src/javascript/WGLMakie.js
+++ b/WGLMakie/src/javascript/WGLMakie.js
@@ -737,7 +737,7 @@ function create_scene(
     const gl = renderer.getContext();
     const err = gl.getError();
     if (err != gl.NO_ERROR) {
-        throw new Error("WebGL error: " + WGL.wglerror(gl, err));
+        throw new Error("WebGL error: " + wglerror(gl, err));
     }
     return renderer;
 }

--- a/WGLMakie/src/shader-abstractions.jl
+++ b/WGLMakie/src/shader-abstractions.jl
@@ -1,5 +1,19 @@
 import ShaderAbstractions as SA
 
+# Use highp precision to avoid float overflows in uniforms (e.g. preprojection
+# matrices for 3D scatter plots can produce values exceeding the f16 range that
+# `mediump` uses on some drivers, leading to Inf values and missing geometry).
+const SHADER_PRECISION_HEADER = """
+#version 300 es
+precision highp int;
+precision highp float;
+precision highp sampler2D;
+precision highp sampler3D;
+precision highp isampler2D;
+precision highp isampler3D;
+precision highp usampler2D;
+precision highp usampler3D;
+"""
 
 to_vertex_dict(dict::Dict) = dict
 
@@ -72,8 +86,8 @@ function create_shader(vertex_attr, uniforms, vertshader, fragshader)
         println(io)
         println(io, vertshader)
     end
-    vert = SA.vertex_header(context) * src
-    frag = SA.fragment_header(context) * uniform_block * fragshader
+    vert = SHADER_PRECISION_HEADER * src
+    frag = SHADER_PRECISION_HEADER * "\nout vec4 fragment_color;\n" * uniform_block * fragshader
     up(x) = replace(x, "#version 300 es" => "")
     filter!(((name, _),) -> !endswith(string(name), "_getter"), uniforms)
     return Dict(


### PR DESCRIPTION
- Force `highp` for all samplers in line vertex/fragment shaders and the generic shader header, so 3D scatter uniforms outside the mediump (f16) range don't collapse to Inf and cull geometry.
- In sprites.vert, multiply the AA/stroke/glow buffer by `sign(bbox_radius)` so `markersize == 0` collapses the padded bbox to zero, matching GLMakie.
- Fix `WGL.wglerror` -> `wglerror` reference in WGLMakie.js and the bundle.

This fixes an error on Linux Brave, somehow most other browsers (even brave on windows), seem to be fine.