### PR TITLE
fix(ci): pass --repo to gh workflow run in command trigger

### DIFF
--- a/.github/workflows/command-trigger.yaml
+++ b/.github/workflows/command-trigger.yaml
@@ -85,6 +85,7 @@ jobs:
             exit 1
           fi
           gh workflow run command-router.yaml \
+            --repo "${{ github.repository }}" \
             --ref "$(echo "$data" | jq -r .head.ref)" \
             -f comment_body="$COMMENT_BODY" \
             -f comment_id="$COMMENT_ID" \


### PR DESCRIPTION
After the reaction permission fix in #5644, the dispatch step now reaches `gh workflow run`, which errors with `failed to run git: fatal: not a git repository`. The trigger job does no checkout (no need to), so `gh` has no local git remote to infer the target repository from. Passing `--repo` explicitly tells it.
