### PR TITLE
feat: Tabs and Subfigure blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ## Unreleased
 
-- Added `Tabs` and `Subfigure` blocks — a tabbed container and the scrollable, event-isolated sub-region it is built on. Tabs are managed with `add_tab!`, `remove_tab!` and `set_tab!`. [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650) [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650)
+- Added `Tabs` and `Subfigure` blocks, a tabbed container and the scrollable, event-isolated sub-region it is built on. [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650) [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650)
 - Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Added decade-aware automatic ticks for `pseudolog10` and `Symlog10` axes via new `PseudologTicks` and `SymlogTicks` types. `LogTicks` is no longer accepted with these scales (it placed ticks at wrong positions). `Symlog10` is now a callable struct exposing its `lower`/`upper`/`linscale` parameters. Closes [#5270](https://github.com/MakieOrg/Makie.jl/issues/5270) [#5625](https://github.com/MakieOrg/Makie.jl/pull/5625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ## Unreleased
 
+- Added `Subfigure` and `Tabs` blocks. `Subfigure` is a clipped, scrollable, optionally event-isolated region pairing a `Scene` with a `GridLayout`; `Tabs` is a tabbed container built on it where only the active tab is visible and receives input. Tabs are seeded with the `labels`/`closable` construction keywords and changed afterwards via `add_tab!`, `remove_tab!` and `set_tab!`. Supported by new scene internals: event isolation (`forward_events!`), an ancestor-visibility cascade (`scene_visible`) and ancestor scissor clipping (`effective_clip`), and a window-pixel-absolute `campixel!`.
 - Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Added decade-aware automatic ticks for `pseudolog10` and `Symlog10` axes via new `PseudologTicks` and `SymlogTicks` types. `LogTicks` is no longer accepted with these scales (it placed ticks at wrong positions). `Symlog10` is now a callable struct exposing its `lower`/`upper`/`linscale` parameters. Closes [#5270](https://github.com/MakieOrg/Makie.jl/issues/5270) [#5625](https://github.com/MakieOrg/Makie.jl/pull/5625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ## Unreleased
 
-- Added `Tabs` and `Subfigure` blocks, a tabbed container and the scrollable, event-isolated sub-region it is built on. [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650) [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650)
+- Added `Tabs` and `Subfigure` blocks, a tabbed container and the scrollable, event-isolated sub-region it is built on. [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650)
 - Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Added decade-aware automatic ticks for `pseudolog10` and `Symlog10` axes via new `PseudologTicks` and `SymlogTicks` types. `LogTicks` is no longer accepted with these scales (it placed ticks at wrong positions). `Symlog10` is now a callable struct exposing its `lower`/`upper`/`linscale` parameters. Closes [#5270](https://github.com/MakieOrg/Makie.jl/issues/5270) [#5625](https://github.com/MakieOrg/Makie.jl/pull/5625)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ## Unreleased
 
-- Added `Subfigure` and `Tabs` blocks. `Subfigure` is a clipped, scrollable, optionally event-isolated region pairing a `Scene` with a `GridLayout`; `Tabs` is a tabbed container built on it where only the active tab is visible and receives input. Tabs are seeded with the `labels`/`closable` construction keywords and changed afterwards via `add_tab!`, `remove_tab!` and `set_tab!`. Supported by new scene internals: event isolation (`forward_events!`), an ancestor-visibility cascade (`scene_visible`) and ancestor scissor clipping (`effective_clip`), and a window-pixel-absolute `campixel!`.
+- Added `Tabs` and `Subfigure` blocks — a tabbed container and the scrollable, event-isolated sub-region it is built on. Tabs are managed with `add_tab!`, `remove_tab!` and `set_tab!`. [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650) [#5650](https://github.com/MakieOrg/Makie.jl/pull/5650)
 - Reworked `Textbox` with selections, multi-cursor, copy / cut / paste, and word / line navigation [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - A trailing `'\n'` in a `text!` string now contributes a full empty line to the layout and bounding box (previously `"abc\n"` was laid out identically to `"abc"`) [#5627](https://github.com/MakieOrg/Makie.jl/pull/5627)
 - Added decade-aware automatic ticks for `pseudolog10` and `Symlog10` axes via new `PseudologTicks` and `SymlogTicks` types. `LogTicks` is no longer accepted with these scales (it placed ticks at wrong positions). `Symlog10` is now a callable struct exposing its `lower`/`upper`/`linscale` parameters. Closes [#5270](https://github.com/MakieOrg/Makie.jl/issues/5270) [#5625](https://github.com/MakieOrg/Makie.jl/pull/5625)

--- a/CairoMakie/src/plot-primitives.jl
+++ b/CairoMakie/src/plot-primitives.jl
@@ -93,10 +93,12 @@ function prepare_for_scene(screen::Screen, scene::Scene)
     # get the root area to correct for its size when translating
     root_area_height = widths(Makie.root(scene))[2]
 
-    # Clip to the effective viewport (intersection with every ancestor's
-    # viewport) so a scene whose content extends past an ancestor — e.g. a
-    # scrollable container's children — is cut off at the ancestor's edge.
-    clip_area = Makie.effective_viewport(scene)
+    # Clip to the intersection of all ancestor viewports — `effective_clip`
+    # — so the scene only renders within the bounds its parents share.
+    # The scene's own viewport is excluded from the intersection, so e.g.
+    # axis markers near a spine extend past the plot scene into the axis's
+    # decoration area (which is clipped at the figure / container edge).
+    clip_area = Makie.effective_clip(scene)
     clip_x, clip_y_makie = origin(clip_area)
     clip_w, clip_h = widths(clip_area)
     clip_top = root_area_height - clip_y_makie - clip_h

--- a/CairoMakie/src/plot-primitives.jl
+++ b/CairoMakie/src/plot-primitives.jl
@@ -32,7 +32,7 @@ function cairo_draw(screen::Screen, scene::Scene)
         # only prepare for scene when it changes
         # this should reduce the number of unnecessary clipping masks etc.
         pparent = Makie.parent_scene(p)::Scene
-        pparent.visible[]::Bool || continue
+        Makie.scene_visible(pparent) || continue
         if pparent != last_scene
             Cairo.restore(screen.context)
             Cairo.save(screen.context)
@@ -92,21 +92,24 @@ function prepare_for_scene(screen::Screen, scene::Scene)
 
     # get the root area to correct for its size when translating
     root_area_height = widths(Makie.root(scene))[2]
+
+    # Clip to the effective viewport (intersection with every ancestor's
+    # viewport) so a scene whose content extends past an ancestor — e.g. a
+    # scrollable container's children — is cut off at the ancestor's edge.
+    clip_area = Makie.effective_viewport(scene)
+    clip_x, clip_y_makie = origin(clip_area)
+    clip_w, clip_h = widths(clip_area)
+    clip_top = root_area_height - clip_y_makie - clip_h
+    Cairo.rectangle(screen.context, clip_x, clip_top, clip_w, clip_h)
+    Cairo.clip(screen.context)
+
+    # Translate so scene-local (0, 0) corresponds to the scene's window origin.
+    # Cairo's y goes down, Makie's goes up, hence the parent-height correction.
     scene_area = viewport(scene)[]
-    scene_height = widths(scene_area)[2]
     scene_x_origin, scene_y_origin = scene_area.origin
-
-    # we need to translate x by the origin, so distance from the left
-    # but y by the distance from the top, which is not the origin, but can
-    # be calculated using the parent's height, the scene's height and the y origin
-    # this is because y goes downwards in Cairo and upwards in Makie
-
+    scene_height = widths(scene_area)[2]
     top_offset = root_area_height - scene_height - scene_y_origin
     Cairo.translate(screen.context, scene_x_origin, top_offset)
-
-    # clip the scene to its viewport
-    Cairo.rectangle(screen.context, 0, 0, widths(scene_area)...)
-    Cairo.clip(screen.context)
 
     return
 end

--- a/CairoMakie/src/plot-primitives.jl
+++ b/CairoMakie/src/plot-primitives.jl
@@ -124,7 +124,7 @@ end
 function draw_background(screen::Screen, scene::Scene, root_h)
     cr = screen.context
     Cairo.save(cr)
-    if scene.clear[]
+    if scene.clear[] && Makie.scene_visible(scene)
         bg = scene.backgroundcolor[]
         Cairo.set_source_rgba(cr, red(bg), green(bg), blue(bg), alpha(bg))
         r = viewport(scene)[]

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -305,19 +305,30 @@ function run_stage(screen, glscene, stage::RenderPlots)
             elem.visible && haskey(elem.variants, stage.target) || continue
 
             found, scene = id2scene(screen, screenid)
-            (found && scene.visible[]) || continue
+            (found && Makie.scene_visible(scene)) || continue
 
             ppu = screen.px_per_unit[]
             a = viewport(scene)[]
 
             require_context(screen.glscreen)
             glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
+            # Only scissor when an ancestor's viewport actually clips this
+            # scene — otherwise the original GL behaviour is preserved (no
+            # scissor), so e.g. axis markers can extend past the plot area.
+            if Makie.needs_ancestor_clip(scene)
+                sa = Makie.effective_viewport(scene)
+                glScissor(round.(Int, ppu .* minimum(sa))..., round.(Int, ppu .* widths(sa))...)
+                glEnable(GL_SCISSOR_TEST)
+            else
+                glDisable(GL_SCISSOR_TEST)
+            end
             elem[:px_per_unit] = ppu
 
             stage.prerender(elem[:overdraw]::UInt8)
 
             render(elem, elem.variants[stage.target])
         end
+        glDisable(GL_SCISSOR_TEST)
     catch e
         @error "Error while rendering!" exception = e
         rethrow(e)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -301,6 +301,7 @@ function run_stage(screen, glscene, stage::RenderPlots)
 
         set_draw_buffers(stage.framebuffer)
 
+        glEnable(GL_SCISSOR_TEST)
         for (zindex, screenid, elem) in screen.renderlist
             elem.visible && haskey(elem.variants, stage.target) || continue
 
@@ -309,19 +310,15 @@ function run_stage(screen, glscene, stage::RenderPlots)
 
             ppu = screen.px_per_unit[]
             a = viewport(scene)[]
+            # Scissor to the intersection of all ancestor viewports (excluding
+            # the scene's own) so each scene draws only within the bounds its
+            # parents share; lets markers near a scene edge extend past it
+            # while still being cut off at the enclosing container / window.
+            sa = Makie.effective_clip(scene)
 
             require_context(screen.glscreen)
             glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
-            # Only scissor when an ancestor's viewport actually clips this
-            # scene — otherwise the original GL behaviour is preserved (no
-            # scissor), so e.g. axis markers can extend past the plot area.
-            if Makie.needs_ancestor_clip(scene)
-                sa = Makie.effective_viewport(scene)
-                glScissor(round.(Int, ppu .* minimum(sa))..., round.(Int, ppu .* widths(sa))...)
-                glEnable(GL_SCISSOR_TEST)
-            else
-                glDisable(GL_SCISSOR_TEST)
-            end
+            glScissor(round.(Int, ppu .* minimum(sa))..., round.(Int, ppu .* widths(sa))...)
             elem[:px_per_unit] = ppu
 
             stage.prerender(elem[:overdraw]::UInt8)

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -12,7 +12,7 @@ function setup!(screen::Screen, fb)
     glEnable(GL_SCISSOR_TEST)
     ppu = screen.px_per_unit[]
     for (id, scene) in screen.screens
-        if scene.visible[] && scene.clear[]
+        if Makie.scene_visible(scene) && scene.clear[]
             a = viewport(scene)[]
             rt = (round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
             glViewport(rt...)

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -14,9 +14,9 @@ function setup!(screen::Screen, fb)
     for (id, scene) in screen.screens
         if Makie.scene_visible(scene) && scene.clear[]
             a = viewport(scene)[]
-            rt = (round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
-            glViewport(rt...)
-            glScissor(rt...)
+            sa = Makie.effective_clip(scene)
+            glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
+            glScissor(round.(Int, ppu .* minimum(sa))..., round.(Int, ppu .* widths(sa))...)
             c = scene.backgroundcolor[]
             glClearColor(red(c), green(c), blue(c), alpha(c))
             glClear(GL_COLOR_BUFFER_BIT)

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -481,7 +481,7 @@ export to_world
 
 # picking + interactive use cases + events
 export mouseover, onpick, pick, Events, Keyboard, Mouse, is_mouseinside
-export ispressed, Exclusively
+export ispressed, Exclusively, forward_events!
 export connect_screen
 export window_area, window_open, mouse_buttons, mouse_position, mouseposition_px,
     scroll, keyboard_buttons, unicode_input, dropped_files, hasfocus, entered_window

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -482,6 +482,7 @@ export to_world
 # picking + interactive use cases + events
 export mouseover, onpick, pick, Events, Keyboard, Mouse, is_mouseinside
 export ispressed, Exclusively, forward_events!
+export content_scene
 export connect_screen
 export window_area, window_open, mouse_buttons, mouse_position, mouseposition_px,
     scroll, keyboard_buttons, unicode_input, dropped_files, hasfocus, entered_window

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -482,7 +482,7 @@ export to_world
 # picking + interactive use cases + events
 export mouseover, onpick, pick, Events, Keyboard, Mouse, is_mouseinside
 export ispressed, Exclusively, forward_events!
-export content_scene
+export content_scene, add_tab!, remove_tab!, set_tab!
 export connect_screen
 export window_area, window_open, mouse_buttons, mouse_position, mouseposition_px,
     scroll, keyboard_buttons, unicode_input, dropped_files, hasfocus, entered_window

--- a/Makie/src/basic_recipes/editabletext.jl
+++ b/Makie/src/basic_recipes/editabletext.jl
@@ -601,7 +601,7 @@ function plot!(plot::EditableText)
         # Hide selections when the editor isn't focused — matches typical
         # text-input UX where the highlight disappears on click-away.
         visible = plot.focused,
-        space = :pixel, transformation = :nothing, inspectable = false,
+        space = plot.space, transformation = :nothing, inspectable = false,
     )
     # The selection rects need to render *behind* the text. Plot order in
     # `plot.plots` is rendering order, and the text plot was created first
@@ -656,7 +656,7 @@ function plot!(plot::EditableText)
         plot, cursor_segments_obs;
         color = plot.cursor_color, linewidth = plot.cursor_width,
         visible = cursor_visible_obs,
-        space = :pixel, transformation = :nothing, inspectable = false,
+        space = plot.space, transformation = :nothing, inspectable = false,
     )
 
     # ── Event handling ───────────────────────────────────────────────────────
@@ -716,7 +716,7 @@ function attach_editabletext_events!(
             event.button == Mouse.left || return Consume(false)
 
             if event.action == Mouse.press
-                mpos = mouseposition_px(parent)
+                mpos = Point2f(events(parent).mouseposition[])
                 if plot.manage_focus[]
                     # Auto-focus on clicks within the text bbox; auto-defocus
                     # on clicks outside.
@@ -787,8 +787,8 @@ function attach_editabletext_events!(
             anchor = drag_anchor[]
             anchor === nothing && return Consume(false)
             Mouse.left in events(parent).mousebuttonstate || return Consume(false)
-            mpos = mouseposition_px(parent)
-            head = _mouse_to_offset(Point2f(mpos))
+            mpos = Point2f(events(parent).mouseposition[])
+            head = _mouse_to_offset(mpos)
             cursors = plot.cursors[]
             # Only rewrite the last cursor (the one created by the press) so prior
             # multi-cursors stay intact. Skip if its head hasn't moved — mouseposition

--- a/Makie/src/camera/camera2d.jl
+++ b/Makie/src/camera/camera2d.jl
@@ -329,8 +329,13 @@ struct UpdatePixelCam
 end
 
 function (cam::UpdatePixelCam)(window_size)
+    # Project absolute window pixels (not viewport-local) to NDC so a coord
+    # `(X, Y)` in a campixel scene renders at window pixel `(X, Y)` regardless
+    # of where the scene sits in its parent. For a scene whose viewport is at
+    # the window origin this is identical to the old `(0..w, 0..h)` projection.
+    vx, vy = Float64.(minimum(window_size))
     w, h = Float64.(widths(window_size))
-    projection = orthographicprojection(0.0, w, 0.0, h, cam.near, cam.far)
+    projection = orthographicprojection(vx, vx + w, vy, vy + h, cam.near, cam.far)
     return set_proj_view!(cam.camera, projection, Mat4d(I))
 end
 
@@ -355,48 +360,6 @@ function campixel!(scene::Scene; nearclip = -10_000.0, farclip = 10_000.0)
     return cam
 end
 
-struct UpdateWindowPixelCam
-    camera::Camera
-    near::Float64
-    far::Float64
-end
-
-function (cam::UpdateWindowPixelCam)(window_area)
-    # Project absolute window pixels to NDC, accounting for the viewport's
-    # position. With this, coord (X, Y) in the scene renders at window pixel
-    # (X, Y) regardless of where the scene sits in its parent — needed for
-    # hosting blocks whose decoration code is in absolute window coords.
-    vx, vy = Float64.(minimum(window_area))
-    w, h = Float64.(widths(window_area))
-    projection = orthographicprojection(vx, vx + w, vy, vy + h, cam.near, cam.far)
-    return set_proj_view!(cam.camera, projection, Mat4d(I))
-end
-
-"""
-    cam_window_pixel!(scene; nearclip = -10_000.0, farclip = 10_000.0)
-
-Like [`campixel!`](@ref), but with a projection that interprets positions in
-*absolute window pixel coordinates* rather than viewport-local pixel
-coordinates: a coordinate `(X, Y)` in the scene always renders at window pixel
-`(X, Y)`, regardless of where the scene's viewport sits in its parent.
-
-For a scene whose viewport is at the window origin (e.g. a `Figure`'s root
-scene) this is identical to `campixel!`. It only differs when the viewport
-starts at a non-zero origin, which is the case for any scene hosted as a child
-of a parent that occupies a sub-region (e.g. a `Tabs` tab). This is the camera
-used by `Block`s' blockscenes, because the block decoration code positions
-things in absolute window coords from the layout `cbb`.
-"""
-function cam_window_pixel!(scene::Scene; nearclip = -10_000.0, farclip = 10_000.0)
-    disconnect!(camera(scene))
-    camera(scene).view_direction[] = Vec3f(0, 0, -1)
-    closure = UpdateWindowPixelCam(camera(scene), nearclip, farclip)
-    on(closure, camera(scene), viewport(scene))
-    cam = PixelCamera()
-    closure(viewport(scene)[])
-    cameracontrols!(scene, cam)
-    return cam
-end
 
 struct RelativeCamera <: AbstractCamera end
 get_space(::RelativeCamera) = :relative

--- a/Makie/src/camera/camera2d.jl
+++ b/Makie/src/camera/camera2d.jl
@@ -355,6 +355,49 @@ function campixel!(scene::Scene; nearclip = -10_000.0, farclip = 10_000.0)
     return cam
 end
 
+struct UpdateWindowPixelCam
+    camera::Camera
+    near::Float64
+    far::Float64
+end
+
+function (cam::UpdateWindowPixelCam)(window_area)
+    # Project absolute window pixels to NDC, accounting for the viewport's
+    # position. With this, coord (X, Y) in the scene renders at window pixel
+    # (X, Y) regardless of where the scene sits in its parent — needed for
+    # hosting blocks whose decoration code is in absolute window coords.
+    vx, vy = Float64.(minimum(window_area))
+    w, h = Float64.(widths(window_area))
+    projection = orthographicprojection(vx, vx + w, vy, vy + h, cam.near, cam.far)
+    return set_proj_view!(cam.camera, projection, Mat4d(I))
+end
+
+"""
+    cam_window_pixel!(scene; nearclip = -10_000.0, farclip = 10_000.0)
+
+Like [`campixel!`](@ref), but with a projection that interprets positions in
+*absolute window pixel coordinates* rather than viewport-local pixel
+coordinates: a coordinate `(X, Y)` in the scene always renders at window pixel
+`(X, Y)`, regardless of where the scene's viewport sits in its parent.
+
+For a scene whose viewport is at the window origin (e.g. a `Figure`'s root
+scene) this is identical to `campixel!`. It only differs when the viewport
+starts at a non-zero origin, which is the case for any scene hosted as a child
+of a parent that occupies a sub-region (e.g. a `Tabs` tab). This is the camera
+used by `Block`s' blockscenes, because the block decoration code positions
+things in absolute window coords from the layout `cbb`.
+"""
+function cam_window_pixel!(scene::Scene; nearclip = -10_000.0, farclip = 10_000.0)
+    disconnect!(camera(scene))
+    camera(scene).view_direction[] = Vec3f(0, 0, -1)
+    closure = UpdateWindowPixelCam(camera(scene), nearclip, farclip)
+    on(closure, camera(scene), viewport(scene))
+    cam = PixelCamera()
+    closure(viewport(scene)[])
+    cameracontrols!(scene, cam)
+    return cam
+end
+
 struct RelativeCamera <: AbstractCamera end
 get_space(::RelativeCamera) = :relative
 

--- a/Makie/src/figureplotting.jl
+++ b/Makie/src/figureplotting.jl
@@ -413,6 +413,18 @@ function update_state_before_display!(f::Figure)
     return
 end
 
+# Recurse into nested layouts so blocks placed inside another block's
+# `GridLayout` — e.g. an `Axis` inside a `Tabs` tab — also get their
+# pre-display state updates (auto limits etc.). The default fallback for
+# non-axis content stays a no-op, so this only adds work for things that
+# care.
+function update_state_before_display!(layout::GridLayout)
+    for gc in layout.content
+        update_state_before_display!(gc.content)
+    end
+    return
+end
+
 @inline plot_args(args...) = (nothing, args)
 @inline function plot_args(
         a::Union{Figure, AbstractAxis, Scene, Plot, GridSubposition, GridPosition},

--- a/Makie/src/interaction/events.jl
+++ b/Makie/src/interaction/events.jl
@@ -54,6 +54,104 @@ function disconnect_screen(scene::Scene, screen)
     return
 end
 
+# Window/rendering context events. They describe the environment rather than
+# user input directed at a particular scene, so an isolated subtree needs them
+# forwarded unconditionally (e.g. `tick` drives animations and rendering).
+const CONTEXT_EVENT_FIELDS = (:window_area, :window_dpi, :window_open, :hasfocus, :entered_window, :tick)
+# User input events. These are gated on activity when forwarding so that an
+# inactive subtree receives no mouse or keyboard input at all.
+const INPUT_EVENT_FIELDS = (:mousebutton, :mouseposition, :scroll, :keyboardbutton, :unicode_input, :dropped_files)
+
+"""
+    release_inputs!(events::Events)
+
+Synthesize release events for every currently-pressed mouse button and keyboard
+key in `events`. Used when an event-isolated subtree is deactivated mid-press so
+it does not retain stuck-down input state (e.g. an axis left mid-drag).
+"""
+function release_inputs!(events::Events)
+    for button in copy(events.mousebuttonstate)
+        events.mousebutton[] = MouseButtonEvent(button, Mouse.release)
+    end
+    for key in copy(events.keyboardstate)
+        events.keyboardbutton[] = KeyEvent(key, Keyboard.release)
+    end
+    return
+end
+
+"""
+    forward_events!(target::Scene, source::Scene; active = Observable(true), priority = 0)
+
+Forward window and input events from `source` into `target`, where `target` owns
+an `Events` object distinct from `source` (create it with `Scene(parent; events = Events())`).
+
+This is the mechanism for event-isolating a subtree: by default every child scene
+shares its parent's `Events`, so listeners on a hidden subtree still fire. Giving a
+subtree its own `Events` and feeding it through `forward_events!` makes its input
+gated by `active`:
+
+- Context events (`$(join(CONTEXT_EVENT_FIELDS, ", "))`) are always forwarded so
+  rendering and layout keep working regardless of `active`.
+- Input events (`$(join(INPUT_EVENT_FIELDS, ", "))`) are forwarded only while
+  `active[]` is `true`. `Consume` returned by `target`'s listeners is propagated
+  back to `source`, so an active subtree consuming an event still blocks lower
+  priority listeners on `source`.
+
+When `active` flips to `false`, held buttons/keys are released in `target` (see
+[`release_inputs!`](@ref)); when it flips to `true`, `target`'s mouse position is
+synced from `source` so hit-testing is immediately correct.
+
+Returns the `Vector{ObserverFunction}` of registered listeners for later `off`-ing.
+"""
+function forward_events!(
+        target::Scene, source::Scene;
+        active::Observable{Bool} = Observable(true), priority::Int = 0
+    )
+    src = events(source)
+    dst = events(target)
+    src === dst && error(
+        "`target` must own an `Events` object distinct from `source`. " *
+            "Create it with `Scene(parent; events = Events())`."
+    )
+
+    obsfuncs = Observables.ObserverFunction[]
+
+    for field in CONTEXT_EVENT_FIELDS
+        s = getfield(src, field)
+        d = getfield(dst, field)
+        push!(
+            obsfuncs, on(s; priority = priority) do value
+                d[] = value
+                return Consume(false)
+            end
+        )
+    end
+
+    for field in INPUT_EVENT_FIELDS
+        s = getfield(src, field)
+        d = getfield(dst, field)
+        push!(
+            obsfuncs, on(s; priority = priority) do value
+                active[] || return Consume(false)
+                return Consume(setindex!(d, value) === true)
+            end
+        )
+    end
+
+    push!(
+        obsfuncs, on(active) do isactive
+            if isactive
+                dst.mouseposition[] = src.mouseposition[]
+            else
+                release_inputs!(dst)
+            end
+            return
+        end
+    )
+
+    return obsfuncs
+end
+
 """
 Picks a mouse position. Implemented by the backend.
 """

--- a/Makie/src/makielayout/MakieLayout.jl
+++ b/Makie/src/makielayout/MakieLayout.jl
@@ -34,6 +34,7 @@ include("blocks/scene.jl")
 include("blocks/menu.jl")
 include("blocks/textbox.jl")
 include("blocks/container.jl")
+include("blocks/subfigure.jl")
 include("blocks/tabs.jl")
 
 export @Block, Block

--- a/Makie/src/makielayout/MakieLayout.jl
+++ b/Makie/src/makielayout/MakieLayout.jl
@@ -34,6 +34,7 @@ include("blocks/scene.jl")
 include("blocks/menu.jl")
 include("blocks/textbox.jl")
 include("blocks/container.jl")
+include("blocks/tabs.jl")
 
 export @Block, Block
 export axislegend

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -532,6 +532,7 @@ function attribute_names(::Type{T}) where {T <: Block}
     T <: Menu && (attrs[:default] = "")
     T <: LScene && (attrs[:scenekw] = "")
     T <: Subfigure && (attrs[:isolate_events] = "")
+    T <: Tabs && (attrs[:closable] = "")
     return keys(attrs)
 end
 

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -694,7 +694,14 @@ function _block(T::Type{<:Block}, fig_or_scene::Union{Figure, Scene}, args, kwdi
     # create base block with otherwise undefined fields
     b = T(fig_or_scene, lobservables, graph)
 
-    b.blockscene = Scene(topscene, clear = false, camera = campixel!)
+    # `cam_window_pixel!` (rather than `campixel!`) maps absolute window
+    # coordinates to NDC, accounting for the viewport's position. Block
+    # decoration code positions things in absolute coords from the layout
+    # `cbb`; with this camera that works regardless of where the topscene's
+    # viewport sits in its parent (e.g. when a block is placed inside a
+    # `Tabs` tab). For a topscene at the window origin the projection is
+    # identical to `campixel!`.
+    b.blockscene = Scene(topscene, clear = false, camera = cam_window_pixel!)
 
     if has_forwarded_layout(T)
         init_layout!(b)

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -531,6 +531,7 @@ function attribute_names(::Type{T}) where {T <: Block}
     T <: Legend && (attrs[:entrygroups] = "")
     T <: Menu && (attrs[:default] = "")
     T <: LScene && (attrs[:scenekw] = "")
+    T <: Subfigure && (attrs[:isolate_events] = "")
     return keys(attrs)
 end
 

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -695,14 +695,7 @@ function _block(T::Type{<:Block}, fig_or_scene::Union{Figure, Scene}, args, kwdi
     # create base block with otherwise undefined fields
     b = T(fig_or_scene, lobservables, graph)
 
-    # `cam_window_pixel!` (rather than `campixel!`) maps absolute window
-    # coordinates to NDC, accounting for the viewport's position. Block
-    # decoration code positions things in absolute coords from the layout
-    # `cbb`; with this camera that works regardless of where the topscene's
-    # viewport sits in its parent (e.g. when a block is placed inside a
-    # `Tabs` tab). For a topscene at the window origin the projection is
-    # identical to `campixel!`.
-    b.blockscene = Scene(topscene, clear = false, camera = cam_window_pixel!)
+    b.blockscene = Scene(topscene, clear = false, camera = campixel!)
 
     if has_forwarded_layout(T)
         init_layout!(b)

--- a/Makie/src/makielayout/blocks/button.jl
+++ b/Makie/src/makielayout/blocks/button.jl
@@ -9,9 +9,10 @@ function initialize_block!(b::Button)
     end
     subscene = Scene(scene, subarea, camera = campixel!)
 
-    # buttonrect is without the left bottom offset of the bbox
+    # campixel is in absolute window coords, so the button background just
+    # echoes the computed bbox.
     buttonrect = lift(scene, b.layoutobservables.computedbbox) do bbox
-        BBox(0, width(bbox), 0, height(bbox))
+        Rect2f(bbox)
     end
 
     on(scene, buttonrect) do rect

--- a/Makie/src/makielayout/blocks/menu.jl
+++ b/Makie/src/makielayout/blocks/menu.jl
@@ -171,19 +171,19 @@ function initialize_block!(m::Menu; default = 1)
         # No need to update when the scene is hidden
         widths(bbox) == Vec2i(0) && return
 
-        pad = m.textpadding[] # gc_heights triggers on padding, so we don't need to react to it
-        # listheight[] = h
-
+        pad = m.textpadding[]
+        # campixel is absolute, so anchor the list at the menuscene viewport
+        # origin. `list_y_bounds` are likewise in absolute window y.
+        ox, oy = Float32(left(bbox)), Float32(bottom(bbox))
         heights_cumsum = [zero(eltype(heights)); cumsum(heights)]
-        list_y_bounds[] = h .- heights_cumsum
+        list_y_bounds[] = oy .+ (h .- heights_cumsum)
         texts_y = @views h .- 0.5 .* (heights_cumsum[1:(end - 1)] .+ heights_cumsum[2:end])
-        textpositions[] = Point2f.(pad[1], texts_y)
+        textpositions[] = Point2f.(ox + pad[1], oy .+ texts_y)
         w_bbox = width(bbox)
-        # need to manipulate the vectors themselves, otherwise update errors when lengths change
         resize!(optionrects.val, length(heights))
 
         optionrects.val .= map(eachindex(heights)) do i
-            BBox(0, w_bbox, h - heights_cumsum[i + 1], h - heights_cumsum[i])
+            BBox(ox, ox + w_bbox, oy + h - heights_cumsum[i + 1], oy + h - heights_cumsum[i])
         end
 
         _update_option_colors!(0, optionstrings, optionpolycolors, m)
@@ -211,23 +211,22 @@ function initialize_block!(m::Menu; default = 1)
     color_selector = Observable(SELECT_INACTIVE_COLOR)
 
     onany(blockscene, e.mouseposition, e.mousebutton; priority = 64) do position, butt
-        mp = screen_relative(menuscene, position)
-        # track if we have been inside menu/options to clean up if we haven't been
+        # optionrects and list_y_bounds are in absolute window coords (campixel
+        # is absolute); offset by the menuscene's translation for the scroll
+        # state when hit-testing.
+        mp = Point2f(position) .- Vec2f(translation(menuscene)[][1], translation(menuscene)[][2])
         is_over_options = false
         is_over_button = false
 
-        if Makie.is_mouseinside(menuscene) # the whole scene containing all options
-            # Is inside the expanded menu selection (the polys cover the whole
-            # selectable area and are in pixel space relative to menuscene)
+        if Makie.is_mouseinside(menuscene)
             if any(r -> mp in r, optionpolys[1][])
                 is_over_options = true
                 was_inside_options[] = true
-                # we either clicked on an item or hover it
                 if _mouse_up(butt, was_pressed_options) # PRESSED
-                    m.i_selected[] = _pick_entry(mp[2], menuscene, list_y_bounds)
+                    m.i_selected[] = _pick_entry(position[2], menuscene, list_y_bounds)
                     m.is_open[] = false
                 else # HOVER
-                    idx_hovered = _pick_entry(mp[2], menuscene, list_y_bounds)
+                    idx_hovered = _pick_entry(position[2], menuscene, list_y_bounds)
                     _update_option_colors!(idx_hovered, optionstrings, optionpolycolors, m)
                 end
             else

--- a/Makie/src/makielayout/blocks/subfigure.jl
+++ b/Makie/src/makielayout/blocks/subfigure.jl
@@ -5,24 +5,24 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
 
     # Unwrap the Compute graph node into a plain Observable{Bool} for the
     # parts of the API that expect one (Scene's `visible`, `forward_events!`).
-    active = lift(identity, blockscene, sf.active)
+    is_visible = lift(identity, blockscene, sf.visible)
 
     scene = if isolate_events
         Scene(
             blockscene; events = Events(), camera = campixel!,
-            viewport = content_area, visible = active, clear = false
+            viewport = content_area, visible = is_visible, clear = false
         )
     else
-        Scene(blockscene; camera = campixel!, viewport = content_area, visible = active, clear = false)
+        Scene(blockscene; camera = campixel!, viewport = content_area, visible = is_visible, clear = false)
     end
     if isolate_events
-        forward_events!(scene, blockscene; active = active)
+        forward_events!(scene, blockscene; active = is_visible)
     end
     sf.scene = scene
 
     poly!(
         blockscene, content_area;
-        color = sf.backgroundcolor, visible = active, inspectable = false
+        color = sf.backgroundcolor, visible = is_visible, inspectable = false
     )
 
     sf.scroll = Observable(Vec2f(0, 0); ignore_equal_values = true)
@@ -53,16 +53,16 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
     # Rounded thumbs (capsule-shaped) computed from the bar rects. The track
     # rectangles aren't drawn — `sf.scrollbar_color` is exposed for users who
     # want a track, but the default is transparent.
-    poly!(blockscene, vbar_rect; color = sf.scrollbar_color, visible = lift(&, active, vvis), inspectable = false)
-    poly!(blockscene, hbar_rect; color = sf.scrollbar_color, visible = lift(&, active, hvis), inspectable = false)
+    poly!(blockscene, vbar_rect; color = sf.scrollbar_color, visible = lift(&, is_visible, vvis), inspectable = false)
+    poly!(blockscene, hbar_rect; color = sf.scrollbar_color, visible = lift(&, is_visible, hvis), inspectable = false)
     vthumb_poly = lift(blockscene, vthumb_rect) do r
         roundedrectvertices(r, min(widths(r)...) / 2, 8)
     end
     hthumb_poly = lift(blockscene, hthumb_rect) do r
         roundedrectvertices(r, min(widths(r)...) / 2, 8)
     end
-    poly!(blockscene, vthumb_poly; color = vthumb_color, visible = lift(&, active, vvis), inspectable = false)
-    poly!(blockscene, hthumb_poly; color = hthumb_color, visible = lift(&, active, hvis), inspectable = false)
+    poly!(blockscene, vthumb_poly; color = vthumb_color, visible = lift(&, is_visible, vvis), inspectable = false)
+    poly!(blockscene, hthumb_poly; color = hthumb_color, visible = lift(&, is_visible, hvis), inspectable = false)
 
     function update_scrollbars!()
         ca = scene.viewport[]
@@ -122,8 +122,13 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
     # Wheel scrolling runs below the default priority so an inner block (e.g.
     # an Axis zoom-on-scroll handler at priority 0) gets the event first; the
     # subfigure only scrolls when nothing else consumed.
+    # The handler listens on `scene.events`, which is the *isolated* Events
+    # when `isolate_events = true`. With shared Events (the default), it
+    # additionally checks `is_mouseinside(scene)` so stacked non-isolated
+    # subfigures don't all scroll on every wheel event.
     on(blockscene, scene.events.scroll; priority = -1) do (dx, dy)
         sf.scrollable[] || return Consume(false)
+        is_mouseinside(scene) || return Consume(false)
         cs = sf.contentsize[]
         ca = scene.viewport[]
         vw, vh = Float32.(widths(ca))
@@ -135,8 +140,21 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
     end
 
     drag_state = Ref{Tuple{Symbol, Float32, Vec2f}}((:none, 0.0f0, Vec2f(0, 0)))
+    # If the subfigure becomes invisible mid-drag (e.g. a Tab switch), or the
+    # backend ever drops the mouse-release, the drag must be cleared so the
+    # next mouse-move doesn't keep scrolling.
+    on(blockscene, is_visible) do v
+        v || (drag_state[] = (:none, 0.0f0, Vec2f(0, 0)))
+        return
+    end
+    on(blockscene, blockscene.events.mousebutton) do ev
+        if ev.action == Mouse.release && drag_state[][1] !== :none
+            drag_state[] = (:none, 0.0f0, Vec2f(0, 0))
+        end
+        return Consume(false)
+    end
     function bar_at(pos)
-        active[] || return :none
+        is_visible[] || return :none
         pt = Point2f(pos)
         if vvis[]
             pt in vthumb_rect[] && return :vthumb
@@ -149,13 +167,14 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
         return :none
     end
 
-    on(blockscene, blockscene.events.mouseposition) do pos
+    on(blockscene, blockscene.events.mouseposition; priority = 60) do pos
+        is_visible[] || return Consume(false)
         kind = bar_at(pos)
         st = drag_state[][1]
-        v_active = st === :vdrag || kind in (:vthumb, :vtrack)
-        h_active = st === :hdrag || kind in (:hthumb, :htrack)
-        vthumb_color[] = to_color(v_active ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
-        hthumb_color[] = to_color(h_active ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
+        v_highlight = st === :vdrag || kind in (:vthumb, :vtrack)
+        h_highlight = st === :hdrag || kind in (:hthumb, :htrack)
+        vthumb_color[] = to_color(v_highlight ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
+        hthumb_color[] = to_color(h_highlight ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
 
         st, anchor, anchor_scroll = drag_state[]
         if st === :vdrag
@@ -187,7 +206,7 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
     end
 
     on(blockscene, blockscene.events.mousebutton; priority = 60) do ev
-        active[] || return Consume(false)
+        is_visible[] || return Consume(false)
         if ev.button == Mouse.left && ev.action == Mouse.press
             pos = blockscene.events.mouseposition[]
             kind = bar_at(pos)
@@ -222,7 +241,7 @@ content_scene(sf::Subfigure) = sf.scene
 
 # `unhide!` force-sets `b.scene.visible[] = true` (intended for blocks like Axis
 # that initialise it `false`), which would override the reactive binding from
-# `active`. Subfigure's scene visibility is driven by `active`, so don't touch
+# `sf.visible`. Subfigure's scene visibility follows `sf.visible`, so don't touch
 # `sf.scene.visible` here — just unhide the blockscene like the default would.
 function unhide!(sf::Subfigure)
     sf.blockscene.visible[] || (sf.blockscene.visible[] = true)

--- a/Makie/src/makielayout/blocks/subfigure.jl
+++ b/Makie/src/makielayout/blocks/subfigure.jl
@@ -1,0 +1,218 @@
+function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
+    blockscene = sf.blockscene
+
+    content_area = lift(round_to_IRect2D, blockscene, sf.layoutobservables.computedbbox)
+
+    # Unwrap the Compute graph node into a plain Observable{Bool} for the
+    # parts of the API that expect one (Scene's `visible`, `forward_events!`).
+    active = lift(identity, blockscene, sf.active)
+
+    scene = if isolate_events
+        Scene(
+            blockscene; events = Events(), camera = campixel!,
+            viewport = content_area, visible = active, clear = false
+        )
+    else
+        Scene(blockscene; camera = campixel!, viewport = content_area, visible = active, clear = false)
+    end
+    if isolate_events
+        forward_events!(scene, blockscene; active = active)
+    end
+    sf.scene = scene
+
+    poly!(
+        blockscene, content_area;
+        color = sf.backgroundcolor, visible = active, inspectable = false
+    )
+
+    sf.scroll = Observable(Vec2f(0, 0); ignore_equal_values = true)
+    sf.contentsize = Observable(Vec2f(0, 0); ignore_equal_values = true)
+
+    layout_bbox = Observable(Rect2f(0, 0, 1, 1); ignore_equal_values = true)
+    layout = GridLayout(; bbox = layout_bbox)
+    layout.parent = scene
+    sf.layout = layout
+
+    on(blockscene, sf.contentpadding; update = true) do pad
+        sides = pad isa Number ? (pad, pad, pad, pad) : pad
+        layout.alignmode[] = Outside(to_rectsides(sides))
+        GridLayoutBase.update!(layout)
+        return
+    end
+
+    # Scrollbar primitives drawn in the parent's blockscene so they sit above
+    # the content area; sized in `update_scrollbars!`.
+    vbar_rect = Observable(Rect2f(0, 0, 0, 0))
+    vthumb_rect = Observable(Rect2f(0, 0, 0, 0))
+    vthumb_color = Observable(to_color(sf.scrollbar_thumb_color[]))
+    vvis = Observable(false; ignore_equal_values = true)
+    hbar_rect = Observable(Rect2f(0, 0, 0, 0))
+    hthumb_rect = Observable(Rect2f(0, 0, 0, 0))
+    hthumb_color = Observable(to_color(sf.scrollbar_thumb_color[]))
+    hvis = Observable(false; ignore_equal_values = true)
+    poly!(blockscene, vbar_rect; color = sf.scrollbar_color, visible = lift(&, active, vvis), inspectable = false)
+    poly!(blockscene, vthumb_rect; color = vthumb_color, visible = lift(&, active, vvis), inspectable = false)
+    poly!(blockscene, hbar_rect; color = sf.scrollbar_color, visible = lift(&, active, hvis), inspectable = false)
+    poly!(blockscene, hthumb_rect; color = hthumb_color, visible = lift(&, active, hvis), inspectable = false)
+
+    function update_scrollbars!()
+        ca = scene.viewport[]
+        cs = sf.contentsize[]
+        sc = sf.scroll[]
+        sbsize = Float32(sf.scrollbar_size[])
+        vw, vh = Float32.(widths(ca))
+        cw, ch = max(cs[1], vw), max(cs[2], vh)
+        max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
+        vvis[] = max_sy > 0
+        hvis[] = max_sx > 0
+        if max_sy > 0
+            tx = right(ca) - sbsize
+            vbar_rect[] = Rect2f((tx, bottom(ca)), (sbsize, vh))
+            thumb_h = max(20.0f0, vh * vh / ch)
+            usable = vh - thumb_h
+            ty = top(ca) - thumb_h - (sc[2] / max_sy) * usable
+            vthumb_rect[] = Rect2f((tx, ty), (sbsize, thumb_h))
+        end
+        if max_sx > 0
+            by = bottom(ca)
+            hbar_rect[] = Rect2f((left(ca), by), (vw, sbsize))
+            thumb_w = max(20.0f0, vw * vw / cw)
+            usable = vw - thumb_w
+            tx = left(ca) + (sc[1] / max_sx) * usable
+            hthumb_rect[] = Rect2f((tx, by), (thumb_w, sbsize))
+        end
+        return
+    end
+
+    onany(blockscene, content_area, sf.scroll, sf.contentsize) do ca, sc, cs
+        vw, vh = Float32.(widths(ca))
+        cw, ch = max(cs[1], vw), max(cs[2], vh)
+        max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
+        sx = clamp(sc[1], 0.0f0, max_sx)
+        sy = clamp(sc[2], 0.0f0, max_sy)
+        if sx != sc[1] || sy != sc[2]
+            sf.scroll[] = Vec2f(sx, sy)
+            return
+        end
+        top_edge = top(ca) + sy
+        left_edge = left(ca) - sx
+        layout_bbox[] = Rect2f(Point2f(left_edge, top_edge - ch), Vec2f(cw, ch))
+        update_scrollbars!()
+        return
+    end
+
+    on(blockscene, layout.layoutobservables.computedbbox) do _
+        dw = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Col())
+        dh = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Row())
+        cw = dw === nothing ? 0.0f0 : Float32(dw)
+        ch = dh === nothing ? 0.0f0 : Float32(dh)
+        sf.contentsize[] = Vec2f(cw, ch)
+        return
+    end
+
+    # Wheel scrolling runs below the default priority so an inner block (e.g.
+    # an Axis zoom-on-scroll handler at priority 0) gets the event first; the
+    # subfigure only scrolls when nothing else consumed.
+    on(blockscene, scene.events.scroll; priority = -1) do (dx, dy)
+        sf.scrollable[] || return Consume(false)
+        cs = sf.contentsize[]
+        ca = scene.viewport[]
+        vw, vh = Float32.(widths(ca))
+        cw, ch = max(cs[1], vw), max(cs[2], vh)
+        (cw <= vw && ch <= vh) && return Consume(false)
+        step = Float32(sf.scroll_speed[])
+        sf.scroll[] = Vec2f(sf.scroll[][1] + step * dx, sf.scroll[][2] - step * dy)
+        return Consume(true)
+    end
+
+    drag_state = Ref{Tuple{Symbol, Float32, Vec2f}}((:none, 0.0f0, Vec2f(0, 0)))
+    function bar_at(pos)
+        active[] || return :none
+        pt = Point2f(pos)
+        if vvis[]
+            pt in vthumb_rect[] && return :vthumb
+            pt in vbar_rect[] && return :vtrack
+        end
+        if hvis[]
+            pt in hthumb_rect[] && return :hthumb
+            pt in hbar_rect[] && return :htrack
+        end
+        return :none
+    end
+
+    on(blockscene, blockscene.events.mouseposition) do pos
+        kind = bar_at(pos)
+        st = drag_state[][1]
+        v_active = st === :vdrag || kind in (:vthumb, :vtrack)
+        h_active = st === :hdrag || kind in (:hthumb, :htrack)
+        vthumb_color[] = to_color(v_active ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
+        hthumb_color[] = to_color(h_active ? sf.scrollbar_thumb_color_active[] : sf.scrollbar_thumb_color[])
+
+        st, anchor, anchor_scroll = drag_state[]
+        if st === :vdrag
+            ca = scene.viewport[]
+            vh = Float32(widths(ca)[2])
+            ch = max(sf.contentsize[][2], vh)
+            max_sy = max(0.0f0, ch - vh)
+            max_sy == 0 && return Consume(false)
+            thumb_h = max(20.0f0, vh * vh / ch)
+            usable = vh - thumb_h
+            dy = anchor - Float32(pos[2])
+            new_sy = clamp(anchor_scroll[2] + dy * max_sy / usable, 0.0f0, max_sy)
+            sf.scroll[] = Vec2f(sf.scroll[][1], new_sy)
+            return Consume(true)
+        elseif st === :hdrag
+            ca = scene.viewport[]
+            vw = Float32(widths(ca)[1])
+            cw = max(sf.contentsize[][1], vw)
+            max_sx = max(0.0f0, cw - vw)
+            max_sx == 0 && return Consume(false)
+            thumb_w = max(20.0f0, vw * vw / cw)
+            usable = vw - thumb_w
+            dx = Float32(pos[1]) - anchor
+            new_sx = clamp(anchor_scroll[1] + dx * max_sx / usable, 0.0f0, max_sx)
+            sf.scroll[] = Vec2f(new_sx, sf.scroll[][2])
+            return Consume(true)
+        end
+        return Consume(false)
+    end
+
+    on(blockscene, blockscene.events.mousebutton; priority = 60) do ev
+        active[] || return Consume(false)
+        if ev.button == Mouse.left && ev.action == Mouse.press
+            pos = blockscene.events.mouseposition[]
+            kind = bar_at(pos)
+            if kind === :vthumb
+                drag_state[] = (:vdrag, Float32(pos[2]), sf.scroll[])
+                return Consume(true)
+            elseif kind === :hthumb
+                drag_state[] = (:hdrag, Float32(pos[1]), sf.scroll[])
+                return Consume(true)
+            elseif kind === :vtrack
+                vh = Float32(widths(scene.viewport[])[2])
+                dir = Float32(pos[2]) < (vthumb_rect[].origin[2] + vthumb_rect[].widths[2] / 2) ? 1 : -1
+                sf.scroll[] = Vec2f(sf.scroll[][1], sf.scroll[][2] + dir * vh)
+                return Consume(true)
+            elseif kind === :htrack
+                vw = Float32(widths(scene.viewport[])[1])
+                dir = Float32(pos[1]) > (hthumb_rect[].origin[1] + hthumb_rect[].widths[1] / 2) ? 1 : -1
+                sf.scroll[] = Vec2f(sf.scroll[][1] + dir * vw, sf.scroll[][2])
+                return Consume(true)
+            end
+        elseif ev.button == Mouse.left && ev.action == Mouse.release
+            drag_state[] = (:none, 0.0f0, Vec2f(0, 0))
+        end
+        return Consume(false)
+    end
+
+    notify(sf.layoutobservables.suggestedbbox)
+    return
+end
+
+content_scene(sf::Subfigure) = sf.scene
+
+# Recurse into the subfigure's layout so blocks placed inside get their
+# pre-display updates (auto axis limits etc.).
+function update_state_before_display!(sf::Subfigure)
+    return update_state_before_display!(sf.layout)
+end

--- a/Makie/src/makielayout/blocks/subfigure.jl
+++ b/Makie/src/makielayout/blocks/subfigure.jl
@@ -211,6 +211,15 @@ end
 
 content_scene(sf::Subfigure) = sf.scene
 
+# `unhide!` force-sets `b.scene.visible[] = true` (intended for blocks like Axis
+# that initialise it `false`), which would override the reactive binding from
+# `active`. Subfigure's scene visibility is driven by `active`, so don't touch
+# `sf.scene.visible` here — just unhide the blockscene like the default would.
+function unhide!(sf::Subfigure)
+    sf.blockscene.visible[] || (sf.blockscene.visible[] = true)
+    return
+end
+
 # Recurse into the subfigure's layout so blocks placed inside get their
 # pre-display updates (auto axis limits etc.).
 function update_state_before_display!(sf::Subfigure)

--- a/Makie/src/makielayout/blocks/subfigure.jl
+++ b/Makie/src/makielayout/blocks/subfigure.jl
@@ -50,10 +50,19 @@ function initialize_block!(sf::Subfigure; isolate_events::Bool = false)
     hthumb_rect = Observable(Rect2f(0, 0, 0, 0))
     hthumb_color = Observable(to_color(sf.scrollbar_thumb_color[]))
     hvis = Observable(false; ignore_equal_values = true)
+    # Rounded thumbs (capsule-shaped) computed from the bar rects. The track
+    # rectangles aren't drawn — `sf.scrollbar_color` is exposed for users who
+    # want a track, but the default is transparent.
     poly!(blockscene, vbar_rect; color = sf.scrollbar_color, visible = lift(&, active, vvis), inspectable = false)
-    poly!(blockscene, vthumb_rect; color = vthumb_color, visible = lift(&, active, vvis), inspectable = false)
     poly!(blockscene, hbar_rect; color = sf.scrollbar_color, visible = lift(&, active, hvis), inspectable = false)
-    poly!(blockscene, hthumb_rect; color = hthumb_color, visible = lift(&, active, hvis), inspectable = false)
+    vthumb_poly = lift(blockscene, vthumb_rect) do r
+        roundedrectvertices(r, min(widths(r)...) / 2, 8)
+    end
+    hthumb_poly = lift(blockscene, hthumb_rect) do r
+        roundedrectvertices(r, min(widths(r)...) / 2, 8)
+    end
+    poly!(blockscene, vthumb_poly; color = vthumb_color, visible = lift(&, active, vvis), inspectable = false)
+    poly!(blockscene, hthumb_poly; color = hthumb_color, visible = lift(&, active, hvis), inspectable = false)
 
     function update_scrollbars!()
         ca = scene.viewport[]

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -23,6 +23,15 @@ function initialize_block!(t::Tabs)
     tab_labelpositions = Observable{Point2f}[]
     tab_labelcolors = Observable{RGBAf}[]
     tab_labelbbs = Observable[]
+    # close-button state
+    close_segments = Observable{Vector{Point2f}}[]  # 4 points per tab (two diagonals)
+    close_colors = Observable{RGBAf}[]
+    close_rects = Observable{Rect2f}[]  # hit-test region, slightly larger than the glyph
+    close_hovered = Observable(0; ignore_equal_values = true)
+    # Resolved label-font metrics (in EM units, multiply by fontsize for pixels).
+    # Updated once the first label plot resolves its font; defaults are sane for
+    # most sans-serif fonts so the very first frame doesn't draw at (0, 0).
+    font_metrics = Observable((asc = 0.95f0, des = -0.21f0, xh = 0.52f0))
 
     content_area = lift(blockscene, t.layoutobservables.computedbbox, headerheight) do cbb, hh
         return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
@@ -33,14 +42,22 @@ function initialize_block!(t::Tabs)
         n == 0 && return
         pad = t.tabpadding[]
         gap = t.tabgap[]
+        fs = Float32(t.fontsize[])
+        fm = font_metrics[]
+        x_height_px = fm.xh * fs
+        closable = t.closable[]
+        close_w = closable ? x_height_px : 0.0f0
+        close_gap = closable ? x_height_px * 1.6f0 : 0.0f0
         widths_ = Vector{Float32}(undef, n)
+        labelws = Vector{Float32}(undef, n)
         hmax = 0.0
         for i in 1:n
             bbs = tab_labelbbs[i][]
             w = isempty(bbs) ? 0.0 : width(bbs[1])
             h = isempty(bbs) ? 0.0 : height(bbs[1])
-            widths_[i] = w + pad[1] + pad[2]
+            labelws[i] = w
             hmax = max(hmax, h)
+            widths_[i] = w + pad[1] + pad[2] + close_w + close_gap
         end
         th = t.tabheight[]
         headerheight[] = th === automatic ? hmax + pad[3] + pad[4] : Float64(th)
@@ -50,12 +67,34 @@ function initialize_block!(t::Tabs)
         l, top_ = left(cbb), top(cbb)
         active = t.active[]
         hov = hovered[]
+        chov = close_hovered[]
         x = l
         for i in 1:n
             x0 = x
             x1 = x + widths_[i]
             tab_rects[i][] = BBox(x0, x1, top_ - hh, top_)
-            tab_labelpositions[i][] = Point2f((x0 + x1) / 2, top_ - hh / 2)
+            # label sits left-aligned in the tab, centered vertically
+            tab_labelpositions[i][] = Point2f(x0 + pad[1] + labelws[i] / 2, top_ - hh / 2)
+            # close button sits to the right of the label; its width is the
+            # measured glyph width so pad[2] on its right matches pad[1] on
+            # the label's left.
+            # The × is drawn as two diagonal line segments, baseline-aligned
+            # with the label (so it sits where a lowercase 'x' would) and
+            # sized to the font's x-height.
+            close_cx = x0 + pad[1] + labelws[i] + close_gap + close_w / 2
+            baseline_y = top_ - hh / 2 - (fm.asc + fm.des) / 2 * fs
+            half = x_height_px / 2
+            y_top = baseline_y + x_height_px
+            y_bot = baseline_y
+            close_segments[i][] = Point2f[
+                Point2f(close_cx - half, y_top), Point2f(close_cx + half, y_bot),  # \
+                Point2f(close_cx + half, y_top), Point2f(close_cx - half, y_bot),  # /
+            ]
+            # hit-test region a bit larger than the glyph, centred on the tab
+            hit_half = max(close_w, fs) / 2 + 2
+            close_rects[i][] = Rect2f(close_cx - hit_half, top_ - hh / 2 - hit_half, 2hit_half, 2hit_half)
+            close_colors[i][] = to_color(i == chov ? t.closecolor_hover[] : t.closecolor[])
+
             tab_bgcolors[i][] = to_color(
                 i == active ? t.tabcolor_active[] :
                     i == hov ? t.tabcolor_hover[] : t.tabcolor_inactive[]
@@ -119,6 +158,41 @@ function initialize_block!(t::Tabs)
         bbs = fast_string_boundingboxes_obs(labelplot)
         push!(tab_labelbbs, bbs)
         on(_ -> recompute_layout!(), blockscene, bbs)
+
+        # The first label resolves the font we'll use for the close glyph
+        # too; capture its metrics so the × is sized to the x-height and
+        # sits on the label's baseline.
+        if i == 1
+            on(blockscene, labelplot.selected_font; update = true) do f
+                try
+                    asc = Float32(Makie.FreeTypeAbstraction.ascender(f))
+                    des = Float32(Makie.FreeTypeAbstraction.descender(f))
+                    ext = Makie.FreeTypeAbstraction.get_extent(f, 'x')
+                    bb = Makie.FreeTypeAbstraction.inkboundingbox(ext)
+                    xh = Float32(widths(bb)[2])
+                    font_metrics[] = (asc = asc, des = des, xh = xh)
+                catch
+                    # keep defaults
+                end
+                return
+            end
+        end
+
+        # Close "×" drawn as two diagonal line segments, sized to x-height.
+        segs = Observable(Point2f[])
+        close_color = Observable(to_color(t.closecolor[]))
+        close_rect = Observable(Rect2f(0, 0, 0, 0))
+        push!(close_segments, segs)
+        push!(close_colors, close_color)
+        push!(close_rects, close_rect)
+        close_visible = lift((c, ls) -> c && i <= length(ls), blockscene, t.closable, t.labels)
+        close_lw = lift(fs -> max(1.0f0, Float32(fs) * 0.08f0), blockscene, t.fontsize)
+        close_plot = linesegments!(
+            blockscene, segs;
+            color = close_color, linewidth = close_lw, visible = close_visible,
+            inspectable = false,
+        )
+        translate!(close_plot, 0, 0, 1)
         return
     end
 
@@ -145,16 +219,26 @@ function initialize_block!(t::Tabs)
     end
 
     onany(
-        blockscene, t.layoutobservables.computedbbox, t.active, hovered, t.tabheight,
-        t.tabpadding, t.tabgap, t.tabcolor_active, t.tabcolor_inactive, t.tabcolor_hover,
-        t.labelcolor_active, t.labelcolor_inactive
+        blockscene, t.layoutobservables.computedbbox, t.active, hovered, close_hovered,
+        t.tabheight, t.tabpadding, t.tabgap, t.tabcolor_active, t.tabcolor_inactive,
+        t.tabcolor_hover, t.labelcolor_active, t.labelcolor_inactive,
+        t.closable, t.closecolor, t.closecolor_hover, font_metrics,
     ) do args...
         recompute_layout!()
     end
 
+    function close_at(pos)
+        t.closable[] || return 0
+        p = Point2f(pos)
+        for i in 1:length(t.labels[])
+            p in close_rects[i][] && return i
+        end
+        return 0
+    end
+
     function tab_at(pos)
         p = Point2f(pos)
-        for i in 1:length(t.subfigures)
+        for i in 1:length(t.labels[])
             p in tab_rects[i][] && return i
         end
         return 0
@@ -162,12 +246,21 @@ function initialize_block!(t::Tabs)
 
     on(blockscene, blockscene.events.mouseposition) do pos
         hovered[] = tab_at(pos)
+        close_hovered[] = close_at(pos)
         return Consume(false)
     end
 
     on(blockscene, blockscene.events.mousebutton; priority = 60) do ev
         if ev.button == Mouse.left && ev.action == Mouse.press
-            i = tab_at(blockscene.events.mouseposition[])
+            pos = blockscene.events.mouseposition[]
+            # Close button takes precedence over the tab body click: clicking
+            # the × removes the tab without first making it active.
+            ci = close_at(pos)
+            if ci != 0
+                t.labels[] = vcat(t.labels[][1:(ci - 1)], t.labels[][(ci + 1):end])
+                return Consume(true)
+            end
+            i = tab_at(pos)
             if i != 0
                 t.active[] = i
                 return Consume(true)

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -134,34 +134,33 @@ function initialize_block!(t::Tabs)
 
     function add_tab!(i)
         is_active = lift(a -> a == i, blockscene, t.active)
-        # `clip` clips to the visible content area and isolates input events
-        # for this tab. Direct content_scene(t, i) plotting goes here, so users
-        # plot in tab-local pixel coordinates (origin at content-area corner).
-        clip = Scene(
+        # One scene per tab. `cam_window_pixel!` (used by Block blockscenes
+        # via `_block`) takes care of the viewport-offset mapping, so blocks
+        # placed into this scene's layout render correctly even though the
+        # scene's viewport doesn't start at the window origin. The scene
+        # itself uses `campixel!` so direct `content_scene(t, i)` plotting
+        # stays in tab-local pixel coords (origin at the content-area corner).
+        scene = Scene(
             blockscene; events = Events(), camera = campixel!,
             viewport = content_area, visible = is_active, clear = false
         )
-        forward_events!(clip, blockscene; active = is_active)
-        # Inner scene uses the root figure's viewport so that Blocks placed via
-        # the GridLayout — whose decoration code positions things in absolute
-        # window pixels — render at the right place. The clipping comes from
-        # `clip` being an ancestor via the effective-viewport scissor.
-        root_viewport = root(blockscene).viewport
-        inner = Scene(clip; viewport = root_viewport, camera = campixel!, clear = false)
+        forward_events!(scene, blockscene; active = is_active)
 
         scroll = Observable(Vec2f(0, 0); ignore_equal_values = true)
         contentsize = Observable(Vec2f(0, 0); ignore_equal_values = true)
         layout_bbox = Observable(Rect2f(0, 0, 1, 1); ignore_equal_values = true)
         layout = GridLayout(; bbox = layout_bbox)
-        layout.parent = inner
+        layout.parent = scene
 
-        push!(t.scenes, clip)
+        push!(t.scenes, scene)
         push!(t.layouts, layout)
         push!(t.scrolls, scroll)
         push!(t.contentsizes, contentsize)
 
-        # Offset the layout's bbox by the scroll, sizing it to fit at least the
-        # viewport and stretching to content size if it's larger.
+        # Layout bbox is in absolute window coords; inner block decorations
+        # placed via the layout end up at those absolute coords, which is what
+        # local campixel expects when the scene's viewport is at the figure
+        # origin (here: `inner`'s viewport).
         onany(blockscene, content_area, scroll, contentsize) do ca, sc, cs
             vw, vh = Float32.(widths(ca))
             cw, ch = max(cs[1], vw), max(cs[2], vh)
@@ -205,9 +204,9 @@ function initialize_block!(t::Tabs)
         # Container scrolling runs at a priority below the default so inner
         # blocks (e.g. an Axis zoom-on-scroll handler at priority 0) get the
         # event first; we only scroll the container if nothing consumed it.
-        on(blockscene, clip.events.scroll; priority = -1) do (dx, dy)
+        on(blockscene, scene.events.scroll; priority = -1) do (dx, dy)
             cs = contentsize[]
-            ca = clip.viewport[]
+            ca = scene.viewport[]
             vw, vh = Float32.(widths(ca))
             cw, ch = max(cs[1], vw), max(cs[2], vh)
             (cw <= vw && ch <= vh) && return Consume(false)

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -1,344 +1,50 @@
-# Whether tab `i` is closable, given the `closable` attribute value (a single
-# `Bool` for all tabs, or a `Vector{Bool}` indexed per tab; out-of-range = not
-# closable).
-_tab_closable(c::Bool, i) = c
-_tab_closable(c::AbstractVector, i) = (1 <= i <= length(c)) && Bool(c[i])
-
-function initialize_block!(t::Tabs)
+function initialize_block!(t::Tabs, labels::AbstractVector = ["Tab 1", "Tab 2"]; closable = true)
     blockscene = t.blockscene
-    t.subfigures = Subfigure[]
 
-    tab_closable(i) = _tab_closable(t.closable[], i)
+    t.tabs = TabData[]
+    t.hovered = Observable(0; ignore_equal_values = true)
+    t.close_hovered = Observable(0; ignore_equal_values = true)
+    t.headerheight = Observable(0.0; ignore_equal_values = true)
+    t.separator_path = Observable(Point2f[])
+    # Defaults are sane for most sans-serif fonts so the first frame doesn't draw
+    # the × at (0, 0); replaced once a label plot resolves its font.
+    t.font_metrics = Observable(TabFontMetrics(0.95f0, -0.21f0, 0.52f0))
+    t.font_metrics_captured = false
 
-    headerheight = Observable(0.0; ignore_equal_values = true)
-    hovered = Observable(0; ignore_equal_values = true)
+    t.content_area = lift(blockscene, t.layoutobservables.computedbbox, t.headerheight) do cbb, hh
+        return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
+    end
 
     # A single continuous separator line under the header that detours up and
     # around the active tab — its left/top/right edges replace the straight
     # line, so the active tab visually connects to the content area below.
-    sep_path = Observable(Point2f[])
     sep_plot = lines!(
-        blockscene, sep_path;
+        blockscene, t.separator_path;
         color = t.separator_color, linewidth = t.separator_thickness, inspectable = false
     )
     # raise above the tab polys (z = 0) so the line isn't covered along their
     # shared bottom edge
     translate!(sep_plot, 0, 0, 2)
 
-    # Per-tab state, all kept in lockstep with `t.subfigures` (and with
-    # `t.labels`). Header text / close visibility / geometry are driven
-    # imperatively from `recompute_layout!` rather than captured per creation
-    # index, so closing a tab in the middle (which `deleteat!`s every array)
-    # keeps slot i ↔ subfigure i ↔ label i aligned.
-    tab_rects = Observable{Rect2f}[]
-    tab_bgcolors = Observable{RGBAf}[]
-    tab_labelpositions = Observable{Point2f}[]
-    tab_labelcolors = Observable{RGBAf}[]
-    tab_labeltexts = Observable{String}[]
-    tab_labelbbs = Observable[]
-    close_segments = Observable{Vector{Point2f}}[]  # 4 points per tab (two diagonals)
-    close_colors = Observable{RGBAf}[]
-    close_rects = Observable{Rect2f}[]  # hit-test region, slightly larger than the glyph
-    close_visibles = Observable{Bool}[]
-    subfig_visibles = Observable{Bool}[]
-    header_plots = Tuple{Any, Any, Any}[]  # (poly, label, close) per tab, for deletion
-    close_hovered = Observable(0; ignore_equal_values = true)
-    # Resolved label-font metrics (in EM units, multiply by fontsize for pixels).
-    # Updated once a label plot resolves its font; defaults are sane for most
-    # sans-serif fonts so the very first frame doesn't draw at (0, 0).
-    font_metrics = Observable((asc = 0.95f0, des = -0.21f0, xh = 0.52f0))
-    font_metrics_captured = Ref(false)
-
-    content_area = lift(blockscene, t.layoutobservables.computedbbox, headerheight) do cbb, hh
-        return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
-    end
-
-    function refresh_visibility!()
-        a = t.active[]
-        for d in 1:length(subfig_visibles)
-            subfig_visibles[d][] = (d == a)
-        end
-        return
-    end
-
-    function recompute_layout!()
-        n = length(t.labels[])
-        # blank any slots beyond the current label count (can happen if the
-        # user sets `labels` to a shorter vector directly rather than closing)
-        for i in (n + 1):length(tab_rects)
-            tab_rects[i][] = Rect2f(0, 0, 0, 0)
-            tab_labeltexts[i][] = ""
-            close_visibles[i][] = false
-            close_rects[i][] = Rect2f(0, 0, 0, 0)
-        end
-        n == 0 && return
-        pad = t.tabpadding[]
-        gap = t.tabgap[]
-        fs = Float32(t.fontsize[])
-        fm = font_metrics[]
-        x_height_px = fm.xh * fs
-        widths_ = Vector{Float32}(undef, n)
-        labelws = Vector{Float32}(undef, n)
-        close_ws = Vector{Float32}(undef, n)
-        close_gaps = Vector{Float32}(undef, n)
-        hmax = 0.0
-        for i in 1:n
-            tab_labeltexts[i][] = t.labels[][i]
-            bbs = tab_labelbbs[i][]
-            w = isempty(bbs) ? 0.0 : width(bbs[1])
-            h = isempty(bbs) ? 0.0 : height(bbs[1])
-            labelws[i] = w
-            hmax = max(hmax, h)
-            cl = tab_closable(i)
-            close_ws[i] = cl ? x_height_px : 0.0f0
-            close_gaps[i] = cl ? x_height_px * 1.6f0 : 0.0f0
-            widths_[i] = w + pad[1] + pad[2] + close_ws[i] + close_gaps[i]
-        end
-        th = t.tabheight[]
-        headerheight[] = th === automatic ? hmax + pad[3] + pad[4] : Float64(th)
-
-        cbb = t.layoutobservables.computedbbox[]
-        hh = headerheight[]
-        l, top_ = left(cbb), top(cbb)
-        active = t.active[]
-        hov = hovered[]
-        chov = close_hovered[]
-        x = l
-        for i in 1:n
-            x0 = x
-            x1 = x + widths_[i]
-            tab_rects[i][] = BBox(x0, x1, top_ - hh, top_)
-            # label sits left-aligned in the tab, centered vertically
-            tab_labelpositions[i][] = Point2f(x0 + pad[1] + labelws[i] / 2, top_ - hh / 2)
-            # The × is drawn as two diagonal line segments, baseline-aligned
-            # with the label (so it sits where a lowercase 'x' would) and sized
-            # to the font's x-height. Non-closable tabs get empty segments and
-            # a zero-size hit rect so nothing draws or hit-tests.
-            close_visibles[i][] = close_ws[i] > 0
-            if close_ws[i] > 0
-                close_cx = x0 + pad[1] + labelws[i] + close_gaps[i] + close_ws[i] / 2
-                baseline_y = top_ - hh / 2 - (fm.asc + fm.des) / 2 * fs
-                half = x_height_px / 2
-                y_top = baseline_y + x_height_px
-                y_bot = baseline_y
-                close_segments[i][] = Point2f[
-                    Point2f(close_cx - half, y_top), Point2f(close_cx + half, y_bot),  # \
-                    Point2f(close_cx + half, y_top), Point2f(close_cx - half, y_bot),  # /
-                ]
-                # hit-test region a bit larger than the glyph, centred on the tab
-                hit_half = max(close_ws[i], fs) / 2 + 2
-                close_rects[i][] = Rect2f(close_cx - hit_half, top_ - hh / 2 - hit_half, 2hit_half, 2hit_half)
-                close_colors[i][] = to_color(i == chov ? t.closecolor_hover[] : t.closecolor[])
-            else
-                close_segments[i][] = Point2f[]
-                close_rects[i][] = Rect2f(0, 0, 0, 0)
-            end
-
-            tab_bgcolors[i][] = to_color(
-                i == active ? t.tabcolor_active[] :
-                    i == hov ? t.tabcolor_hover[] : t.tabcolor_inactive[]
-            )
-            tab_labelcolors[i][] = to_color(i == active ? t.labelcolor_active[] : t.labelcolor_inactive[])
-            x = x1 + gap
-        end
-
-        # Separator path: a horizontal line under the header that detours up
-        # and over the active tab so the active tab "merges" into the panel.
-        sep_y = Float32(top_ - hh)
-        if 1 <= active <= n
-            ar = tab_rects[active][]
-            ax0, ax1 = left(ar), right(ar)
-            aytop = top(ar)
-            sep_path[] = Point2f[
-                (Float32(l), sep_y),
-                (ax0, sep_y),
-                (ax0, aytop),
-                (ax1, aytop),
-                (ax1, sep_y),
-                (Float32(right(cbb)), sep_y),
-            ]
-        else
-            sep_path[] = Point2f[(Float32(l), sep_y), (Float32(right(cbb)), sep_y)]
-        end
-        return
-    end
-
-    function add_subfigure!()
-        vis = Observable(false; ignore_equal_values = true)
-        sf = Subfigure(
-            blockscene;
-            bbox = content_area,
-            isolate_events = true,
-            visible = vis,
-            contentpadding = t.contentpadding,
-        )
-        push!(t.subfigures, sf)
-        push!(subfig_visibles, vis)
-        return sf
-    end
-
-    function add_header!()
-        rect = Observable(Rect2f(0, 0, 0, 0))
-        bgcolor = Observable(to_color(t.tabcolor_inactive[]))
-        labelpos = Observable(Point2f(0, 0))
-        labelcolor = Observable(to_color(t.labelcolor_inactive[]))
-        labeltext = Observable("")
-        push!(tab_rects, rect)
-        push!(tab_bgcolors, bgcolor)
-        push!(tab_labelpositions, labelpos)
-        push!(tab_labelcolors, labelcolor)
-        push!(tab_labeltexts, labeltext)
-
-        poly_pts = lift(roundedrectvertices, blockscene, rect, t.cornerradius, t.cornersegments)
-        polyplot = poly!(blockscene, poly_pts; color = bgcolor, inspectable = false)
-        labelplot = text!(
-            blockscene, labelpos; text = labeltext, fontsize = t.fontsize, font = t.font,
-            color = labelcolor, align = (:center, :center), markerspace = :data, inspectable = false
-        )
-        translate!(labelplot, 0, 0, 1)
-        bbs = fast_string_boundingboxes_obs(labelplot)
-        push!(tab_labelbbs, bbs)
-        on(_ -> recompute_layout!(), blockscene, bbs)
-
-        # Capture the resolved label font's metrics once, so the × is sized to
-        # the x-height and sits on the label's baseline.
-        if !font_metrics_captured[]
-            font_metrics_captured[] = true
-            on(blockscene, labelplot.selected_font; update = true) do f
-                try
-                    asc = Float32(Makie.FreeTypeAbstraction.ascender(f))
-                    des = Float32(Makie.FreeTypeAbstraction.descender(f))
-                    ext = Makie.FreeTypeAbstraction.get_extent(f, 'x')
-                    bb = Makie.FreeTypeAbstraction.inkboundingbox(ext)
-                    xh = Float32(widths(bb)[2])
-                    font_metrics[] = (asc = asc, des = des, xh = xh)
-                catch
-                    # keep defaults
-                end
-                return
-            end
-        end
-
-        # Close "×" drawn as two diagonal line segments, sized to x-height.
-        segs = Observable(Point2f[])
-        close_color = Observable(to_color(t.closecolor[]))
-        close_rect = Observable(Rect2f(0, 0, 0, 0))
-        close_visible = Observable(false)
-        push!(close_segments, segs)
-        push!(close_colors, close_color)
-        push!(close_rects, close_rect)
-        push!(close_visibles, close_visible)
-        close_lw = lift(fs -> max(1.0f0, Float32(fs) * 0.08f0), blockscene, t.fontsize)
-        closeplot = linesegments!(
-            blockscene, segs;
-            color = close_color, linewidth = close_lw, visible = close_visible,
-            inspectable = false,
-        )
-        translate!(closeplot, 0, 0, 1)
-
-        push!(header_plots, (polyplot, labelplot, closeplot))
-        return
-    end
-
-    # Remove tab `ci`: delete its subfigure (freeing its content) and header
-    # plots, drop the matching entry from every parallel array, then update
-    # `labels` / `closable` / `active` so the remaining tabs stay aligned.
-    function remove_tab!(ci)
-        n = length(t.labels[])
-        (1 <= ci <= n) || return
-
-        delete!(t.subfigures[ci])
-        deleteat!(t.subfigures, ci)
-        deleteat!(subfig_visibles, ci)
-
-        for p in header_plots[ci]
-            delete!(blockscene, p)
-        end
-        deleteat!(header_plots, ci)
-        for arr in (
-                tab_rects, tab_bgcolors, tab_labelpositions, tab_labelcolors,
-                tab_labeltexts, tab_labelbbs, close_segments, close_colors,
-                close_rects, close_visibles,
-            )
-            deleteat!(arr, ci)
-        end
-
-        new_n = n - 1
-        old_active = t.active[]
-        new_active = if new_n == 0
-            0
-        elseif old_active < ci
-            old_active
-        elseif old_active == ci
-            min(ci, new_n)
-        else
-            old_active - 1
-        end
-
-        # Order matters: `labels` must be updated first so the recompute it
-        # triggers sees `n == new_n`, matching the already-shrunken arrays. The
-        # `closable` vector and `active` are corrected immediately after (their
-        # recomputes are synchronous, so no stale frame renders in between).
-        t.labels[] = vcat(t.labels[][1:(ci - 1)], t.labels[][(ci + 1):end])
-        c = t.closable[]
-        if c isa AbstractVector && ci <= length(c)
-            t.closable[] = vcat(c[1:(ci - 1)], c[(ci + 1):end])
-        end
-        t.active[] = new_active
-        refresh_visibility!()
-        recompute_layout!()
-        return
-    end
-
-    on(blockscene, t.labels; update = true) do labels
-        n = length(labels)
-        while length(t.subfigures) < n
-            add_subfigure!()
-            add_header!()
-        end
-        # clamp active onto the new range so it doesn't point at a removed tab
-        if !isempty(labels) && t.active[] > n
-            t.active[] = clamp(t.active[], 1, n)
-        end
-        refresh_visibility!()
-        recompute_layout!()
-        return
+    closable_for(i) = closable isa AbstractVector ? (1 <= i <= length(closable) && Bool(closable[i])) : Bool(closable)
+    for (i, label) in enumerate(labels)
+        add_tab!(t, label; closable = closable_for(i))
     end
 
     onany(
-        blockscene, t.layoutobservables.computedbbox, t.active, hovered, close_hovered,
+        blockscene, t.layoutobservables.computedbbox, t.active, t.hovered, t.close_hovered,
         t.tabheight, t.tabpadding, t.tabgap, t.tabcolor_active, t.tabcolor_inactive,
         t.tabcolor_hover, t.labelcolor_active, t.labelcolor_inactive,
-        t.closable, t.closecolor, t.closecolor_hover, font_metrics,
+        t.closecolor, t.closecolor_hover, t.font_metrics,
     ) do args...
-        recompute_layout!()
+        recompute_layout!(t)
     end
 
-    on(blockscene, t.active) do _
-        refresh_visibility!()
-        return
-    end
-
-    function close_at(pos)
-        p = Point2f(pos)
-        for i in 1:length(t.labels[])
-            tab_closable(i) || continue
-            p in close_rects[i][] && return i
-        end
-        return 0
-    end
-
-    function tab_at(pos)
-        p = Point2f(pos)
-        for i in 1:length(t.labels[])
-            p in tab_rects[i][] && return i
-        end
-        return 0
-    end
+    on(_ -> refresh_visibility!(t), blockscene, t.active)
 
     on(blockscene, blockscene.events.mouseposition) do pos
-        hovered[] = tab_at(pos)
-        close_hovered[] = close_at(pos)
+        t.hovered[] = tab_at(t, pos)
+        t.close_hovered[] = close_at(t, pos)
         return Consume(false)
     end
 
@@ -347,12 +53,12 @@ function initialize_block!(t::Tabs)
             pos = blockscene.events.mouseposition[]
             # Close button takes precedence over the tab body click: clicking
             # the × removes the tab without first making it active.
-            ci = close_at(pos)
+            ci = close_at(t, pos)
             if ci != 0
-                remove_tab!(ci)
+                remove_tab!(t, ci)
                 return Consume(true)
             end
-            i = tab_at(pos)
+            i = tab_at(t, pos)
             if i != 0
                 t.active[] = i
                 return Consume(true)
@@ -365,7 +71,270 @@ function initialize_block!(t::Tabs)
     return
 end
 
-Base.getindex(t::Tabs, i::Integer) = t.subfigures[i]
+"""
+    add_tab!(tabs::Tabs, label = "Tab N"; closable = true, activate = false) -> Subfigure
+
+Append a tab to `tabs` and return its [`Subfigure`](@ref). Plot into it via
+`tabs[end][row, col] = Axis(...)` or `content_scene(tabs, length(tabs))`. Pass
+`activate = true` to switch to the new tab immediately. The first tab added to an
+empty `Tabs` becomes active automatically.
+
+`label` accepts anything `text!` does — a plain `String`, a `rich(...)` for
+colored / styled spans, or a `LaTeXString` (`L"..."`).
+"""
+function add_tab!(
+        t::Tabs, label = "Tab $(length(t.tabs) + 1)";
+        closable::Bool = true, activate::Bool = false
+    )
+    blockscene = t.blockscene
+
+    visible = Observable(false; ignore_equal_values = true)
+    sf = Subfigure(
+        blockscene;
+        bbox = t.content_area, isolate_events = true,
+        visible = visible, contentpadding = t.contentpadding,
+    )
+
+    label_obs = Observable{Any}(label)
+    closable_obs = Observable(closable)
+    rect = Observable(Rect2f(0, 0, 0, 0))
+    bgcolor = Observable(to_color(t.tabcolor_inactive[]))
+    labelpos = Observable(Point2f(0, 0))
+    labelcolor = Observable(to_color(t.labelcolor_inactive[]))
+    close_segments = Observable(Point2f[])
+    close_color = Observable(to_color(t.closecolor[]))
+    close_rect = Observable(Rect2f(0, 0, 0, 0))
+    close_visible = Observable(false)
+
+    poly_pts = lift(roundedrectvertices, blockscene, rect, t.cornerradius, t.cornersegments)
+    polyplot = poly!(blockscene, poly_pts; color = bgcolor, inspectable = false)
+    labelplot = text!(
+        blockscene, labelpos; text = label_obs, fontsize = t.fontsize, font = t.font,
+        color = labelcolor, align = (:center, :center), markerspace = :data, inspectable = false
+    )
+    translate!(labelplot, 0, 0, 1)
+    labelboundingboxes = fast_string_boundingboxes_obs(labelplot)
+
+    # Close "×" drawn as two diagonal line segments, sized to x-height.
+    close_lw = lift(fs -> max(1.0f0, Float32(fs) * 0.08f0), blockscene, t.fontsize)
+    closeplot = linesegments!(
+        blockscene, close_segments;
+        color = close_color, linewidth = close_lw, visible = close_visible, inspectable = false,
+    )
+    translate!(closeplot, 0, 0, 1)
+
+    td = TabData(
+        sf, label_obs, closable_obs, visible, rect, bgcolor, labelpos, labelcolor,
+        labelboundingboxes, close_segments, close_color, close_rect, close_visible,
+        (polyplot, labelplot, closeplot),
+    )
+    push!(t.tabs, td)
+
+    # Changing the label text (→ new measured size) or the closability needs a
+    # relayout; binding the text plot to `label_obs` already redraws the glyphs.
+    on(_ -> recompute_layout!(t), blockscene, labelboundingboxes)
+    on(_ -> recompute_layout!(t), blockscene, closable_obs)
+
+    # Capture the resolved label font's metrics once, so the × is sized to the
+    # x-height and sits on the label's baseline.
+    if !t.font_metrics_captured
+        t.font_metrics_captured = true
+        on(blockscene, labelplot.selected_font; update = true) do f
+            try
+                asc = Float32(Makie.FreeTypeAbstraction.ascender(f))
+                des = Float32(Makie.FreeTypeAbstraction.descender(f))
+                ext = Makie.FreeTypeAbstraction.get_extent(f, 'x')
+                bb = Makie.FreeTypeAbstraction.inkboundingbox(ext)
+                xh = Float32(widths(bb)[2])
+                t.font_metrics[] = TabFontMetrics(asc, des, xh)
+            catch
+                # keep defaults
+            end
+            return
+        end
+    end
+
+    if activate || t.active[] < 1
+        t.active[] = length(t.tabs)
+    end
+    refresh_visibility!(t)
+    recompute_layout!(t)
+    return sf
+end
+
+"""
+    remove_tab!(tabs::Tabs, i::Integer)
+
+Remove tab `i`, freeing its [`Subfigure`](@ref) content and header plots. The
+remaining tabs shift down and `active` is updated to keep pointing at the same
+tab (or its neighbour if the active tab itself was removed).
+"""
+function remove_tab!(t::Tabs, i::Integer)
+    n = length(t.tabs)
+    (1 <= i <= n) || return
+
+    td = t.tabs[i]
+    delete!(td.subfigure)
+    for p in td.plots
+        delete!(t.blockscene, p)
+    end
+    deleteat!(t.tabs, i)
+
+    new_n = n - 1
+    old_active = t.active[]
+    new_active = if new_n == 0
+        0
+    elseif old_active < i
+        old_active
+    elseif old_active == i
+        min(i, new_n)
+    else
+        old_active - 1
+    end
+    t.active[] = new_active
+    refresh_visibility!(t)
+    recompute_layout!(t)
+    return
+end
+
+"""
+    set_tab!(tabs::Tabs, i::Integer; label, closable)
+
+Change properties of tab `i`. Omitted keywords are left unchanged: `label`
+sets the tab's text, `closable` whether it shows a close (×) button.
+"""
+function set_tab!(t::Tabs, i::Integer; label = nothing, closable = nothing)
+    td = t.tabs[i]
+    label === nothing || (td.label[] = label)
+    closable === nothing || (td.closable[] = Bool(closable))
+    return
+end
+
+function refresh_visibility!(t::Tabs)
+    a = t.active[]
+    for (i, td) in enumerate(t.tabs)
+        td.visible[] = (i == a)
+    end
+    return
+end
+
+function tab_at(t::Tabs, pos)
+    p = Point2f(pos)
+    for (i, td) in enumerate(t.tabs)
+        p in td.rect[] && return i
+    end
+    return 0
+end
+
+function close_at(t::Tabs, pos)
+    p = Point2f(pos)
+    for (i, td) in enumerate(t.tabs)
+        td.closable[] || continue
+        p in td.close_rect[] && return i
+    end
+    return 0
+end
+
+function recompute_layout!(t::Tabs)
+    n = length(t.tabs)
+    if n == 0
+        t.headerheight[] = 0.0
+        t.separator_path[] = Point2f[]
+        return
+    end
+
+    pad = t.tabpadding[]
+    gap = t.tabgap[]
+    fs = Float32(t.fontsize[])
+    fm = t.font_metrics[]
+    x_height_px = fm.x_height * fs
+    widths_ = Vector{Float32}(undef, n)
+    labelws = Vector{Float32}(undef, n)
+    close_ws = Vector{Float32}(undef, n)
+    close_gaps = Vector{Float32}(undef, n)
+    hmax = 0.0
+    for (i, td) in enumerate(t.tabs)
+        bbs = td.labelboundingboxes[]
+        w = isempty(bbs) ? 0.0 : width(bbs[1])
+        h = isempty(bbs) ? 0.0 : height(bbs[1])
+        labelws[i] = w
+        hmax = max(hmax, h)
+        cl = td.closable[]
+        close_ws[i] = cl ? x_height_px : 0.0f0
+        close_gaps[i] = cl ? x_height_px * 1.6f0 : 0.0f0
+        widths_[i] = w + pad[1] + pad[2] + close_ws[i] + close_gaps[i]
+    end
+    th = t.tabheight[]
+    t.headerheight[] = th === automatic ? hmax + pad[3] + pad[4] : Float64(th)
+
+    cbb = t.layoutobservables.computedbbox[]
+    hh = t.headerheight[]
+    l, top_ = left(cbb), top(cbb)
+    active = t.active[]
+    hov = t.hovered[]
+    chov = t.close_hovered[]
+    x = l
+    for (i, td) in enumerate(t.tabs)
+        x0 = x
+        x1 = x + widths_[i]
+        td.rect[] = BBox(x0, x1, top_ - hh, top_)
+        # label sits left-aligned in the tab, centered vertically
+        td.labelpos[] = Point2f(x0 + pad[1] + labelws[i] / 2, top_ - hh / 2)
+        # The × is drawn as two diagonal line segments, baseline-aligned with
+        # the label (so it sits where a lowercase 'x' would) and sized to the
+        # font's x-height. Non-closable tabs get empty segments and a zero-size
+        # hit rect so nothing draws or hit-tests.
+        td.close_visible[] = close_ws[i] > 0
+        if close_ws[i] > 0
+            close_cx = x0 + pad[1] + labelws[i] + close_gaps[i] + close_ws[i] / 2
+            baseline_y = top_ - hh / 2 - (fm.ascent + fm.descent) / 2 * fs
+            half = x_height_px / 2
+            y_top = baseline_y + x_height_px
+            y_bot = baseline_y
+            td.close_segments[] = Point2f[
+                Point2f(close_cx - half, y_top), Point2f(close_cx + half, y_bot),  # \
+                Point2f(close_cx + half, y_top), Point2f(close_cx - half, y_bot),  # /
+            ]
+            # hit-test region a bit larger than the glyph, centred on the tab
+            hit_half = max(close_ws[i], fs) / 2 + 2
+            td.close_rect[] = Rect2f(close_cx - hit_half, top_ - hh / 2 - hit_half, 2hit_half, 2hit_half)
+            td.close_color[] = to_color(i == chov ? t.closecolor_hover[] : t.closecolor[])
+        else
+            td.close_segments[] = Point2f[]
+            td.close_rect[] = Rect2f(0, 0, 0, 0)
+        end
+
+        td.bgcolor[] = to_color(
+            i == active ? t.tabcolor_active[] :
+                i == hov ? t.tabcolor_hover[] : t.tabcolor_inactive[]
+        )
+        td.labelcolor[] = to_color(i == active ? t.labelcolor_active[] : t.labelcolor_inactive[])
+        x = x1 + gap
+    end
+
+    # Separator path: a horizontal line under the header that detours up and
+    # over the active tab so the active tab "merges" into the panel.
+    sep_y = Float32(top_ - hh)
+    if 1 <= active <= n
+        ar = t.tabs[active].rect[]
+        ax0, ax1 = left(ar), right(ar)
+        aytop = top(ar)
+        t.separator_path[] = Point2f[
+            (Float32(l), sep_y),
+            (ax0, sep_y),
+            (ax0, aytop),
+            (ax1, aytop),
+            (ax1, sep_y),
+            (Float32(right(cbb)), sep_y),
+        ]
+    else
+        t.separator_path[] = Point2f[(Float32(l), sep_y), (Float32(right(cbb)), sep_y)]
+    end
+    return
+end
+
+Base.getindex(t::Tabs, i::Integer) = t.tabs[i].subfigure
+Base.length(t::Tabs) = length(t.tabs)
 
 # Generic `Block` indexing would lazy-init a fresh, disconnected `GridLayout`
 # on `t.layout` — a silent foot-gun: `Axis(tabs[1, 1])` would create an
@@ -387,14 +356,14 @@ end
 
 Return the content `Scene` of tab `i`, for plotting directly into a tab.
 """
-content_scene(t::Tabs, i::Integer) = content_scene(t.subfigures[i])
+content_scene(t::Tabs, i::Integer) = content_scene(t.tabs[i].subfigure)
 
 # Hand pre-display state updates to each tab's Subfigure so blocks placed inside a
 # tab (which the Figure can't see because they have a Scene parent, not a
 # Figure parent) still get e.g. auto axis limits.
 function update_state_before_display!(t::Tabs)
-    for sf in t.subfigures
-        update_state_before_display!(sf)
+    for td in t.tabs
+        update_state_before_display!(td.subfigure)
     end
     return
 end

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -1,0 +1,414 @@
+function initialize_block!(t::Tabs)
+    blockscene = t.blockscene
+    t.scenes = Scene[]
+    t.layouts = GridLayout[]
+    t.scrolls = Observable{Vec2f}[]
+    t.contentsizes = Observable{Vec2f}[]
+
+    headerheight = Observable(0.0; ignore_equal_values = true)
+    hovered = Observable(0; ignore_equal_values = true)
+
+    # A single continuous separator line under the header that leads up and
+    # around the active tab — its left/top/right edges replace the straight
+    # line, so the active tab visually connects to the content area below
+    # without any inactive tabs needing a different background color.
+    sep_path = Observable(Point2f[])
+    sep_plot = lines!(
+        blockscene, sep_path;
+        color = t.separator_color, linewidth = t.separator_thickness, inspectable = false
+    )
+    # raise above the tab polys (which sit at z=0) so the line isn't covered
+    # where it runs along their shared bottom edge
+    translate!(sep_plot, 0, 0, 2)
+
+    # per-tab header primitives, indexed alongside t.scenes / t.layouts
+    tab_rects = Observable{Rect2f}[]
+    tab_bgcolors = Observable{RGBAf}[]
+    tab_labelpositions = Observable{Point2f}[]
+    tab_labelcolors = Observable{RGBAf}[]
+    tab_labelbbs = Observable[]
+
+    # per-tab scrollbar state (drawn in blockscene, gated by overflow)
+    vbar_rect = Observable{Rect2f}[]            # vertical track rect (per tab)
+    vthumb_rect = Observable{Rect2f}[]
+    vthumb_color = Observable{RGBAf}[]
+    hbar_rect = Observable{Rect2f}[]
+    hthumb_rect = Observable{Rect2f}[]
+    hthumb_color = Observable{RGBAf}[]
+    vbar_visible = Observable{Bool}[]
+    hbar_visible = Observable{Bool}[]
+    # interactive scrollbar state shared across tabs (only one drag at a time)
+    drag_state = Ref{Tuple{Symbol, Int, Float32, Vec2f}}((:none, 0, 0.0f0, Vec2f(0, 0)))
+
+    content_area = lift(blockscene, t.layoutobservables.computedbbox, headerheight) do cbb, hh
+        return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
+    end
+
+    function recompute_layout!()
+        n = length(t.scenes)
+        n == 0 && return
+        pad = t.tabpadding[]
+        gap = t.tabgap[]
+        widths_ = Vector{Float32}(undef, n)
+        hmax = 0.0
+        for i in 1:n
+            bbs = tab_labelbbs[i][]
+            w = isempty(bbs) ? 0.0 : width(bbs[1])
+            h = isempty(bbs) ? 0.0 : height(bbs[1])
+            widths_[i] = w + pad[1] + pad[2]
+            hmax = max(hmax, h)
+        end
+        th = t.tabheight[]
+        headerheight[] = th === automatic ? hmax + pad[3] + pad[4] : Float64(th)
+
+        cbb = t.layoutobservables.computedbbox[]
+        hh = headerheight[]
+        l, top_ = left(cbb), top(cbb)
+        active = t.active[]
+        hov = hovered[]
+        x = l
+        for i in 1:n
+            x0 = x
+            x1 = x + widths_[i]
+            tab_rects[i][] = BBox(x0, x1, top_ - hh, top_)
+            tab_labelpositions[i][] = Point2f((x0 + x1) / 2, top_ - hh / 2)
+            tab_bgcolors[i][] = to_color(
+                i == active ? t.tabcolor_active[] :
+                    i == hov ? t.tabcolor_hover[] : t.tabcolor_inactive[]
+            )
+            tab_labelcolors[i][] = to_color(i == active ? t.labelcolor_active[] : t.labelcolor_inactive[])
+            x = x1 + gap
+        end
+
+        # Separator path: a horizontal line under the header that detours up and
+        # over the active tab so the active tab "merges" into the content area.
+        sep_y = Float32(top_ - hh)
+        if 1 <= active <= n
+            ar = tab_rects[active][]
+            ax0, ax1 = left(ar), right(ar)
+            aytop = top(ar)
+            sep_path[] = Point2f[
+                (Float32(l), sep_y),
+                (ax0, sep_y),
+                (ax0, aytop),
+                (ax1, aytop),
+                (ax1, sep_y),
+                (Float32(right(cbb)), sep_y),
+            ]
+        else
+            sep_path[] = Point2f[(Float32(l), sep_y), (Float32(right(cbb)), sep_y)]
+        end
+        return
+    end
+
+    function update_scrollbars!(i)
+        ca = t.scenes[i].viewport[]
+        cs = t.contentsizes[i][]
+        sc = t.scrolls[i][]
+        sbsize = Float32(t.scrollbar_size[])
+        vw, vh = Float32.(widths(ca))
+        cw, ch = max(cs[1], vw), max(cs[2], vh)
+        max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
+
+        vbar_visible[i][] = max_sy > 0
+        hbar_visible[i][] = max_sx > 0
+
+        if max_sy > 0
+            tx = right(ca) - sbsize
+            vbar_rect[i][] = Rect2f((tx, bottom(ca)), (sbsize, vh))
+            thumb_h = max(20.0f0, vh * vh / ch)
+            usable = vh - thumb_h
+            ty = top(ca) - thumb_h - (sc[2] / max_sy) * usable
+            vthumb_rect[i][] = Rect2f((tx, ty), (sbsize, thumb_h))
+        end
+        if max_sx > 0
+            by = bottom(ca)
+            hbar_rect[i][] = Rect2f((left(ca), by), (vw, sbsize))
+            thumb_w = max(20.0f0, vw * vw / cw)
+            usable = vw - thumb_w
+            tx = left(ca) + (sc[1] / max_sx) * usable
+            hthumb_rect[i][] = Rect2f((tx, by), (thumb_w, sbsize))
+        end
+        return
+    end
+
+    function add_tab!(i)
+        is_active = lift(a -> a == i, blockscene, t.active)
+        # `clip` clips to the visible content area and isolates input events
+        # for this tab. Direct content_scene(t, i) plotting goes here, so users
+        # plot in tab-local pixel coordinates (origin at content-area corner).
+        clip = Scene(
+            blockscene; events = Events(), camera = campixel!,
+            viewport = content_area, visible = is_active, clear = false
+        )
+        forward_events!(clip, blockscene; active = is_active)
+        # Inner scene uses the root figure's viewport so that Blocks placed via
+        # the GridLayout — whose decoration code positions things in absolute
+        # window pixels — render at the right place. The clipping comes from
+        # `clip` being an ancestor via the effective-viewport scissor.
+        root_viewport = root(blockscene).viewport
+        inner = Scene(clip; viewport = root_viewport, camera = campixel!, clear = false)
+
+        scroll = Observable(Vec2f(0, 0); ignore_equal_values = true)
+        contentsize = Observable(Vec2f(0, 0); ignore_equal_values = true)
+        layout_bbox = Observable(Rect2f(0, 0, 1, 1); ignore_equal_values = true)
+        layout = GridLayout(; bbox = layout_bbox)
+        layout.parent = inner
+
+        push!(t.scenes, clip)
+        push!(t.layouts, layout)
+        push!(t.scrolls, scroll)
+        push!(t.contentsizes, contentsize)
+
+        # Offset the layout's bbox by the scroll, sizing it to fit at least the
+        # viewport and stretching to content size if it's larger.
+        onany(blockscene, content_area, scroll, contentsize) do ca, sc, cs
+            vw, vh = Float32.(widths(ca))
+            cw, ch = max(cs[1], vw), max(cs[2], vh)
+            max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
+            sx = clamp(sc[1], 0.0f0, max_sx)
+            sy = clamp(sc[2], 0.0f0, max_sy)
+            if sx != sc[1] || sy != sc[2]
+                scroll[] = Vec2f(sx, sy)
+                return
+            end
+            top_edge = top(ca) + sy
+            left_edge = left(ca) - sx
+            layout_bbox[] = Rect2f(Point2f(left_edge, top_edge - ch), Vec2f(cw, ch))
+            update_scrollbars!(i)
+            return
+        end
+
+        # Outside padding keeps block protrusions (axis titles, ticklabels) inside
+        # the clipped content area instead of overflowing and getting cut off.
+        on(blockscene, t.contentpadding; update = true) do pad
+            sides = pad isa Number ? (pad, pad, pad, pad) : pad
+            layout.alignmode[] = Outside(to_rectsides(sides))
+            GridLayoutBase.update!(layout)
+            return
+        end
+
+        # After every layout pass, remeasure the determinable content size so
+        # scroll bounds and scrollbars react to fixed row/col sizes the user
+        # sets via `colsize!`/`rowsize!`/`width=`/`height=`.
+        on(blockscene, layout.layoutobservables.computedbbox) do _
+            dw = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Col())
+            dh = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Row())
+            cw = dw === nothing ? 0.0f0 : Float32(dw)
+            ch = dh === nothing ? 0.0f0 : Float32(dh)
+            contentsize[] = Vec2f(cw, ch)
+            return
+        end
+
+        # Wheel/trackpad scrolling. Uses the tab's isolated events, so only the
+        # active tab sees the scroll.
+        # Container scrolling runs at a priority below the default so inner
+        # blocks (e.g. an Axis zoom-on-scroll handler at priority 0) get the
+        # event first; we only scroll the container if nothing consumed it.
+        on(blockscene, clip.events.scroll; priority = -1) do (dx, dy)
+            cs = contentsize[]
+            ca = clip.viewport[]
+            vw, vh = Float32.(widths(ca))
+            cw, ch = max(cs[1], vw), max(cs[2], vh)
+            (cw <= vw && ch <= vh) && return Consume(false)
+            step = Float32(t.scroll_speed[])
+            scroll[] = Vec2f(scroll[][1] + step * dx, scroll[][2] - step * dy)
+            return Consume(true)
+        end
+
+        # scrollbar primitives (drawn in blockscene so they sit above content)
+        vbar_r = Observable(Rect2f(0, 0, 0, 0))
+        vth_r = Observable(Rect2f(0, 0, 0, 0))
+        vth_c = Observable(to_color(t.scrollbar_thumb_color[]))
+        vvis = Observable(false; ignore_equal_values = true)
+        hbar_r = Observable(Rect2f(0, 0, 0, 0))
+        hth_r = Observable(Rect2f(0, 0, 0, 0))
+        hth_c = Observable(to_color(t.scrollbar_thumb_color[]))
+        hvis = Observable(false; ignore_equal_values = true)
+        push!(vbar_rect, vbar_r)
+        push!(vthumb_rect, vth_r)
+        push!(vthumb_color, vth_c)
+        push!(hbar_rect, hbar_r)
+        push!(hthumb_rect, hth_r)
+        push!(hthumb_color, hth_c)
+        push!(vbar_visible, vvis)
+        push!(hbar_visible, hvis)
+        poly!(blockscene, vbar_r; color = t.scrollbar_color, visible = lift(&, is_active, vvis), inspectable = false)
+        poly!(blockscene, vth_r; color = vth_c, visible = lift(&, is_active, vvis), inspectable = false)
+        poly!(blockscene, hbar_r; color = t.scrollbar_color, visible = lift(&, is_active, hvis), inspectable = false)
+        poly!(blockscene, hth_r; color = hth_c, visible = lift(&, is_active, hvis), inspectable = false)
+        return
+    end
+
+    function add_header!(i)
+        rect = Observable(Rect2f(0, 0, 0, 0))
+        bgcolor = Observable(to_color(t.tabcolor_inactive[]))
+        labelpos = Observable(Point2f(0, 0))
+        labelcolor = Observable(to_color(t.labelcolor_inactive[]))
+        push!(tab_rects, rect)
+        push!(tab_bgcolors, bgcolor)
+        push!(tab_labelpositions, labelpos)
+        push!(tab_labelcolors, labelcolor)
+
+        poly_pts = lift(roundedrectvertices, blockscene, rect, t.cornerradius, t.cornersegments)
+        poly!(blockscene, poly_pts; color = bgcolor, inspectable = false)
+        labelstr = lift(ls -> get(ls, i, ""), blockscene, t.labels)
+        labelplot = text!(
+            blockscene, labelpos; text = labelstr, fontsize = t.fontsize, font = t.font,
+            color = labelcolor, align = (:center, :center), markerspace = :data, inspectable = false
+        )
+        translate!(labelplot, 0, 0, 1)
+        bbs = fast_string_boundingboxes_obs(labelplot)
+        push!(tab_labelbbs, bbs)
+        on(_ -> recompute_layout!(), blockscene, bbs)
+        return
+    end
+
+    on(blockscene, t.labels; update = true) do labels
+        while length(t.scenes) < length(labels)
+            i = length(t.scenes) + 1
+            add_tab!(i)
+            add_header!(i)
+        end
+        recompute_layout!()
+        return
+    end
+
+    onany(
+        blockscene, t.layoutobservables.computedbbox, t.active, hovered, t.tabheight,
+        t.tabpadding, t.tabgap, t.tabcolor_active, t.tabcolor_inactive, t.tabcolor_hover,
+        t.labelcolor_active, t.labelcolor_inactive
+    ) do args...
+        recompute_layout!()
+    end
+
+    function tab_at(pos)
+        p = Point2f(pos)
+        for i in 1:length(t.scenes)
+            p in tab_rects[i][] && return i
+        end
+        return 0
+    end
+
+    # Returns (:vthumb | :vtrack | :hthumb | :htrack | :none, tab_index) at pos.
+    # We only look at the currently active tab, since inactive scrollbars are hidden.
+    function scrollbar_at(pos)
+        i = t.active[]
+        i == 0 && return :none, 0
+        p = Point2f(pos)
+        vvis = i <= length(vbar_visible) && vbar_visible[i][]
+        hvis = i <= length(hbar_visible) && hbar_visible[i][]
+        if vvis
+            p in vthumb_rect[i][] && return :vthumb, i
+            p in vbar_rect[i][] && return :vtrack, i
+        end
+        if hvis
+            p in hthumb_rect[i][] && return :hthumb, i
+            p in hbar_rect[i][] && return :htrack, i
+        end
+        return :none, 0
+    end
+
+    on(blockscene, blockscene.events.mouseposition) do pos
+        hovered[] = tab_at(pos)
+        kind, i = scrollbar_at(pos)
+        st, di, _, _ = drag_state[]
+        for j in 1:length(t.scenes)
+            # Keep the dragged thumb highlighted regardless of mouse position,
+            # otherwise dragging "off" the thumb visibly drops the active state.
+            v_active = (st === :vdrag && di == j) || (kind in (:vthumb, :vtrack) && j == i)
+            h_active = (st === :hdrag && di == j) || (kind in (:hthumb, :htrack) && j == i)
+            vthumb_color[j][] = to_color(v_active ? t.scrollbar_thumb_color_active[] : t.scrollbar_thumb_color[])
+            hthumb_color[j][] = to_color(h_active ? t.scrollbar_thumb_color_active[] : t.scrollbar_thumb_color[])
+        end
+        # handle ongoing drag
+        anchor = drag_state[][3]
+        anchor_scroll = drag_state[][4]
+        if st === :vdrag && di > 0
+            ca = t.scenes[di].viewport[]
+            vh = Float32(widths(ca)[2])
+            ch = max(t.contentsizes[di][][2], vh)
+            max_sy = max(0.0f0, ch - vh)
+            max_sy == 0 && return Consume(false)
+            thumb_h = max(20.0f0, vh * vh / ch)
+            usable = vh - thumb_h
+            # pos.y vs anchor.y: dragging DOWN (y decreases in window coords) → scroll down (scroll_y increases)
+            dy = anchor - Float32(pos[2])
+            new_sy = clamp(anchor_scroll[2] + dy * max_sy / usable, 0.0f0, max_sy)
+            t.scrolls[di][] = Vec2f(t.scrolls[di][][1], new_sy)
+            return Consume(true)
+        elseif st === :hdrag && di > 0
+            ca = t.scenes[di].viewport[]
+            vw = Float32(widths(ca)[1])
+            cw = max(t.contentsizes[di][][1], vw)
+            max_sx = max(0.0f0, cw - vw)
+            max_sx == 0 && return Consume(false)
+            thumb_w = max(20.0f0, vw * vw / cw)
+            usable = vw - thumb_w
+            dx = Float32(pos[1]) - anchor
+            new_sx = clamp(anchor_scroll[1] + dx * max_sx / usable, 0.0f0, max_sx)
+            t.scrolls[di][] = Vec2f(new_sx, t.scrolls[di][][2])
+            return Consume(true)
+        end
+        return Consume(false)
+    end
+
+    on(blockscene, blockscene.events.mousebutton; priority = 60) do ev
+        if ev.button == Mouse.left && ev.action == Mouse.press
+            pos = blockscene.events.mouseposition[]
+            kind, i = scrollbar_at(pos)
+            if kind === :vthumb
+                drag_state[] = (:vdrag, i, Float32(pos[2]), t.scrolls[i][])
+                return Consume(true)
+            elseif kind === :hthumb
+                drag_state[] = (:hdrag, i, Float32(pos[1]), t.scrolls[i][])
+                return Consume(true)
+            elseif kind === :vtrack
+                # page scroll: jump by viewport height
+                ca = t.scenes[i].viewport[]
+                vh = Float32(widths(ca)[2])
+                dir = Float32(pos[2]) < (vthumb_rect[i][].origin[2] + vthumb_rect[i][].widths[2] / 2) ? 1 : -1
+                t.scrolls[i][] = Vec2f(t.scrolls[i][][1], t.scrolls[i][][2] + dir * vh)
+                return Consume(true)
+            elseif kind === :htrack
+                ca = t.scenes[i].viewport[]
+                vw = Float32(widths(ca)[1])
+                dir = Float32(pos[1]) > (hthumb_rect[i][].origin[1] + hthumb_rect[i][].widths[1] / 2) ? 1 : -1
+                t.scrolls[i][] = Vec2f(t.scrolls[i][][1] + dir * vw, t.scrolls[i][][2])
+                return Consume(true)
+            else
+                # tab header click
+                ti = tab_at(pos)
+                if ti != 0
+                    t.active[] = ti
+                    return Consume(true)
+                end
+            end
+        elseif ev.button == Mouse.left && ev.action == Mouse.release
+            drag_state[] = (:none, 0, 0.0f0, Vec2f(0, 0))
+        end
+        return Consume(false)
+    end
+
+    notify(t.layoutobservables.suggestedbbox)
+    return
+end
+
+Base.getindex(t::Tabs, i::Integer) = t.layouts[i]
+
+"""
+    content_scene(tabs::Tabs, i::Integer)
+
+Return the content `Scene` of tab `i`, for plotting directly into a tab.
+"""
+content_scene(t::Tabs, i::Integer) = t.scenes[i]
+
+# Blocks placed inside a tab's GridLayout aren't in `fig.content` (they're
+# created with a Scene parent, so `register_in_figure!` is skipped). Hand the
+# pre-display updates down to each tab's layout so auto axis limits etc. run.
+function update_state_before_display!(t::Tabs)
+    for layout in t.layouts
+        update_state_before_display!(layout)
+    end
+    return
+end

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -72,7 +72,7 @@ function initialize_block!(t::Tabs, labels::AbstractVector = ["Tab 1", "Tab 2"];
 end
 
 """
-    add_tab!(tabs::Tabs, label = "Tab N"; closable = true, activate = false) -> Subfigure
+    add_tab!(tabs::Tabs, label = "Tab N"; activate = false, kwargs...) -> Subfigure
 
 Append a tab to `tabs` and return its [`Subfigure`](@ref). Plot into it via
 `tabs[end][row, col] = Axis(...)` or `content_scene(tabs, length(tabs))`. Pass
@@ -80,11 +80,13 @@ Append a tab to `tabs` and return its [`Subfigure`](@ref). Plot into it via
 empty `Tabs` becomes active automatically.
 
 `label` accepts anything `text!` does — a plain `String`, a `rich(...)` for
-colored / styled spans, or a `LaTeXString` (`L"..."`).
+colored / styled spans, or a `LaTeXString` (`L"..."`). Any further keywords
+(e.g. `closable`) are forwarded to [`set_tab!`](@ref) to set the new tab's
+properties.
 """
 function add_tab!(
         t::Tabs, label = "Tab $(length(t.tabs) + 1)";
-        closable::Bool = true, activate::Bool = false
+        activate::Bool = false, kwargs...
     )
     blockscene = t.blockscene
 
@@ -96,7 +98,7 @@ function add_tab!(
     )
 
     label_obs = Observable{Any}(label)
-    closable_obs = Observable(closable)
+    closable_obs = Observable(true)
     rect = Observable(Rect2f(0, 0, 0, 0))
     bgcolor = Observable(to_color(t.tabcolor_inactive[]))
     labelpos = Observable(Point2f(0, 0))
@@ -153,6 +155,8 @@ function add_tab!(
             return
         end
     end
+
+    isempty(kwargs) || set_tab!(t, length(t.tabs); kwargs...)
 
     if activate || t.active[] < 1
         t.active[] = length(t.tabs)

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -1,51 +1,35 @@
 function initialize_block!(t::Tabs)
     blockscene = t.blockscene
-    t.scenes = Scene[]
-    t.layouts = GridLayout[]
-    t.scrolls = Observable{Vec2f}[]
-    t.contentsizes = Observable{Vec2f}[]
+    t.subfigures = Subfigure[]
 
     headerheight = Observable(0.0; ignore_equal_values = true)
     hovered = Observable(0; ignore_equal_values = true)
 
-    # A single continuous separator line under the header that leads up and
+    # A single continuous separator line under the header that detours up and
     # around the active tab — its left/top/right edges replace the straight
-    # line, so the active tab visually connects to the content area below
-    # without any inactive tabs needing a different background color.
+    # line, so the active tab visually connects to the content area below.
     sep_path = Observable(Point2f[])
     sep_plot = lines!(
         blockscene, sep_path;
         color = t.separator_color, linewidth = t.separator_thickness, inspectable = false
     )
-    # raise above the tab polys (which sit at z=0) so the line isn't covered
-    # where it runs along their shared bottom edge
+    # raise above the tab polys (z = 0) so the line isn't covered along their
+    # shared bottom edge
     translate!(sep_plot, 0, 0, 2)
 
-    # per-tab header primitives, indexed alongside t.scenes / t.layouts
+    # per-tab header primitives, indexed alongside t.subfigures
     tab_rects = Observable{Rect2f}[]
     tab_bgcolors = Observable{RGBAf}[]
     tab_labelpositions = Observable{Point2f}[]
     tab_labelcolors = Observable{RGBAf}[]
     tab_labelbbs = Observable[]
 
-    # per-tab scrollbar state (drawn in blockscene, gated by overflow)
-    vbar_rect = Observable{Rect2f}[]            # vertical track rect (per tab)
-    vthumb_rect = Observable{Rect2f}[]
-    vthumb_color = Observable{RGBAf}[]
-    hbar_rect = Observable{Rect2f}[]
-    hthumb_rect = Observable{Rect2f}[]
-    hthumb_color = Observable{RGBAf}[]
-    vbar_visible = Observable{Bool}[]
-    hbar_visible = Observable{Bool}[]
-    # interactive scrollbar state shared across tabs (only one drag at a time)
-    drag_state = Ref{Tuple{Symbol, Int, Float32, Vec2f}}((:none, 0, 0.0f0, Vec2f(0, 0)))
-
     content_area = lift(blockscene, t.layoutobservables.computedbbox, headerheight) do cbb, hh
         return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
     end
 
     function recompute_layout!()
-        n = length(t.scenes)
+        n = length(t.subfigures)
         n == 0 && return
         pad = t.tabpadding[]
         gap = t.tabgap[]
@@ -80,8 +64,8 @@ function initialize_block!(t::Tabs)
             x = x1 + gap
         end
 
-        # Separator path: a horizontal line under the header that detours up and
-        # over the active tab so the active tab "merges" into the content area.
+        # Separator path: a horizontal line under the header that detours up
+        # and over the active tab so the active tab "merges" into the panel.
         sep_y = Float32(top_ - hh)
         if 1 <= active <= n
             ar = tab_rects[active][]
@@ -101,142 +85,17 @@ function initialize_block!(t::Tabs)
         return
     end
 
-    function update_scrollbars!(i)
-        ca = t.scenes[i].viewport[]
-        cs = t.contentsizes[i][]
-        sc = t.scrolls[i][]
-        sbsize = Float32(t.scrollbar_size[])
-        vw, vh = Float32.(widths(ca))
-        cw, ch = max(cs[1], vw), max(cs[2], vh)
-        max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
-
-        vbar_visible[i][] = max_sy > 0
-        hbar_visible[i][] = max_sx > 0
-
-        if max_sy > 0
-            tx = right(ca) - sbsize
-            vbar_rect[i][] = Rect2f((tx, bottom(ca)), (sbsize, vh))
-            thumb_h = max(20.0f0, vh * vh / ch)
-            usable = vh - thumb_h
-            ty = top(ca) - thumb_h - (sc[2] / max_sy) * usable
-            vthumb_rect[i][] = Rect2f((tx, ty), (sbsize, thumb_h))
-        end
-        if max_sx > 0
-            by = bottom(ca)
-            hbar_rect[i][] = Rect2f((left(ca), by), (vw, sbsize))
-            thumb_w = max(20.0f0, vw * vw / cw)
-            usable = vw - thumb_w
-            tx = left(ca) + (sc[1] / max_sx) * usable
-            hthumb_rect[i][] = Rect2f((tx, by), (thumb_w, sbsize))
-        end
-        return
-    end
-
-    function add_tab!(i)
+    function add_subfigure!(i)
         is_active = lift(a -> a == i, blockscene, t.active)
-        # One scene per tab. `cam_window_pixel!` (used by Block blockscenes
-        # via `_block`) takes care of the viewport-offset mapping, so blocks
-        # placed into this scene's layout render correctly even though the
-        # scene's viewport doesn't start at the window origin. The scene
-        # itself uses `campixel!` so direct `content_scene(t, i)` plotting
-        # stays in tab-local pixel coords (origin at the content-area corner).
-        scene = Scene(
-            blockscene; events = Events(), camera = campixel!,
-            viewport = content_area, visible = is_active, clear = false
+        sf = Subfigure(
+            blockscene;
+            bbox = content_area,
+            isolate_events = true,
+            active = is_active,
+            contentpadding = t.contentpadding,
         )
-        forward_events!(scene, blockscene; active = is_active)
-
-        scroll = Observable(Vec2f(0, 0); ignore_equal_values = true)
-        contentsize = Observable(Vec2f(0, 0); ignore_equal_values = true)
-        layout_bbox = Observable(Rect2f(0, 0, 1, 1); ignore_equal_values = true)
-        layout = GridLayout(; bbox = layout_bbox)
-        layout.parent = scene
-
-        push!(t.scenes, scene)
-        push!(t.layouts, layout)
-        push!(t.scrolls, scroll)
-        push!(t.contentsizes, contentsize)
-
-        # Layout bbox is in absolute window coords; inner block decorations
-        # placed via the layout end up at those absolute coords, which is what
-        # local campixel expects when the scene's viewport is at the figure
-        # origin (here: `inner`'s viewport).
-        onany(blockscene, content_area, scroll, contentsize) do ca, sc, cs
-            vw, vh = Float32.(widths(ca))
-            cw, ch = max(cs[1], vw), max(cs[2], vh)
-            max_sx, max_sy = max(0.0f0, cw - vw), max(0.0f0, ch - vh)
-            sx = clamp(sc[1], 0.0f0, max_sx)
-            sy = clamp(sc[2], 0.0f0, max_sy)
-            if sx != sc[1] || sy != sc[2]
-                scroll[] = Vec2f(sx, sy)
-                return
-            end
-            top_edge = top(ca) + sy
-            left_edge = left(ca) - sx
-            layout_bbox[] = Rect2f(Point2f(left_edge, top_edge - ch), Vec2f(cw, ch))
-            update_scrollbars!(i)
-            return
-        end
-
-        # Outside padding keeps block protrusions (axis titles, ticklabels) inside
-        # the clipped content area instead of overflowing and getting cut off.
-        on(blockscene, t.contentpadding; update = true) do pad
-            sides = pad isa Number ? (pad, pad, pad, pad) : pad
-            layout.alignmode[] = Outside(to_rectsides(sides))
-            GridLayoutBase.update!(layout)
-            return
-        end
-
-        # After every layout pass, remeasure the determinable content size so
-        # scroll bounds and scrollbars react to fixed row/col sizes the user
-        # sets via `colsize!`/`rowsize!`/`width=`/`height=`.
-        on(blockscene, layout.layoutobservables.computedbbox) do _
-            dw = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Col())
-            dh = GridLayoutBase.determinedirsize(layout, GridLayoutBase.Row())
-            cw = dw === nothing ? 0.0f0 : Float32(dw)
-            ch = dh === nothing ? 0.0f0 : Float32(dh)
-            contentsize[] = Vec2f(cw, ch)
-            return
-        end
-
-        # Wheel/trackpad scrolling. Uses the tab's isolated events, so only the
-        # active tab sees the scroll.
-        # Container scrolling runs at a priority below the default so inner
-        # blocks (e.g. an Axis zoom-on-scroll handler at priority 0) get the
-        # event first; we only scroll the container if nothing consumed it.
-        on(blockscene, scene.events.scroll; priority = -1) do (dx, dy)
-            cs = contentsize[]
-            ca = scene.viewport[]
-            vw, vh = Float32.(widths(ca))
-            cw, ch = max(cs[1], vw), max(cs[2], vh)
-            (cw <= vw && ch <= vh) && return Consume(false)
-            step = Float32(t.scroll_speed[])
-            scroll[] = Vec2f(scroll[][1] + step * dx, scroll[][2] - step * dy)
-            return Consume(true)
-        end
-
-        # scrollbar primitives (drawn in blockscene so they sit above content)
-        vbar_r = Observable(Rect2f(0, 0, 0, 0))
-        vth_r = Observable(Rect2f(0, 0, 0, 0))
-        vth_c = Observable(to_color(t.scrollbar_thumb_color[]))
-        vvis = Observable(false; ignore_equal_values = true)
-        hbar_r = Observable(Rect2f(0, 0, 0, 0))
-        hth_r = Observable(Rect2f(0, 0, 0, 0))
-        hth_c = Observable(to_color(t.scrollbar_thumb_color[]))
-        hvis = Observable(false; ignore_equal_values = true)
-        push!(vbar_rect, vbar_r)
-        push!(vthumb_rect, vth_r)
-        push!(vthumb_color, vth_c)
-        push!(hbar_rect, hbar_r)
-        push!(hthumb_rect, hth_r)
-        push!(hthumb_color, hth_c)
-        push!(vbar_visible, vvis)
-        push!(hbar_visible, hvis)
-        poly!(blockscene, vbar_r; color = t.scrollbar_color, visible = lift(&, is_active, vvis), inspectable = false)
-        poly!(blockscene, vth_r; color = vth_c, visible = lift(&, is_active, vvis), inspectable = false)
-        poly!(blockscene, hbar_r; color = t.scrollbar_color, visible = lift(&, is_active, hvis), inspectable = false)
-        poly!(blockscene, hth_r; color = hth_c, visible = lift(&, is_active, hvis), inspectable = false)
-        return
+        push!(t.subfigures, sf)
+        return sf
     end
 
     function add_header!(i)
@@ -264,10 +123,9 @@ function initialize_block!(t::Tabs)
     end
 
     on(blockscene, t.labels; update = true) do labels
-        while length(t.scenes) < length(labels)
-            i = length(t.scenes) + 1
-            add_tab!(i)
-            add_header!(i)
+        while length(t.subfigures) < length(labels)
+            add_subfigure!(length(t.subfigures) + 1)
+            add_header!(length(t.subfigures))
         end
         recompute_layout!()
         return
@@ -283,108 +141,24 @@ function initialize_block!(t::Tabs)
 
     function tab_at(pos)
         p = Point2f(pos)
-        for i in 1:length(t.scenes)
+        for i in 1:length(t.subfigures)
             p in tab_rects[i][] && return i
         end
         return 0
     end
 
-    # Returns (:vthumb | :vtrack | :hthumb | :htrack | :none, tab_index) at pos.
-    # We only look at the currently active tab, since inactive scrollbars are hidden.
-    function scrollbar_at(pos)
-        i = t.active[]
-        i == 0 && return :none, 0
-        p = Point2f(pos)
-        vvis = i <= length(vbar_visible) && vbar_visible[i][]
-        hvis = i <= length(hbar_visible) && hbar_visible[i][]
-        if vvis
-            p in vthumb_rect[i][] && return :vthumb, i
-            p in vbar_rect[i][] && return :vtrack, i
-        end
-        if hvis
-            p in hthumb_rect[i][] && return :hthumb, i
-            p in hbar_rect[i][] && return :htrack, i
-        end
-        return :none, 0
-    end
-
     on(blockscene, blockscene.events.mouseposition) do pos
         hovered[] = tab_at(pos)
-        kind, i = scrollbar_at(pos)
-        st, di, _, _ = drag_state[]
-        for j in 1:length(t.scenes)
-            # Keep the dragged thumb highlighted regardless of mouse position,
-            # otherwise dragging "off" the thumb visibly drops the active state.
-            v_active = (st === :vdrag && di == j) || (kind in (:vthumb, :vtrack) && j == i)
-            h_active = (st === :hdrag && di == j) || (kind in (:hthumb, :htrack) && j == i)
-            vthumb_color[j][] = to_color(v_active ? t.scrollbar_thumb_color_active[] : t.scrollbar_thumb_color[])
-            hthumb_color[j][] = to_color(h_active ? t.scrollbar_thumb_color_active[] : t.scrollbar_thumb_color[])
-        end
-        # handle ongoing drag
-        anchor = drag_state[][3]
-        anchor_scroll = drag_state[][4]
-        if st === :vdrag && di > 0
-            ca = t.scenes[di].viewport[]
-            vh = Float32(widths(ca)[2])
-            ch = max(t.contentsizes[di][][2], vh)
-            max_sy = max(0.0f0, ch - vh)
-            max_sy == 0 && return Consume(false)
-            thumb_h = max(20.0f0, vh * vh / ch)
-            usable = vh - thumb_h
-            # pos.y vs anchor.y: dragging DOWN (y decreases in window coords) → scroll down (scroll_y increases)
-            dy = anchor - Float32(pos[2])
-            new_sy = clamp(anchor_scroll[2] + dy * max_sy / usable, 0.0f0, max_sy)
-            t.scrolls[di][] = Vec2f(t.scrolls[di][][1], new_sy)
-            return Consume(true)
-        elseif st === :hdrag && di > 0
-            ca = t.scenes[di].viewport[]
-            vw = Float32(widths(ca)[1])
-            cw = max(t.contentsizes[di][][1], vw)
-            max_sx = max(0.0f0, cw - vw)
-            max_sx == 0 && return Consume(false)
-            thumb_w = max(20.0f0, vw * vw / cw)
-            usable = vw - thumb_w
-            dx = Float32(pos[1]) - anchor
-            new_sx = clamp(anchor_scroll[1] + dx * max_sx / usable, 0.0f0, max_sx)
-            t.scrolls[di][] = Vec2f(new_sx, t.scrolls[di][][2])
-            return Consume(true)
-        end
         return Consume(false)
     end
 
     on(blockscene, blockscene.events.mousebutton; priority = 60) do ev
         if ev.button == Mouse.left && ev.action == Mouse.press
-            pos = blockscene.events.mouseposition[]
-            kind, i = scrollbar_at(pos)
-            if kind === :vthumb
-                drag_state[] = (:vdrag, i, Float32(pos[2]), t.scrolls[i][])
+            i = tab_at(blockscene.events.mouseposition[])
+            if i != 0
+                t.active[] = i
                 return Consume(true)
-            elseif kind === :hthumb
-                drag_state[] = (:hdrag, i, Float32(pos[1]), t.scrolls[i][])
-                return Consume(true)
-            elseif kind === :vtrack
-                # page scroll: jump by viewport height
-                ca = t.scenes[i].viewport[]
-                vh = Float32(widths(ca)[2])
-                dir = Float32(pos[2]) < (vthumb_rect[i][].origin[2] + vthumb_rect[i][].widths[2] / 2) ? 1 : -1
-                t.scrolls[i][] = Vec2f(t.scrolls[i][][1], t.scrolls[i][][2] + dir * vh)
-                return Consume(true)
-            elseif kind === :htrack
-                ca = t.scenes[i].viewport[]
-                vw = Float32(widths(ca)[1])
-                dir = Float32(pos[1]) > (hthumb_rect[i][].origin[1] + hthumb_rect[i][].widths[1] / 2) ? 1 : -1
-                t.scrolls[i][] = Vec2f(t.scrolls[i][][1] + dir * vw, t.scrolls[i][][2])
-                return Consume(true)
-            else
-                # tab header click
-                ti = tab_at(pos)
-                if ti != 0
-                    t.active[] = ti
-                    return Consume(true)
-                end
             end
-        elseif ev.button == Mouse.left && ev.action == Mouse.release
-            drag_state[] = (:none, 0, 0.0f0, Vec2f(0, 0))
         end
         return Consume(false)
     end
@@ -393,21 +167,21 @@ function initialize_block!(t::Tabs)
     return
 end
 
-Base.getindex(t::Tabs, i::Integer) = t.layouts[i]
+Base.getindex(t::Tabs, i::Integer) = t.subfigures[i]
 
 """
     content_scene(tabs::Tabs, i::Integer)
 
 Return the content `Scene` of tab `i`, for plotting directly into a tab.
 """
-content_scene(t::Tabs, i::Integer) = t.scenes[i]
+content_scene(t::Tabs, i::Integer) = content_scene(t.subfigures[i])
 
-# Blocks placed inside a tab's GridLayout aren't in `fig.content` (they're
-# created with a Scene parent, so `register_in_figure!` is skipped). Hand the
-# pre-display updates down to each tab's layout so auto axis limits etc. run.
+# Hand pre-display state updates to each tab's Subfigure so blocks placed inside a
+# tab (which the Figure can't see because they have a Scene parent, not a
+# Figure parent) still get e.g. auto axis limits.
 function update_state_before_display!(t::Tabs)
-    for layout in t.layouts
-        update_state_before_display!(layout)
+    for sf in t.subfigures
+        update_state_before_display!(sf)
     end
     return
 end

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -1,6 +1,14 @@
+# Whether tab `i` is closable, given the `closable` attribute value (a single
+# `Bool` for all tabs, or a `Vector{Bool}` indexed per tab; out-of-range = not
+# closable).
+_tab_closable(c::Bool, i) = c
+_tab_closable(c::AbstractVector, i) = (1 <= i <= length(c)) && Bool(c[i])
+
 function initialize_block!(t::Tabs)
     blockscene = t.blockscene
     t.subfigures = Subfigure[]
+
+    tab_closable(i) = _tab_closable(t.closable[], i)
 
     headerheight = Observable(0.0; ignore_equal_values = true)
     hovered = Observable(0; ignore_equal_values = true)
@@ -17,47 +25,74 @@ function initialize_block!(t::Tabs)
     # shared bottom edge
     translate!(sep_plot, 0, 0, 2)
 
-    # per-tab header primitives, indexed alongside t.subfigures
+    # Per-tab state, all kept in lockstep with `t.subfigures` (and with
+    # `t.labels`). Header text / close visibility / geometry are driven
+    # imperatively from `recompute_layout!` rather than captured per creation
+    # index, so closing a tab in the middle (which `deleteat!`s every array)
+    # keeps slot i ↔ subfigure i ↔ label i aligned.
     tab_rects = Observable{Rect2f}[]
     tab_bgcolors = Observable{RGBAf}[]
     tab_labelpositions = Observable{Point2f}[]
     tab_labelcolors = Observable{RGBAf}[]
+    tab_labeltexts = Observable{String}[]
     tab_labelbbs = Observable[]
-    # close-button state
     close_segments = Observable{Vector{Point2f}}[]  # 4 points per tab (two diagonals)
     close_colors = Observable{RGBAf}[]
     close_rects = Observable{Rect2f}[]  # hit-test region, slightly larger than the glyph
+    close_visibles = Observable{Bool}[]
+    subfig_visibles = Observable{Bool}[]
+    header_plots = Tuple{Any, Any, Any}[]  # (poly, label, close) per tab, for deletion
     close_hovered = Observable(0; ignore_equal_values = true)
     # Resolved label-font metrics (in EM units, multiply by fontsize for pixels).
-    # Updated once the first label plot resolves its font; defaults are sane for
-    # most sans-serif fonts so the very first frame doesn't draw at (0, 0).
+    # Updated once a label plot resolves its font; defaults are sane for most
+    # sans-serif fonts so the very first frame doesn't draw at (0, 0).
     font_metrics = Observable((asc = 0.95f0, des = -0.21f0, xh = 0.52f0))
+    font_metrics_captured = Ref(false)
 
     content_area = lift(blockscene, t.layoutobservables.computedbbox, headerheight) do cbb, hh
         return round_to_IRect2D(BBox(left(cbb), right(cbb), bottom(cbb), top(cbb) - hh))
     end
 
+    function refresh_visibility!()
+        a = t.active[]
+        for d in 1:length(subfig_visibles)
+            subfig_visibles[d][] = (d == a)
+        end
+        return
+    end
+
     function recompute_layout!()
         n = length(t.labels[])
+        # blank any slots beyond the current label count (can happen if the
+        # user sets `labels` to a shorter vector directly rather than closing)
+        for i in (n + 1):length(tab_rects)
+            tab_rects[i][] = Rect2f(0, 0, 0, 0)
+            tab_labeltexts[i][] = ""
+            close_visibles[i][] = false
+            close_rects[i][] = Rect2f(0, 0, 0, 0)
+        end
         n == 0 && return
         pad = t.tabpadding[]
         gap = t.tabgap[]
         fs = Float32(t.fontsize[])
         fm = font_metrics[]
         x_height_px = fm.xh * fs
-        closable = t.closable[]
-        close_w = closable ? x_height_px : 0.0f0
-        close_gap = closable ? x_height_px * 1.6f0 : 0.0f0
         widths_ = Vector{Float32}(undef, n)
         labelws = Vector{Float32}(undef, n)
+        close_ws = Vector{Float32}(undef, n)
+        close_gaps = Vector{Float32}(undef, n)
         hmax = 0.0
         for i in 1:n
+            tab_labeltexts[i][] = t.labels[][i]
             bbs = tab_labelbbs[i][]
             w = isempty(bbs) ? 0.0 : width(bbs[1])
             h = isempty(bbs) ? 0.0 : height(bbs[1])
             labelws[i] = w
             hmax = max(hmax, h)
-            widths_[i] = w + pad[1] + pad[2] + close_w + close_gap
+            cl = tab_closable(i)
+            close_ws[i] = cl ? x_height_px : 0.0f0
+            close_gaps[i] = cl ? x_height_px * 1.6f0 : 0.0f0
+            widths_[i] = w + pad[1] + pad[2] + close_ws[i] + close_gaps[i]
         end
         th = t.tabheight[]
         headerheight[] = th === automatic ? hmax + pad[3] + pad[4] : Float64(th)
@@ -75,25 +110,29 @@ function initialize_block!(t::Tabs)
             tab_rects[i][] = BBox(x0, x1, top_ - hh, top_)
             # label sits left-aligned in the tab, centered vertically
             tab_labelpositions[i][] = Point2f(x0 + pad[1] + labelws[i] / 2, top_ - hh / 2)
-            # close button sits to the right of the label; its width is the
-            # measured glyph width so pad[2] on its right matches pad[1] on
-            # the label's left.
             # The × is drawn as two diagonal line segments, baseline-aligned
-            # with the label (so it sits where a lowercase 'x' would) and
-            # sized to the font's x-height.
-            close_cx = x0 + pad[1] + labelws[i] + close_gap + close_w / 2
-            baseline_y = top_ - hh / 2 - (fm.asc + fm.des) / 2 * fs
-            half = x_height_px / 2
-            y_top = baseline_y + x_height_px
-            y_bot = baseline_y
-            close_segments[i][] = Point2f[
-                Point2f(close_cx - half, y_top), Point2f(close_cx + half, y_bot),  # \
-                Point2f(close_cx + half, y_top), Point2f(close_cx - half, y_bot),  # /
-            ]
-            # hit-test region a bit larger than the glyph, centred on the tab
-            hit_half = max(close_w, fs) / 2 + 2
-            close_rects[i][] = Rect2f(close_cx - hit_half, top_ - hh / 2 - hit_half, 2hit_half, 2hit_half)
-            close_colors[i][] = to_color(i == chov ? t.closecolor_hover[] : t.closecolor[])
+            # with the label (so it sits where a lowercase 'x' would) and sized
+            # to the font's x-height. Non-closable tabs get empty segments and
+            # a zero-size hit rect so nothing draws or hit-tests.
+            close_visibles[i][] = close_ws[i] > 0
+            if close_ws[i] > 0
+                close_cx = x0 + pad[1] + labelws[i] + close_gaps[i] + close_ws[i] / 2
+                baseline_y = top_ - hh / 2 - (fm.asc + fm.des) / 2 * fs
+                half = x_height_px / 2
+                y_top = baseline_y + x_height_px
+                y_bot = baseline_y
+                close_segments[i][] = Point2f[
+                    Point2f(close_cx - half, y_top), Point2f(close_cx + half, y_bot),  # \
+                    Point2f(close_cx + half, y_top), Point2f(close_cx - half, y_bot),  # /
+                ]
+                # hit-test region a bit larger than the glyph, centred on the tab
+                hit_half = max(close_ws[i], fs) / 2 + 2
+                close_rects[i][] = Rect2f(close_cx - hit_half, top_ - hh / 2 - hit_half, 2hit_half, 2hit_half)
+                close_colors[i][] = to_color(i == chov ? t.closecolor_hover[] : t.closecolor[])
+            else
+                close_segments[i][] = Point2f[]
+                close_rects[i][] = Rect2f(0, 0, 0, 0)
+            end
 
             tab_bgcolors[i][] = to_color(
                 i == active ? t.tabcolor_active[] :
@@ -124,34 +163,36 @@ function initialize_block!(t::Tabs)
         return
     end
 
-    function add_subfigure!(i)
-        is_active = lift(a -> a == i, blockscene, t.active)
+    function add_subfigure!()
+        vis = Observable(false; ignore_equal_values = true)
         sf = Subfigure(
             blockscene;
             bbox = content_area,
             isolate_events = true,
-            visible = is_active,
+            visible = vis,
             contentpadding = t.contentpadding,
         )
         push!(t.subfigures, sf)
+        push!(subfig_visibles, vis)
         return sf
     end
 
-    function add_header!(i)
+    function add_header!()
         rect = Observable(Rect2f(0, 0, 0, 0))
         bgcolor = Observable(to_color(t.tabcolor_inactive[]))
         labelpos = Observable(Point2f(0, 0))
         labelcolor = Observable(to_color(t.labelcolor_inactive[]))
+        labeltext = Observable("")
         push!(tab_rects, rect)
         push!(tab_bgcolors, bgcolor)
         push!(tab_labelpositions, labelpos)
         push!(tab_labelcolors, labelcolor)
+        push!(tab_labeltexts, labeltext)
 
         poly_pts = lift(roundedrectvertices, blockscene, rect, t.cornerradius, t.cornersegments)
-        poly!(blockscene, poly_pts; color = bgcolor, inspectable = false)
-        labelstr = lift(ls -> get(ls, i, ""), blockscene, t.labels)
+        polyplot = poly!(blockscene, poly_pts; color = bgcolor, inspectable = false)
         labelplot = text!(
-            blockscene, labelpos; text = labelstr, fontsize = t.fontsize, font = t.font,
+            blockscene, labelpos; text = labeltext, fontsize = t.fontsize, font = t.font,
             color = labelcolor, align = (:center, :center), markerspace = :data, inspectable = false
         )
         translate!(labelplot, 0, 0, 1)
@@ -159,10 +200,10 @@ function initialize_block!(t::Tabs)
         push!(tab_labelbbs, bbs)
         on(_ -> recompute_layout!(), blockscene, bbs)
 
-        # The first label resolves the font we'll use for the close glyph
-        # too; capture its metrics so the × is sized to the x-height and
-        # sits on the label's baseline.
-        if i == 1
+        # Capture the resolved label font's metrics once, so the × is sized to
+        # the x-height and sits on the label's baseline.
+        if !font_metrics_captured[]
+            font_metrics_captured[] = true
             on(blockscene, labelplot.selected_font; update = true) do f
                 try
                     asc = Float32(Makie.FreeTypeAbstraction.ascender(f))
@@ -182,38 +223,84 @@ function initialize_block!(t::Tabs)
         segs = Observable(Point2f[])
         close_color = Observable(to_color(t.closecolor[]))
         close_rect = Observable(Rect2f(0, 0, 0, 0))
+        close_visible = Observable(false)
         push!(close_segments, segs)
         push!(close_colors, close_color)
         push!(close_rects, close_rect)
-        close_visible = lift((c, ls) -> c && i <= length(ls), blockscene, t.closable, t.labels)
+        push!(close_visibles, close_visible)
         close_lw = lift(fs -> max(1.0f0, Float32(fs) * 0.08f0), blockscene, t.fontsize)
-        close_plot = linesegments!(
+        closeplot = linesegments!(
             blockscene, segs;
             color = close_color, linewidth = close_lw, visible = close_visible,
             inspectable = false,
         )
-        translate!(close_plot, 0, 0, 1)
+        translate!(closeplot, 0, 0, 1)
+
+        push!(header_plots, (polyplot, labelplot, closeplot))
+        return
+    end
+
+    # Remove tab `ci`: delete its subfigure (freeing its content) and header
+    # plots, drop the matching entry from every parallel array, then update
+    # `labels` / `closable` / `active` so the remaining tabs stay aligned.
+    function remove_tab!(ci)
+        n = length(t.labels[])
+        (1 <= ci <= n) || return
+
+        delete!(t.subfigures[ci])
+        deleteat!(t.subfigures, ci)
+        deleteat!(subfig_visibles, ci)
+
+        for p in header_plots[ci]
+            delete!(blockscene, p)
+        end
+        deleteat!(header_plots, ci)
+        for arr in (
+                tab_rects, tab_bgcolors, tab_labelpositions, tab_labelcolors,
+                tab_labeltexts, tab_labelbbs, close_segments, close_colors,
+                close_rects, close_visibles,
+            )
+            deleteat!(arr, ci)
+        end
+
+        new_n = n - 1
+        old_active = t.active[]
+        new_active = if new_n == 0
+            0
+        elseif old_active < ci
+            old_active
+        elseif old_active == ci
+            min(ci, new_n)
+        else
+            old_active - 1
+        end
+
+        # Order matters: `labels` must be updated first so the recompute it
+        # triggers sees `n == new_n`, matching the already-shrunken arrays. The
+        # `closable` vector and `active` are corrected immediately after (their
+        # recomputes are synchronous, so no stale frame renders in between).
+        t.labels[] = vcat(t.labels[][1:(ci - 1)], t.labels[][(ci + 1):end])
+        c = t.closable[]
+        if c isa AbstractVector && ci <= length(c)
+            t.closable[] = vcat(c[1:(ci - 1)], c[(ci + 1):end])
+        end
+        t.active[] = new_active
+        refresh_visibility!()
+        recompute_layout!()
         return
     end
 
     on(blockscene, t.labels; update = true) do labels
         n = length(labels)
-        # grow if more labels
         while length(t.subfigures) < n
-            add_subfigure!(length(t.subfigures) + 1)
-            add_header!(length(t.subfigures))
+            add_subfigure!()
+            add_header!()
         end
         # clamp active onto the new range so it doesn't point at a removed tab
         if !isempty(labels) && t.active[] > n
             t.active[] = clamp(t.active[], 1, n)
         end
-        # extra subfigures stay around (their `visible` is bound to
-        # `active == i` so they're already hidden), but their headers shouldn't
-        # render. Move the leftover tab rects off-screen and the labels are
-        # already empty strings via `get(ls, i, "")`.
-        for i in (n + 1):length(t.subfigures)
-            tab_rects[i][] = Rect2f(0, 0, 0, 0)
-        end
+        refresh_visibility!()
         recompute_layout!()
         return
     end
@@ -227,10 +314,15 @@ function initialize_block!(t::Tabs)
         recompute_layout!()
     end
 
+    on(blockscene, t.active) do _
+        refresh_visibility!()
+        return
+    end
+
     function close_at(pos)
-        t.closable[] || return 0
         p = Point2f(pos)
         for i in 1:length(t.labels[])
+            tab_closable(i) || continue
             p in close_rects[i][] && return i
         end
         return 0
@@ -257,7 +349,7 @@ function initialize_block!(t::Tabs)
             # the × removes the tab without first making it active.
             ci = close_at(pos)
             if ci != 0
-                t.labels[] = vcat(t.labels[][1:(ci - 1)], t.labels[][(ci + 1):end])
+                remove_tab!(ci)
                 return Consume(true)
             end
             i = tab_at(pos)

--- a/Makie/src/makielayout/blocks/tabs.jl
+++ b/Makie/src/makielayout/blocks/tabs.jl
@@ -29,7 +29,7 @@ function initialize_block!(t::Tabs)
     end
 
     function recompute_layout!()
-        n = length(t.subfigures)
+        n = length(t.labels[])
         n == 0 && return
         pad = t.tabpadding[]
         gap = t.tabgap[]
@@ -91,7 +91,7 @@ function initialize_block!(t::Tabs)
             blockscene;
             bbox = content_area,
             isolate_events = true,
-            active = is_active,
+            visible = is_active,
             contentpadding = t.contentpadding,
         )
         push!(t.subfigures, sf)
@@ -123,9 +123,22 @@ function initialize_block!(t::Tabs)
     end
 
     on(blockscene, t.labels; update = true) do labels
-        while length(t.subfigures) < length(labels)
+        n = length(labels)
+        # grow if more labels
+        while length(t.subfigures) < n
             add_subfigure!(length(t.subfigures) + 1)
             add_header!(length(t.subfigures))
+        end
+        # clamp active onto the new range so it doesn't point at a removed tab
+        if !isempty(labels) && t.active[] > n
+            t.active[] = clamp(t.active[], 1, n)
+        end
+        # extra subfigures stay around (their `visible` is bound to
+        # `active == i` so they're already hidden), but their headers shouldn't
+        # render. Move the leftover tab rects off-screen and the labels are
+        # already empty strings via `get(ls, i, "")`.
+        for i in (n + 1):length(t.subfigures)
+            tab_rects[i][] = Rect2f(0, 0, 0, 0)
         end
         recompute_layout!()
         return
@@ -168,6 +181,21 @@ function initialize_block!(t::Tabs)
 end
 
 Base.getindex(t::Tabs, i::Integer) = t.subfigures[i]
+
+# Generic `Block` indexing would lazy-init a fresh, disconnected `GridLayout`
+# on `t.layout` — a silent foot-gun: `Axis(tabs[1, 1])` would create an
+# orphan that never displays. Force users to specify which tab.
+function Base.getindex(
+        ::Tabs,
+        ::Union{Integer, Colon, AbstractRange},
+        ::Union{Integer, Colon, AbstractRange},
+        side = GridLayoutBase.Inner()
+    )
+    error(
+        "`Tabs` doesn't have a top-level grid layout — index into a specific " *
+            "tab first: `tabs[i][row, col]` (or `tabs[i].layout[row, col]`)."
+    )
+end
 
 """
     content_scene(tabs::Tabs, i::Integer)

--- a/Makie/src/makielayout/blocks/textbox.jl
+++ b/Makie/src/makielayout/blocks/textbox.jl
@@ -53,11 +53,10 @@ function initialize_block!(tbox::Textbox)
     realtextcolor = Observable(to_color(:red))
 
     # Position the editor at the top-left of the inner area, accounting for textpadding.
-    # The inner text plot uses `space = :pixel` which is viewport-local (see
-    # `Camera.pixel_space`), so the anchor is in scenearea-local coords.
+    # campixel is in absolute window coords, so we anchor at the window-coord top-left.
     text_origin = lift(topscene, scenearea, tbox.textpadding) do area, padding
         l, _r, _b, t = padding
-        return Point2f(l, widths(area)[2] - t)
+        return Point2f(left(area) + l, top(area) - t)
     end
 
     # Placeholder is rendered as a separate text! that's visible whenever
@@ -82,7 +81,6 @@ function initialize_block!(tbox::Textbox)
         font = tbox.font,
         fontsize = tbox.fontsize,
         cursor_color = tbox.cursorcolor,
-        space = :pixel,
         multiline = false,
         manage_focus = false,            # Textbox drives focus (see below)
         input_filter = c -> is_allowed(c, tbox.restriction[]),

--- a/Makie/src/makielayout/blocks/textbox.jl
+++ b/Makie/src/makielayout/blocks/textbox.jl
@@ -53,8 +53,9 @@ function initialize_block!(tbox::Textbox)
     realtextcolor = Observable(to_color(:red))
 
     # Position the editor at the top-left of the inner area, accounting for textpadding.
+    # The inner text plot uses `space = :pixel` which is viewport-local (see
+    # `Camera.pixel_space`), so the anchor is in scenearea-local coords.
     text_origin = lift(topscene, scenearea, tbox.textpadding) do area, padding
-        # padding = (left, right, bottom, top); text uses (:left, :top) align so we anchor at the top-left
         l, _r, _b, t = padding
         return Point2f(l, widths(area)[2] - t)
     end

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1458,10 +1458,10 @@ scientific-figure panels, sidebars, dialog regions, etc.
         scrollable = true
         "Speed of wheel/trackpad scrolling."
         scroll_speed = 15.0
-        "Thickness in pixels of the scrollbar tracks shown when content overflows."
-        scrollbar_size = 8
-        "Background color of a scrollbar track."
-        scrollbar_color = RGBAf(0, 0, 0, 0.05)
+        "Thickness in pixels of the scrollbar thumbs shown when content overflows."
+        scrollbar_size = 6
+        "Background color of the scrollbar track (default transparent — only the thumb is drawn)."
+        scrollbar_color = RGBAf(0, 0, 0, 0)
         "Color of the scrollbar thumb (the draggable handle)."
         scrollbar_thumb_color = RGBAf(0, 0, 0, 0.3)
         "Color of the scrollbar thumb when hovered or dragged."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1429,9 +1429,9 @@ A clipped, optionally event-isolated, scrollable region with its own
 to a sub-region. Place blocks via `Axis(subfig[1, 1])` etc., or plot
 directly into `content_scene(subfig)` (in viewport-local pixel coords).
 
-The `active::Observable{Bool}` attribute controls whether the subfigure is
+The `visible::Observable{Bool}` attribute controls whether the subfigure is
 shown and, when constructed with `isolate_events = true`, whether it
-receives mouse and keyboard input. When inactive, the subfigure renders
+receives mouse and keyboard input. When hidden, the subfigure renders
 nothing and (if isolated) sees no input events.
 
 Content larger than the subfigure scrolls vertically and horizontally;
@@ -1440,7 +1440,7 @@ from the inner `GridLayout`'s determinable size, so setting fixed row /
 column sizes makes the subfigure overflow and scroll.
 
 `Tabs` is built on `Subfigure` — one per tab, with `isolate_events = true`
-and `active = (tabs.active == i)`. Use `Subfigure` directly for scrollable
+and `visible = (tabs.active == i)`. Use `Subfigure` directly for scrollable
 scientific-figure panels, sidebars, dialog regions, etc.
 """
 @Block Subfigure begin
@@ -1449,7 +1449,7 @@ scientific-figure panels, sidebars, dialog regions, etc.
     contentsize::Observable{Vec2f}
     @attributes begin
         "Whether the subfigure is shown. When `false` it renders nothing and (if `isolate_events = true`) receives no input."
-        active = true
+        visible = true
         "Padding (in pixels) around the content, as a number or a (left, right, bottom, top) tuple."
         contentpadding = 10
         "Background color of the content area."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1422,23 +1422,79 @@ end
 
 
 """
-Tabs(fig_or_scene; labels = ["Tab 1", "Tab 2"], kwargs...)
+    Subfigure(fig_or_scene; kwargs...)
 
-A tabbed container. Each tab owns its own content `Scene` paired with a
-`GridLayout`, so it behaves like a miniature `Figure`: place `Block`s with
-`tabs[i][row, col] = Axis(...)` or plot directly into `tabs[i]` / `content_scene(tabs, i)`.
+A clipped, optionally event-isolated, scrollable region with its own
+`Scene` paired with a `GridLayout` — the same shape as a `Figure`, scoped
+to a sub-region. Place blocks via `Axis(subfig[1, 1])` etc., or plot
+directly into `content_scene(subfig)` (in viewport-local pixel coords).
 
-Only the active tab (selected via the `active` attribute or by clicking its
-header) is visible. Each content `Scene` is event-isolated: it owns its own
-`Events` object and receives mouse and keyboard input only while active, so
-hidden tabs and their plots never react to input (see [`forward_events!`](@ref)).
-Content larger than the visible area can be scrolled vertically and horizontally.
+The `active::Observable{Bool}` attribute controls whether the subfigure is
+shown and, when constructed with `isolate_events = true`, whether it
+receives mouse and keyboard input. When inactive, the subfigure renders
+nothing and (if isolated) sees no input events.
+
+Content larger than the subfigure scrolls vertically and horizontally;
+scrollbars appear only when there is overflow. Content size is derived
+from the inner `GridLayout`'s determinable size, so setting fixed row /
+column sizes makes the subfigure overflow and scroll.
+
+`Tabs` is built on `Subfigure` — one per tab, with `isolate_events = true`
+and `active = (tabs.active == i)`. Use `Subfigure` directly for scrollable
+scientific-figure panels, sidebars, dialog regions, etc.
+"""
+@Block Subfigure begin
+    scene::Scene
+    scroll::Observable{Vec2f}
+    contentsize::Observable{Vec2f}
+    @attributes begin
+        "Whether the subfigure is shown. When `false` it renders nothing and (if `isolate_events = true`) receives no input."
+        active = true
+        "Padding (in pixels) around the content, as a number or a (left, right, bottom, top) tuple."
+        contentpadding = 10
+        "Background color of the content area."
+        backgroundcolor = :transparent
+        "Whether wheel/trackpad scroll inside the subfigure scrolls its content."
+        scrollable = true
+        "Speed of wheel/trackpad scrolling."
+        scroll_speed = 15.0
+        "Thickness in pixels of the scrollbar tracks shown when content overflows."
+        scrollbar_size = 8
+        "Background color of a scrollbar track."
+        scrollbar_color = RGBAf(0, 0, 0, 0.05)
+        "Color of the scrollbar thumb (the draggable handle)."
+        scrollbar_thumb_color = RGBAf(0, 0, 0, 0.3)
+        "Color of the scrollbar thumb when hovered or dragged."
+        scrollbar_thumb_color_active = RGBAf(0, 0, 0, 0.5)
+        "The height setting of the subfigure."
+        height = nothing
+        "The width setting of the subfigure."
+        width = nothing
+        "Controls if the parent layout can adjust to this element's width."
+        tellwidth = false
+        "Controls if the parent layout can adjust to this element's height."
+        tellheight = false
+        "The horizontal alignment of the subfigure in its suggested bounding box."
+        halign = :center
+        "The vertical alignment of the subfigure in its suggested bounding box."
+        valign = :center
+        "The alignment of the subfigure in its suggested bounding box."
+        alignmode = Inside()
+    end
+end
+
+
+"""
+    Tabs(fig_or_scene; labels = ["Tab 1", "Tab 2"], kwargs...)
+
+A tabbed container. Each tab is backed by a [`Subfigure`](@ref) with isolated
+events: place blocks with `tabs[i][row, col] = Axis(...)` or plot directly
+into `content_scene(tabs, i)`. Only the active tab is visible and only the
+active tab receives mouse / keyboard events. Content larger than the visible
+area scrolls vertically and horizontally.
 """
 @Block Tabs begin
-    scenes::Vector{Scene}
-    layouts::Vector{GridLayout}
-    scrolls::Vector{Observable{Vec2f}}
-    contentsizes::Vector{Observable{Vec2f}}
+    subfigures::Vector{Subfigure}
     @attributes begin
         "The labels of the tabs. The number of labels determines the number of tabs."
         labels = ["Tab 1", "Tab 2"]
@@ -1456,7 +1512,7 @@ Content larger than the visible area can be scrolled vertically and horizontally
         cornerradius = 0
         "Number of vertices used to render rounded tab corners."
         cornersegments = 10
-        "Background color of the active tab header. Should match the content area background for the cmux-style 'connected' look."
+        "Background color of the active tab header."
         tabcolor_active = :white
         "Background color of inactive tab headers."
         tabcolor_inactive = :white
@@ -1466,26 +1522,14 @@ Content larger than the visible area can be scrolled vertically and horizontally
         labelcolor_active = :black
         "Color of inactive tab labels."
         labelcolor_inactive = RGBf(0.4, 0.4, 0.4)
-        "Background color of the content area."
-        backgroundcolor = :transparent
         "Gap in pixels between adjacent tab headers."
         tabgap = 0
         "Color of the thin separator line drawn under the header strip (broken under the active tab)."
         separator_color = RGBf(0.82, 0.82, 0.82)
         "Thickness in pixels of the header bottom separator."
         separator_thickness = 1
-        "Padding (in pixels) around the content of each tab, as a number or a (left, right, bottom, top) tuple."
+        "Padding (in pixels) forwarded to each tab's content area."
         contentpadding = 10
-        "Speed of scrolling the content area."
-        scroll_speed = 15.0
-        "Thickness in pixels of the scrollbar tracks shown when content overflows."
-        scrollbar_size = 8
-        "Background color of a scrollbar track."
-        scrollbar_color = RGBAf(0, 0, 0, 0.05)
-        "Color of the scrollbar thumb (the draggable handle)."
-        scrollbar_thumb_color = RGBAf(0, 0, 0, 0.3)
-        "Color of the scrollbar thumb when hovered or dragged."
-        scrollbar_thumb_color_active = RGBAf(0, 0, 0, 0.5)
         "The height setting of the tabs block."
         height = nothing
         "The width setting of the tabs block."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1522,6 +1522,12 @@ area scrolls vertically and horizontally.
         labelcolor_active = :black
         "Color of inactive tab labels."
         labelcolor_inactive = RGBf(0.4, 0.4, 0.4)
+        "Whether a close (×) button is drawn on each tab. Clicking it removes that tab from `labels`."
+        closable = true
+        "Color of the close (×) icon when idle."
+        closecolor = RGBf(0.5, 0.5, 0.5)
+        "Color of the close (×) icon when hovered."
+        closecolor_hover = RGBf(0, 0, 0)
         "Gap in pixels between adjacent tab headers."
         tabgap = 0
         "Color of the thin separator line drawn under the header strip (broken under the active tab)."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1485,20 +1485,66 @@ end
 
 
 """
-    Tabs(fig_or_scene; labels = ["Tab 1", "Tab 2"], kwargs...)
+Resolved metrics of a tab label's font, in EM units (multiply by fontsize for
+pixels). Used to size and baseline-align the close `×`.
+"""
+struct TabFontMetrics
+    ascent::Float32
+    descent::Float32
+    x_height::Float32
+end
+
+"""
+Per-tab state for [`Tabs`](@ref): the tab's [`Subfigure`](@ref), its label and
+closability, and the observables backing its header rendering. One `TabData`
+exists per live tab, so closing a tab in the middle is a single `deleteat!` with
+nothing to keep in sync. Mutate via [`add_tab!`](@ref), [`remove_tab!`](@ref),
+[`set_tab!`](@ref) rather than directly.
+"""
+struct TabData
+    subfigure::Subfigure
+    label::Observable{Any}
+    closable::Observable{Bool}
+    visible::Observable{Bool}
+    rect::Observable{Rect2f}
+    bgcolor::Observable{RGBAf}
+    labelpos::Observable{Point2f}
+    labelcolor::Observable{RGBAf}
+    labelboundingboxes::Observable
+    close_segments::Observable{Vector{Point2f}}
+    close_color::Observable{RGBAf}
+    close_rect::Observable{Rect2f}
+    close_visible::Observable{Bool}
+    plots::Tuple{Any, Any, Any}  # (poly, label, close) for deletion
+end
+
+"""
+    Tabs(fig_or_scene, labels = ["Tab 1", "Tab 2"]; closable = true, kwargs...)
 
 A tabbed container. Each tab is backed by a [`Subfigure`](@ref) with isolated
 events: place blocks with `tabs[i][row, col] = Axis(...)` or plot directly
 into `content_scene(tabs, i)`. Only the active tab is visible and only the
 active tab receives mouse / keyboard events. Content larger than the visible
 area scrolls vertically and horizontally.
+
+`labels` (a positional argument) and the `closable` keyword seed the initial
+tabs; they are not reactive attributes. Change the set of tabs afterwards with
+the setter functions [`add_tab!`](@ref), [`remove_tab!`](@ref) and
+[`set_tab!`](@ref). `closable` may be a single `Bool` (applied to every initial
+tab) or a `Vector{Bool}` (one entry per tab; tabs beyond its length are not
+closable). The active tab is the scalar `active` attribute.
 """
 @Block Tabs begin
-    subfigures::Vector{Subfigure}
+    tabs::Vector{TabData}
+    content_area::Observable{Rect2i}
+    headerheight::Observable{Float64}
+    separator_path::Observable{Vector{Point2f}}
+    hovered::Observable{Int}
+    close_hovered::Observable{Int}
+    font_metrics::Observable{TabFontMetrics}
+    font_metrics_captured::Bool
     @attributes begin
-        "The labels of the tabs. The number of labels determines the number of tabs."
-        labels = ["Tab 1", "Tab 2"]
-        "Index of the active (visible) tab."
+        "Index of the active (visible) tab, or `0` when there are no tabs."
         active = 1
         "Height of the tab header strip in pixels, or `automatic` to derive it from the label size."
         tabheight = automatic
@@ -1522,8 +1568,6 @@ area scrolls vertically and horizontally.
         labelcolor_active = :black
         "Color of inactive tab labels."
         labelcolor_inactive = RGBf(0.4, 0.4, 0.4)
-        "Whether a close (×) button is drawn on each tab. Clicking it removes that tab from `labels`. Either a single `Bool` for all tabs, or a `Vector{Bool}` with one entry per tab (tabs beyond the vector's length are not closable)."
-        closable = true
         "Color of the close (×) icon when idle."
         closecolor = RGBf(0.5, 0.5, 0.5)
         "Color of the close (×) icon when hovered."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1421,6 +1421,89 @@ end
 end
 
 
+"""
+Tabs(fig_or_scene; labels = ["Tab 1", "Tab 2"], kwargs...)
+
+A tabbed container. Each tab owns its own content `Scene` paired with a
+`GridLayout`, so it behaves like a miniature `Figure`: place `Block`s with
+`tabs[i][row, col] = Axis(...)` or plot directly into `tabs[i]` / `content_scene(tabs, i)`.
+
+Only the active tab (selected via the `active` attribute or by clicking its
+header) is visible. Each content `Scene` is event-isolated: it owns its own
+`Events` object and receives mouse and keyboard input only while active, so
+hidden tabs and their plots never react to input (see [`forward_events!`](@ref)).
+Content larger than the visible area can be scrolled vertically and horizontally.
+"""
+@Block Tabs begin
+    scenes::Vector{Scene}
+    layouts::Vector{GridLayout}
+    scrolls::Vector{Observable{Vec2f}}
+    contentsizes::Vector{Observable{Vec2f}}
+    @attributes begin
+        "The labels of the tabs. The number of labels determines the number of tabs."
+        labels = ["Tab 1", "Tab 2"]
+        "Index of the active (visible) tab."
+        active = 1
+        "Height of the tab header strip in pixels, or `automatic` to derive it from the label size."
+        tabheight = automatic
+        "Font size of the tab labels."
+        fontsize = @inherit(:fontsize, 16.0f0)
+        "Font of the tab labels."
+        font = :regular
+        "Padding (left, right, bottom, top) around each tab label in pixels."
+        tabpadding = (12, 12, 8, 8)
+        "Corner radius of the tab header backgrounds."
+        cornerradius = 0
+        "Number of vertices used to render rounded tab corners."
+        cornersegments = 10
+        "Background color of the active tab header. Should match the content area background for the cmux-style 'connected' look."
+        tabcolor_active = :white
+        "Background color of inactive tab headers."
+        tabcolor_inactive = :white
+        "Background color of a hovered, inactive tab header (brief gray feedback while pointing/clicking)."
+        tabcolor_hover = RGBf(0.92, 0.92, 0.92)
+        "Color of the active tab label."
+        labelcolor_active = :black
+        "Color of inactive tab labels."
+        labelcolor_inactive = RGBf(0.4, 0.4, 0.4)
+        "Background color of the content area."
+        backgroundcolor = :transparent
+        "Gap in pixels between adjacent tab headers."
+        tabgap = 0
+        "Color of the thin separator line drawn under the header strip (broken under the active tab)."
+        separator_color = RGBf(0.82, 0.82, 0.82)
+        "Thickness in pixels of the header bottom separator."
+        separator_thickness = 1
+        "Padding (in pixels) around the content of each tab, as a number or a (left, right, bottom, top) tuple."
+        contentpadding = 10
+        "Speed of scrolling the content area."
+        scroll_speed = 15.0
+        "Thickness in pixels of the scrollbar tracks shown when content overflows."
+        scrollbar_size = 8
+        "Background color of a scrollbar track."
+        scrollbar_color = RGBAf(0, 0, 0, 0.05)
+        "Color of the scrollbar thumb (the draggable handle)."
+        scrollbar_thumb_color = RGBAf(0, 0, 0, 0.3)
+        "Color of the scrollbar thumb when hovered or dragged."
+        scrollbar_thumb_color_active = RGBAf(0, 0, 0, 0.5)
+        "The height setting of the tabs block."
+        height = nothing
+        "The width setting of the tabs block."
+        width = nothing
+        "Controls if the parent layout can adjust to this element's width."
+        tellwidth = false
+        "Controls if the parent layout can adjust to this element's height."
+        tellheight = false
+        "The horizontal alignment of the block in its suggested bounding box."
+        halign = :center
+        "The vertical alignment of the block in its suggested bounding box."
+        valign = :center
+        "The alignment of the block in its suggested bounding box."
+        alignmode = Inside()
+    end
+end
+
+
 abstract type LegendElement end
 
 struct LineElement <: LegendElement

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -1522,7 +1522,7 @@ area scrolls vertically and horizontally.
         labelcolor_active = :black
         "Color of inactive tab labels."
         labelcolor_inactive = RGBf(0.4, 0.4, 0.4)
-        "Whether a close (×) button is drawn on each tab. Clicking it removes that tab from `labels`."
+        "Whether a close (×) button is drawn on each tab. Clicking it removes that tab from `labels`. Either a single `Bool` for all tabs, or a `Vector{Bool}` with one entry per tab (tabs beyond the vector's length are not closable)."
         closable = true
         "Color of the close (×) icon when idle."
         closecolor = RGBf(0.5, 0.5, 0.5)

--- a/Makie/src/scenes.jl
+++ b/Makie/src/scenes.jl
@@ -474,6 +474,14 @@ function effective_clip(scene::Scene)
         s = parent(s)
         rect = intersect(rect, viewport(s)[])
     end
+    # `intersect` on `Rect2i` returns negative widths for disjoint rects, which
+    # turns `glScissor` into `GL_INVALID_VALUE` (and Cairo's clip into a no-op).
+    # Clamp to an empty rect at the intersection origin so callers get a sane
+    # "draw nothing" instead.
+    w = widths(rect)
+    if w[1] < 0 || w[2] < 0
+        return Rect2i(minimum(rect), Vec2i(0, 0))
+    end
     return rect
 end
 

--- a/Makie/src/scenes.jl
+++ b/Makie/src/scenes.jl
@@ -454,47 +454,27 @@ function scene_visible(scene::Scene)
 end
 
 """
-    effective_viewport(scene::Scene)::Rect2i
+    effective_clip(scene::Scene)::Rect2i
 
-The intersection of `scene`'s viewport with every ancestor's viewport. Backends
-should use this — not `viewport(scene)` — to set the scissor rectangle for
-rendering, so a scene whose content extends past an ancestor's viewport gets
-clipped at the ancestor (e.g. a scrollable container clipping its overflowing
-contents). Returns a `Rect2i`; the rect may be empty when there is no overlap.
+Intersection of every ancestor's viewport (not including `scene`'s own).
+Backends use this as the scissor rectangle, so a scene is rendered only within
+the bounds shared by every one of its parents. The scene's own viewport is
+not part of the intersection — that lets plots near a scene's edge (e.g. axis
+markers near the spines) extend past the scene's own viewport, while still
+being clipped at the smallest enclosing ancestor.
+
+For the root scene the intersection is empty; the root's own viewport is
+returned so the scissor matches the window.
 """
-function effective_viewport(scene::Scene)
-    rect = viewport(scene)[]
-    s = scene
+function effective_clip(scene::Scene)
+    isroot(scene) && return viewport(scene)[]
+    s = parent(scene)
+    rect = viewport(s)[]
     while !isroot(s)
         s = parent(s)
         rect = intersect(rect, viewport(s)[])
     end
     return rect
-end
-
-"""
-    needs_ancestor_clip(scene::Scene)::Bool
-
-`true` when an ancestor's viewport actually clips this scene's viewport — i.e.
-`effective_viewport(scene)` is strictly smaller than `viewport(scene)`. Backends
-can use this to skip scissor setup for scenes that fit within all their
-ancestors, preserving the existing "no-scissor" rendering for those scenes
-(markers that extend beyond axis edges, etc.).
-"""
-function needs_ancestor_clip(scene::Scene)
-    own = viewport(scene)[]
-    own_min, own_max = minimum(own), maximum(own)
-    s = scene
-    while !isroot(s)
-        s = parent(s)
-        pa = viewport(s)[]
-        # element-wise containment: `<=`/`>=` on `Vec` is lexicographic, not
-        # per-component, so we need `all(.<=)` / `all(.>=)` here
-        if !(all(minimum(pa) .<= own_min) && all(maximum(pa) .>= own_max))
-            return true
-        end
-    end
-    return false
 end
 
 GeometryBasics.widths(scene::Scene) = widths(to_value(viewport(scene)))

--- a/Makie/src/scenes.jl
+++ b/Makie/src/scenes.jl
@@ -436,6 +436,67 @@ function root(scene::Scene)
 end
 parent_or_self(scene::Scene) = isroot(scene) ? scene : parent(scene)
 
+"""
+    scene_visible(scene::Scene)
+
+Effective visibility of `scene`: `true` only if `scene` and all of its ancestors
+are visible. Unlike `scene.visible[]`, this cascades down the scene tree, so a
+scene nested under an invisible ancestor counts as hidden even when its own
+`visible[]` is `true` (as happens when a `Block` force-shows its own scene).
+"""
+function scene_visible(scene::Scene)
+    while true
+        scene.visible[] || return false
+        isroot(scene) && return true
+        scene = parent(scene)
+    end
+    return
+end
+
+"""
+    effective_viewport(scene::Scene)::Rect2i
+
+The intersection of `scene`'s viewport with every ancestor's viewport. Backends
+should use this — not `viewport(scene)` — to set the scissor rectangle for
+rendering, so a scene whose content extends past an ancestor's viewport gets
+clipped at the ancestor (e.g. a scrollable container clipping its overflowing
+contents). Returns a `Rect2i`; the rect may be empty when there is no overlap.
+"""
+function effective_viewport(scene::Scene)
+    rect = viewport(scene)[]
+    s = scene
+    while !isroot(s)
+        s = parent(s)
+        rect = intersect(rect, viewport(s)[])
+    end
+    return rect
+end
+
+"""
+    needs_ancestor_clip(scene::Scene)::Bool
+
+`true` when an ancestor's viewport actually clips this scene's viewport — i.e.
+`effective_viewport(scene)` is strictly smaller than `viewport(scene)`. Backends
+can use this to skip scissor setup for scenes that fit within all their
+ancestors, preserving the existing "no-scissor" rendering for those scenes
+(markers that extend beyond axis edges, etc.).
+"""
+function needs_ancestor_clip(scene::Scene)
+    own = viewport(scene)[]
+    own_min, own_max = minimum(own), maximum(own)
+    s = scene
+    while !isroot(s)
+        s = parent(s)
+        pa = viewport(s)[]
+        # element-wise containment: `<=`/`>=` on `Vec` is lexicographic, not
+        # per-component, so we need `all(.<=)` / `all(.>=)` here
+        if !(all(minimum(pa) .<= own_min) && all(maximum(pa) .>= own_max))
+            return true
+        end
+    end
+    return false
+end
+
 GeometryBasics.widths(scene::Scene) = widths(to_value(viewport(scene)))
 
 Base.size(scene::Scene) = Tuple(widths(scene))

--- a/Makie/test/events_isolation.jl
+++ b/Makie/test/events_isolation.jl
@@ -70,7 +70,7 @@ end
 
 @testset "Tabs event isolation" begin
     f = Figure()
-    t = Tabs(f[1, 1]; labels = ["A", "B"])
+    t = Tabs(f[1, 1], ["A", "B"])
     s1, s2 = content_scene(t, 1), content_scene(t, 2)
     @test events(s1) !== events(f.scene)
     @test events(s2) !== events(s1)
@@ -90,15 +90,12 @@ end
     @test counts[2] == before[2] + 1
 end
 
-@testset "Tabs closable" begin
-    @test Makie._tab_closable(true, 1)
-    @test !Makie._tab_closable(false, 2)
-    @test Makie._tab_closable([true, false], 1)
-    @test !Makie._tab_closable([true, false], 2)
-    @test !Makie._tab_closable([true, false], 3)   # out of range -> not closable
+labels_of(t) = [td.label[] for td in t.tabs]
+closable_of(t) = [td.closable[] for td in t.tabs]
 
+@testset "Tabs closable" begin
     f = Figure()
-    t = Tabs(f[1, 1]; labels = ["A", "B", "C"], closable = [true, false, true])
+    t = Tabs(f[1, 1], ["A", "B", "C"]; closable = [true, false, true])
     scenes0 = [content_scene(t, i) for i in 1:3]
 
     # click the center of tab `slot`'s close glyph (the LineSegments plots are
@@ -115,9 +112,40 @@ end
     end
 
     click_close(1)   # close "A"
-    @test t.labels[] == ["B", "C"]
-    @test t.closable[] == [false, true]          # vector stays aligned
+    @test labels_of(t) == ["B", "C"]
+    @test closable_of(t) == [false, true]        # per-tab state stays aligned
     # reindex: remaining tabs map to their original content scenes
     @test content_scene(t, 1) === scenes0[2]
     @test content_scene(t, 2) === scenes0[3]
+end
+
+@testset "Tabs setter API" begin
+    f = Figure()
+    t = Tabs(f[1, 1], ["A", "B"])
+    @test length(t) == 2
+    @test t.active[] == 1
+
+    sf = add_tab!(t, "C"; activate = true)
+    @test length(t) == 3
+    @test labels_of(t) == ["A", "B", "C"]
+    @test t.active[] == 3
+    @test content_scene(t, 3) === sf.scene
+
+    set_tab!(t, 3; label = "Z")
+    @test labels_of(t) == ["A", "B", "Z"]
+
+    set_tab!(t, 1; closable = false)
+    @test closable_of(t) == [false, true, true]
+
+    remove_tab!(t, 3)
+    @test length(t) == 2
+    @test t.active[] == 2                         # clamped down from removed tab
+
+    remove_tab!(t, 1)
+    remove_tab!(t, 1)
+    @test length(t) == 0
+    @test t.active[] == 0                         # no tabs -> no active tab
+
+    add_tab!(t, "back")
+    @test t.active[] == 1                         # first tab on empty becomes active
 end

--- a/Makie/test/events_isolation.jl
+++ b/Makie/test/events_isolation.jl
@@ -125,13 +125,14 @@ end
     @test length(t) == 2
     @test t.active[] == 1
 
-    sf = add_tab!(t, "C"; activate = true)
+    sf = add_tab!(t, "C"; activate = true, closable = false)   # closable forwarded to set_tab!
     @test length(t) == 3
     @test labels_of(t) == ["A", "B", "C"]
     @test t.active[] == 3
     @test content_scene(t, 3) === sf.scene
+    @test closable_of(t) == [true, true, false]
 
-    set_tab!(t, 3; label = "Z")
+    set_tab!(t, 3; label = "Z", closable = true)
     @test labels_of(t) == ["A", "B", "Z"]
 
     set_tab!(t, 1; closable = false)

--- a/Makie/test/events_isolation.jl
+++ b/Makie/test/events_isolation.jl
@@ -89,3 +89,35 @@ end
     @test counts[1] == before[1]
     @test counts[2] == before[2] + 1
 end
+
+@testset "Tabs closable" begin
+    @test Makie._tab_closable(true, 1)
+    @test !Makie._tab_closable(false, 2)
+    @test Makie._tab_closable([true, false], 1)
+    @test !Makie._tab_closable([true, false], 2)
+    @test !Makie._tab_closable([true, false], 3)   # out of range -> not closable
+
+    f = Figure()
+    t = Tabs(f[1, 1]; labels = ["A", "B", "C"], closable = [true, false, true])
+    scenes0 = [content_scene(t, i) for i in 1:3]
+
+    # click the center of tab `slot`'s close glyph (the LineSegments plots are
+    # the close ×s, in tab order; the separator is a `Lines`, not LineSegments)
+    function click_close(slot)
+        cps = filter(p -> p isa Makie.LineSegments, t.blockscene.plots)
+        seg = cps[slot].positions[]
+        cx = sum(p -> p[1], seg) / length(seg)
+        cy = sum(p -> p[2], seg) / length(seg)
+        e = t.blockscene.events
+        e.mouseposition[] = (Float64(cx), Float64(cy))
+        e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.press)
+        return e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.release)
+    end
+
+    click_close(1)   # close "A"
+    @test t.labels[] == ["B", "C"]
+    @test t.closable[] == [false, true]          # vector stays aligned
+    # reindex: remaining tabs map to their original content scenes
+    @test content_scene(t, 1) === scenes0[2]
+    @test content_scene(t, 2) === scenes0[3]
+end

--- a/Makie/test/events_isolation.jl
+++ b/Makie/test/events_isolation.jl
@@ -1,0 +1,91 @@
+using Makie
+using Makie: forward_events!, MouseButtonEvent, KeyEvent, Mouse, Keyboard, Events
+using Test
+
+@testset "forward_events! isolation" begin
+    root = Scene()
+    active = Observable(true)
+    target = Scene(root; events = Events(), viewport = Rect2i(0, 0, 100, 100))
+    @test events(target) !== events(root)
+    forward_events!(target, root; active = active)
+
+    @testset "context events always forwarded" begin
+        root.events.window_dpi[] = 123.0
+        @test target.events.window_dpi[] == 123.0
+        active[] = false
+        root.events.window_dpi[] = 200.0
+        @test target.events.window_dpi[] == 200.0
+        active[] = true
+    end
+
+    @testset "input gated by active" begin
+        root.events.mouseposition[] = (10.0, 10.0)
+        @test target.events.mouseposition[] == (10.0, 10.0)
+
+        active[] = false
+        root.events.mouseposition[] = (20.0, 20.0)
+        @test target.events.mouseposition[] == (10.0, 10.0)
+
+        active[] = true
+        root.events.mouseposition[] = (30.0, 30.0)
+        @test target.events.mouseposition[] == (30.0, 30.0)
+    end
+
+    @testset "keyboard gated by active" begin
+        got = Ref(0)
+        on(target.events.keyboardbutton) do _
+            got[] += 1
+            return Consume(false)
+        end
+        active[] = true
+        root.events.keyboardbutton[] = KeyEvent(Keyboard.a, Keyboard.press)
+        root.events.keyboardbutton[] = KeyEvent(Keyboard.a, Keyboard.release)
+        @test got[] == 2
+
+        active[] = false
+        before = got[]
+        root.events.keyboardbutton[] = KeyEvent(Keyboard.b, Keyboard.press)
+        @test got[] == before
+    end
+
+    @testset "Consume propagates back to source" begin
+        active[] = true
+        on(target.events.mousebutton; priority = 10) do _
+            return Consume(true)
+        end
+        consumed = setindex!(root.events.mousebutton, MouseButtonEvent(Mouse.left, Mouse.press))
+        @test consumed == true
+    end
+
+    @testset "held inputs released on deactivation" begin
+        active[] = true
+        empty!(root.events.mousebuttonstate)
+        empty!(target.events.mousebuttonstate)
+        root.events.mousebutton[] = MouseButtonEvent(Mouse.right, Mouse.press)
+        @test Mouse.right in target.events.mousebuttonstate
+        active[] = false
+        @test isempty(target.events.mousebuttonstate)
+    end
+end
+
+@testset "Tabs event isolation" begin
+    f = Figure()
+    t = Tabs(f[1, 1]; labels = ["A", "B"])
+    s1, s2 = content_scene(t, 1), content_scene(t, 2)
+    @test events(s1) !== events(f.scene)
+    @test events(s2) !== events(s1)
+
+    counts = [0, 0]
+    on(_ -> (counts[1] += 1; Consume(false)), events(s1).keyboardbutton)
+    on(_ -> (counts[2] += 1; Consume(false)), events(s2).keyboardbutton)
+
+    t.active[] = 1
+    f.scene.events.keyboardbutton[] = KeyEvent(Keyboard.a, Keyboard.press)
+    @test counts == [1, 0]
+
+    t.active[] = 2
+    before = copy(counts)
+    f.scene.events.keyboardbutton[] = KeyEvent(Keyboard.b, Keyboard.press)
+    @test counts[1] == before[1]
+    @test counts[2] == before[2] + 1
+end

--- a/Makie/test/runtests.jl
+++ b/Makie/test/runtests.jl
@@ -55,6 +55,7 @@ end
         include("SceneLike/figures.jl")
         include("SceneLike/makielayout.jl")
         include("SceneLike/PolarAxis.jl")
+        include("events_isolation.jl")
     end
 
     @testset "Conversion & Projection Pipeline" begin

--- a/docs/fake_interaction.jl
+++ b/docs/fake_interaction.jl
@@ -15,6 +15,7 @@ export KeyPress
 export KeyDown, KeyUp
 export Lazy
 export Wait
+export Scroll
 export relative_pos
 export textbox_offset_pos
 
@@ -189,6 +190,27 @@ duration(::KeyUp, _) = 0.0
 keyboardevents_start(k::KeyUp) = [Makie.KeyEvent(k.key, Keyboard.release)]
 
 
+"""
+    Scroll(delta; duration = 0.8)
+
+Emits `events.scroll` events over `duration` seconds so that the totals sum to
+`delta` (a `(dx, dy)` tuple in scroll units). Use to animate a wheel/trackpad
+scroll over a scrollable container.
+"""
+struct Scroll
+    delta::Tuple{Float64, Float64}
+    duration::Float64
+end
+Scroll(delta; duration = 0.8) = Scroll(Tuple(Float64.(delta)), duration)
+duration(s::Scroll, _) = s.duration
+
+function scrollevents_frame(s::Scroll, time, prev_time)
+    s.duration <= 0 && return []
+    frac = (time - prev_time) / s.duration
+    frac <= 0 && return []
+    return [Tuple(frac .* s.delta)]
+end
+
 mouseevents_start(obj) = []
 mouseevents_end(obj) = []
 mouseevents_frame(obj, t) = []
@@ -198,6 +220,7 @@ mousepositions_frame(obj, startpos, t) = []
 keyboardevents_start(obj) = []
 keyboardevents_end(obj) = []
 unicode_inputs_frame(obj, time, prev_time) = []
+scrollevents_frame(obj, time, prev_time) = []
 
 function alpha_blend(fg::Makie.RGBA, bg::Makie.RGB)
     r = (fg.r * fg.alpha + bg.r * (1 - fg.alpha))
@@ -301,6 +324,9 @@ function interaction_record(func, figlike, filepath, events::AbstractVector; fps
                 end
                 for c in unicode_inputs_frame(event, t_in_event, prev_t_in_event)
                     content_scene.events.unicode_input[] = c
+                end
+                for sc in scrollevents_frame(event, t_in_event, prev_t_in_event)
+                    content_scene.events.scroll[] = sc
                 end
                 prev_t_in_event = t_in_event
 

--- a/docs/src/reference/blocks/tabs.md
+++ b/docs/src/reference/blocks/tabs.md
@@ -47,6 +47,20 @@ nothing # hide
 ```@setup tabs
 using ..FakeInteraction
 
+# Find a tab's label center and close-button center by inspecting the plots
+# that `Tabs` adds to its blockscene (one `Text` per label, one `LineSegments`
+# per close ×, in tab order). This stays in sync with the actual rendered
+# layout without poking new fields into `Tabs`.
+function tab_label_center(tabs, i)
+    plots = filter(p -> p isa Makie.Text, tabs.blockscene.plots)
+    return Point2f(plots[i].positions[][1])
+end
+function tab_close_center(tabs, i)
+    plots = filter(p -> p isa Makie.LineSegments, tabs.blockscene.plots)
+    seg = plots[i].positions[]
+    return Point2f(sum(p -> p[1], seg) / length(seg), sum(p -> p[2], seg) / length(seg))
+end
+
 function vbar_thumb_center(sf)
     ca = sf.scene.viewport[]
     cs = sf.contentsize[][2]
@@ -62,20 +76,14 @@ end
 
 events = [
     Wait(1.0),
-    Lazy() do fig
-        MouseTo(relative_pos(tabs, (0.18, 0.94)))  # over tab 2 header
-    end,
+    Lazy() do fig MouseTo(tab_label_center(tabs, 2)) end,    # over tab 2 ("Wide")
     LeftClick(),
     Wait(1.0),
-    Lazy() do fig
-        MouseTo(relative_pos(tabs, (0.28, 0.94)))  # over tab 3 header
-    end,
+    Lazy() do fig MouseTo(tab_label_center(tabs, 3)) end,    # over tab 3 ("Tall")
     LeftClick(),
     Wait(0.4),
-    # grab the vertical scrollbar thumb and drag down
-    Lazy() do fig
-        MouseTo(vbar_thumb_center(tabs.subfigures[3]))
-    end,
+    # Grab the vertical scrollbar thumb and drag it down.
+    Lazy() do fig MouseTo(vbar_thumb_center(tabs.subfigures[3])) end,
     LeftDown(),
     Lazy() do fig
         sf = tabs.subfigures[3]
@@ -83,19 +91,23 @@ events = [
         MouseTo(Point2f(right(ca) - 4, bottom(ca) + 60), 1.5)
     end,
     LeftUp(),
-    Wait(0.3),
-    # grab the thumb at its new lower position and drag back up
-    Lazy() do fig
-        MouseTo(vbar_thumb_center(tabs.subfigures[3]))
-    end,
-    LeftDown(),
+    Wait(0.5),
+    # Move into the (now-visible) bottom row's axis and zoom it with the
+    # wheel — Tabs lets the axis consume scroll first when the cursor is
+    # inside, so this demonstrates per-tab interactivity.
     Lazy() do fig
         sf = tabs.subfigures[3]
         ca = sf.scene.viewport[]
-        MouseTo(Point2f(right(ca) - 4, top(ca) - 12), 1.2)
+        MouseTo(Point2f(left(ca) + 0.45 * widths(ca)[1], bottom(ca) + 0.2 * widths(ca)[2]))
     end,
-    LeftUp(),
-    Wait(0.6),
+    Scroll((0.0, -3.0); duration = 0.5),             # zoom in
+    Wait(0.5),
+    # Close the "Wide" tab via its × button. Small pause after landing so
+    # the click doesn't feel instantaneous.
+    Lazy() do fig MouseTo(tab_close_center(tabs, 2)) end,
+    Wait(0.3),
+    LeftClick(),
+    Wait(1.5),
 ]
 
 interaction_record(fig, "tabs_example.mp4", events)

--- a/docs/src/reference/blocks/tabs.md
+++ b/docs/src/reference/blocks/tabs.md
@@ -14,7 +14,7 @@ GLMakie.activate!() # hide
 
 fig = Figure(size = (700, 450))
 
-tabs = Tabs(fig[1, 1]; labels = ["Single axis", "Wide", "Tall"])
+tabs = Tabs(fig[1, 1], ["Single axis", "Wide", "Tall"])
 
 # Tab 1 — a single axis
 scatter!(
@@ -83,10 +83,10 @@ events = [
     LeftClick(),
     Wait(0.4),
     # Grab the vertical scrollbar thumb and drag it down.
-    Lazy() do fig MouseTo(vbar_thumb_center(tabs.subfigures[3])) end,
+    Lazy() do fig MouseTo(vbar_thumb_center(tabs[3])) end,
     LeftDown(),
     Lazy() do fig
-        sf = tabs.subfigures[3]
+        sf = tabs[3]
         ca = sf.scene.viewport[]
         MouseTo(Point2f(right(ca) - 4, bottom(ca) + 60), 1.5)
     end,
@@ -96,7 +96,7 @@ events = [
     # wheel — Tabs lets the axis consume scroll first when the cursor is
     # inside, so this demonstrates per-tab interactivity.
     Lazy() do fig
-        sf = tabs.subfigures[3]
+        sf = tabs[3]
         ca = sf.scene.viewport[]
         MouseTo(Point2f(left(ca) + 0.45 * widths(ca)[1], bottom(ca) + 0.2 * widths(ca)[2]))
     end,

--- a/docs/src/reference/blocks/tabs.md
+++ b/docs/src/reference/blocks/tabs.md
@@ -1,0 +1,113 @@
+# Tabs
+
+A tabbed container. Each tab is backed by a [`Subfigure`](@ref) with isolated
+events: only the active tab is visible, and only the active tab receives
+mouse and keyboard input. Place blocks with `tabs[i][row, col] = Axis(...)`
+or plot directly into `content_scene(tabs, i)`. Content larger than the
+visible area scrolls vertically and horizontally; scrollbars appear only when
+there is overflow.
+
+```@example tabs
+using GLMakie
+import Makie.GridLayoutBase as GLB
+GLMakie.activate!() # hide
+
+fig = Figure(size = (700, 450))
+
+tabs = Tabs(fig[1, 1]; labels = ["Single axis", "Wide", "Tall"])
+
+# Tab 1 — a single axis
+scatter!(
+    Axis(tabs[1][1, 1], title = "Drag to pan, scroll to zoom"),
+    randn(150), randn(150), color = 1:150, colormap = :viridis
+)
+
+# Tab 2 — three Fixed-width axes side by side → horizontal scroll
+for (col, sym) in enumerate((:tomato, :steelblue, :seagreen))
+    ax = Axis(tabs[2][1, col], title = "col $col")
+    scatter!(ax, randn(60), randn(60), color = sym)
+end
+GLB.colsize!(tabs[2].layout, 1, GLB.Fixed(300))
+GLB.colsize!(tabs[2].layout, 2, GLB.Fixed(300))
+GLB.colsize!(tabs[2].layout, 3, GLB.Fixed(300))
+
+# Tab 3 — three Fixed-height axes stacked → vertical scroll
+for (row, sym) in enumerate((:tomato, :steelblue, :seagreen))
+    ax = Axis(tabs[3][row, 1], title = "row $row")
+    lines!(ax, 1:50, cumsum(randn(50)), color = sym)
+end
+GLB.rowsize!(tabs[3].layout, 1, GLB.Fixed(180))
+GLB.rowsize!(tabs[3].layout, 2, GLB.Fixed(180))
+GLB.rowsize!(tabs[3].layout, 3, GLB.Fixed(180))
+
+fig
+nothing # hide
+```
+
+```@setup tabs
+using ..FakeInteraction
+
+function vbar_thumb_center(sf)
+    ca = sf.scene.viewport[]
+    cs = sf.contentsize[][2]
+    vh = widths(ca)[2]
+    ch = max(cs, vh)
+    thumb_h = max(20.0, vh^2 / ch)
+    max_sy = max(0.0, ch - vh)
+    usable = vh - thumb_h
+    sc_y = sf.scroll[][2]
+    ty = top(ca) - thumb_h - (sc_y / max_sy) * usable
+    return Point2f(right(ca) - 4, ty + thumb_h / 2)
+end
+
+events = [
+    Wait(1.0),
+    Lazy() do fig
+        MouseTo(relative_pos(tabs, (0.18, 0.94)))  # over tab 2 header
+    end,
+    LeftClick(),
+    Wait(1.0),
+    Lazy() do fig
+        MouseTo(relative_pos(tabs, (0.28, 0.94)))  # over tab 3 header
+    end,
+    LeftClick(),
+    Wait(0.4),
+    # grab the vertical scrollbar thumb and drag down
+    Lazy() do fig
+        MouseTo(vbar_thumb_center(tabs.subfigures[3]))
+    end,
+    LeftDown(),
+    Lazy() do fig
+        sf = tabs.subfigures[3]
+        ca = sf.scene.viewport[]
+        MouseTo(Point2f(right(ca) - 4, bottom(ca) + 60), 1.5)
+    end,
+    LeftUp(),
+    Wait(0.3),
+    # grab the thumb at its new lower position and drag back up
+    Lazy() do fig
+        MouseTo(vbar_thumb_center(tabs.subfigures[3]))
+    end,
+    LeftDown(),
+    Lazy() do fig
+        sf = tabs.subfigures[3]
+        ca = sf.scene.viewport[]
+        MouseTo(Point2f(right(ca) - 4, top(ca) - 12), 1.2)
+    end,
+    LeftUp(),
+    Wait(0.6),
+]
+
+interaction_record(fig, "tabs_example.mp4", events)
+```
+
+```@raw html
+<video autoplay loop muted playsinline src="./tabs_example.mp4" width="700"/>
+```
+
+
+## Attributes
+
+```@attrdocs
+Tabs
+```

--- a/docs/src/reference/blocks/tabs.md
+++ b/docs/src/reference/blocks/tabs.md
@@ -118,6 +118,42 @@ interaction_record(fig, "tabs_example.mp4", events)
 ```
 
 
+## Modifying tabs at runtime
+
+Change the set of tabs with `add_tab!`, `remove_tab!` and `set_tab!`, and switch
+the visible tab with the `active` attribute.
+
+```@example tabs_runtime
+using GLMakie
+GLMakie.activate!() # hide
+
+fig = Figure(size = (700, 300))
+tabs = Tabs(fig[1, 1], ["First"])
+lines(tabs[1][1, 1], cumsum(randn(100)))
+
+# `add_tab!` returns the new tab's Subfigure, so you can plot into it directly.
+sf = add_tab!(tabs, "Second"; activate = true)
+scatter(sf[1, 1], randn(50), randn(50))
+
+# A third tab, populated via the `tabs[i]` accessor instead.
+add_tab!(tabs, "Third")
+heatmap(tabs[3][1, 1], randn(20, 20))
+
+# Change properties of an existing tab; omitted keywords are left unchanged.
+set_tab!(tabs, 1; label = "Renamed", closable = false)
+
+# Remove a tab; `active` reindexes to a neighbour automatically.
+remove_tab!(tabs, 2)
+
+tabs.active[] = 1
+fig
+```
+
+In an interactive window these are typically wired to widgets — e.g. an "add
+view" `Button` whose callback calls `add_tab!` — or driven by your application
+logic. Closing a tab through its `×` button calls `remove_tab!` for you.
+
+
 ## Attributes
 
 ```@attrdocs


### PR DESCRIPTION
Adds two new blocks: `Tabs` and the `Subfigure` it's built on.

`Subfigure` is a clipped, scrollable, optionally event-isolated region pairing a `Scene` with a `GridLayout` — the same shape as a `Figure`, scoped to a sub-region. `Tabs` stacks one `Subfigure` per tab and shows only the active one: only the active tab receives mouse/keyboard input, and content larger than the tab area scrolls (scrollbars appear on overflow).

https://github.com/user-attachments/assets/0155b975-cb86-42e9-b6e1-966b2aeb16a9

Place blocks with `tabs[i][row, col]`, or plot straight into a tab's scene with `content_scene(tabs, i)`:

```julia
tabs = Tabs(fig[1, 1], ["Overview", "Details"])
lines(tabs[1][1, 1], cumsum(randn(100)))
scatter(tabs[2][1, 1], randn(50), randn(50))
```

The set of tabs is changed at runtime with `add_tab!`, `remove_tab!` and `set_tab!`; the visible tab is the `active` attribute. `labels` is a positional construction argument and `closable` (a `Bool`, or a per-tab `Vector{Bool}`) controls the close × button.

Making an inactive/hidden subtree actually behave as hidden needed a few scene-level additions, which are independently useful:

- `forward_events!(target, source; active)` — give a subtree its own `Events` and forward the parent's into it, gated on `active`. Context events (tick, window size, …) always pass through; input events only while active, and held buttons/keys are released on deactivation.
- `scene_visible(scene)` — effective visibility that returns `false` when any ancestor is hidden, unlike `scene.visible[]` (which a `Block` force-sets on its own scene). Backends now gate rendering on this.
- `effective_clip(scene)` — clips each scene to the intersection of its ancestors' viewports, so a tab's content is cut off at the container edge. Replaces the old `effective_viewport`/`needs_ancestor_clip` pair.
- `campixel!` is now window-pixel-absolute, so a campixel scene's coordinates map to absolute window pixels regardless of where the scene sits. This ripples into `Button`/`Menu`/`Textbox`/`EditableText` anchoring.

Targets `ff/breaking-0.25`.
