### PR TITLE
fix(ci): grant pull-requests:write to slash-command trigger

### DIFF
--- a/.github/workflows/command-trigger.yaml
+++ b/.github/workflows/command-trigger.yaml
@@ -34,8 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write         # dispatch the router workflow
-      issues: write          # react to the triggering comment
-      pull-requests: read
+      # Reacting to a PR-conversation comment requires pull-requests: write even
+      # though the API path is /issues/comments/{id}/reactions — GitHub gates
+      # this on the comment's parent (a PR), not the URL surface.
+      pull-requests: write
     steps:
       - name: Check write access
         id: perm


### PR DESCRIPTION
The command-trigger's reaction step has been hitting `Resource not accessible by integration` because the dispatch job declared `issues: write` and `pull-requests: read`. The endpoint URL is `/issues/comments/{id}/reactions`, so `issues: write` looks right — but GitHub gates the permission on the comment's parent (a PR), not the URL surface, so reacting to a PR-conversation comment needs `pull-requests: write`.

Verified empirically on this branch: a throwaway workflow reacting to a fixed comment with `issues: write` + `pull-requests: read` reproduced the same 403; switching to `pull-requests: write` alone (dropping `issues: write` entirely) succeeded and the reaction was posted. So this is the minimal fix.
