### PR TITLE
Add iterate function for `FigureAxis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added an `Base.iterate` for `FigureAxis` so that can be splashed in code as well.
+- Added an `Base.iterate` for `FigureAxis` so that can be splashed in code as well [#5646](https://github.com/MakieOrg/Makie.jl/pull/5646).
 - Fixed `center!` (and therefore `reset_limits!` in `LScene`) crashing with empty, NaN or zero-width content [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).
 - Fixed `FastPixel` scatter crash when markers are clipped in GLMakie [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).
 - Fixed WGLMakie scatter/sprite markers disappearing in 3D scenes when camera distances produce uniform values outside `mediump` (f16) range. WGLMakie now forces `highp` precision for all vertex/fragment uniforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added an `Base.iterate` for `FigureAxis` so that can be splashed in code as well.
 - Fixed `center!` (and therefore `reset_limits!` in `LScene`) crashing with empty, NaN or zero-width content [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).
 - Fixed `FastPixel` scatter crash when markers are clipped in GLMakie [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).
 - Fixed WGLMakie scatter/sprite markers disappearing in 3D scenes when camera distances produce uniform values outside `mediump` (f16) range. WGLMakie now forces `highp` precision for all vertex/fragment uniforms.

--- a/Makie/src/figureplotting.jl
+++ b/Makie/src/figureplotting.jl
@@ -13,6 +13,7 @@ Base.show(io::IO, fap::FigureAxisPlot) = show(io, fap.figure)
 Base.show(io::IO, ::MIME"text/plain", fap::FigureAxisPlot) = print(io, "FigureAxisPlot()")
 
 Base.iterate(fap::FigureAxisPlot, args...) = iterate((fap.figure, fap.axis, fap.plot), args...)
+Base.iterate(fap::FigureAxis, args...) = iterate((fap.figure, fap.axis), args...)
 Base.iterate(ap::AxisPlot, args...) = iterate((ap.axis, ap.plot), args...)
 
 get_scene(ap::AxisPlot) = get_scene(ap.axis.scene)

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -25,6 +25,26 @@ end
     @test p2 isa Scatter
 end
 
+@testset "FigureAxis" begin
+    fap = scatter(rand(100, 2))
+    @test fap isa Makie.FigureAxisPlot
+    fig, ax, p = scatter(rand(100, 2))
+    @test fig isa Figure
+    @test ax isa Axis
+    @test p isa Scatter
+
+    # Now create just a
+    fa = Makie.FigureAxis(fig, ax)
+    @test fa isa Makie.FigureAxis
+    # Test iterate here as well
+    fig2, ax2 = fa
+    # and they are still the exact same
+    @test fig2 === fig
+    @test ax2 === ax
+end
+
+
+
 @testset "Argument-level axis hints" begin
     # Data types can define preferred_axis_attributes(AxisType, args...)
     # to provide axis defaults when used as plot arguments.

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -42,9 +42,6 @@ end
     @test fig2 === fig
     @test ax2 === ax
 end
-
-
-
 @testset "Argument-level axis hints" begin
     # Data types can define preferred_axis_attributes(AxisType, args...)
     # to provide axis defaults when used as plot arguments.


### PR DESCRIPTION
# Description

Adds a `Base.iterate` for `FigureAxis` so one can do `fig, ax = fa` splashing like it already exists for AxisPlot and FigureAxisPlot.

## Type of change

Delete options that do not apply:

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- Added or changed relevant sections in the documentation (none affected)
- [x] Added unit tests for new algorithms, conversion methods, etc.
- Added reference image tests for new plotting functions, recipes, visual options, etc. (none affected)