### PR TITLE
Validate Figure keyword attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Menu and Toggle now immediately changed their color when updated via an Observable [5588](https://github.com/MakieOrg/Makie.jl/pull/5588)
 - Added `convert_arguments` method for one dimensional `StatsBase.Histogram` for `Stairs` [#5631](https://github.com/MakieOrg/Makie.jl/pull/5631)
+- Fixed invalid `Figure` keyword arguments being silently added to the scene theme [#5653](https://github.com/MakieOrg/Makie.jl/pull/5653).
 - Added an `Base.iterate` for `FigureAxis` so that can be splashed in code as well [#5646](https://github.com/MakieOrg/Makie.jl/pull/5646).
 - Fixed `center!` (and therefore `reset_limits!` in `LScene`) crashing with empty, NaN or zero-width content [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).
 - Fixed `FastPixel` scatter crash when markers are clipped in GLMakie [#5634](https://github.com/MakieOrg/Makie.jl/pull/5634).

--- a/Makie/src/figures.jl
+++ b/Makie/src/figures.jl
@@ -116,9 +116,50 @@ one number or a tuple of four numbers for left, right, bottom and top paddings v
 All other keyword arguments such as `size` and `backgroundcolor` are forwarded to the
 [`Scene`](@ref) owned by the figure which acts as the container for all other visual objects.
 """
+function InvalidAttributeError(::Type{Figure}, attributes::Set{Symbol})
+    return InvalidAttributeError(Figure, "figure", attributes)
+end
+
+function attribute_names(::Type{Figure})
+    scene_keywords = (
+        :viewport,
+        :events,
+        :clear,
+        :transform_func,
+        :camera,
+        :camera_controls,
+        :transformation,
+        :plots,
+        :children,
+        :current_screens,
+        :parent,
+        :visible,
+        :ssao,
+        :lights,
+        :theme,
+        :deregister_callbacks,
+    )
+    return union(keys(current_default_theme()), scene_keywords, (:figure_padding, :resolution))
+end
+
+function is_attribute(::Type{Figure}, sym::Symbol)
+    return sym in attribute_names(Figure) ||
+        !isnothing(symbol_to_block(sym)) ||
+        !isnothing(symbol_to_plot(sym))
+end
+
+function _check_figure_kwargs(kwdict::Dict)
+    badnames = Set{Symbol}(key for key in keys(kwdict) if !is_attribute(Figure, key))
+    if !isempty(badnames)
+        throw(InvalidAttributeError(Figure, badnames))
+    end
+    return
+end
+
 function Figure(; kwargs...)
 
     kwargs_dict = Dict(kwargs)
+    _check_figure_kwargs(kwargs_dict)
     padding = pop!(kwargs_dict, :figure_padding, theme(:figure_padding))
     scene = Scene(; camera = campixel!, clear = true, kwargs_dict...)
     padding = convert(Observable{Any}, padding)

--- a/Makie/test/pipeline.jl
+++ b/Makie/test/pipeline.jl
@@ -150,7 +150,8 @@ end
 
 import Makie:
     InvalidAttributeError,
-    attribute_names
+    attribute_names,
+    is_attribute
 import Makie: _attribute_docs
 
 @testset "validated attributes" begin
@@ -232,6 +233,22 @@ end
     @test :default in attribute_names(Menu)
     @test :entrygroups in attribute_names(Legend)
     @test :palette in attribute_names(PolarAxis)
+end
+
+@testset "validated attributes for figures" begin
+    err = InvalidAttributeError(Figure, Set{Symbol}())
+    @test err.object_name == "figure"
+
+    @test :figure_padding in attribute_names(Figure)
+    @test :size in attribute_names(Figure)
+    @test :backgroundcolor in attribute_names(Figure)
+    @test is_attribute(Figure, :Legend)
+
+    @test Figure(size = (100, 100), backgroundcolor = :white, figure_padding = 0) isa Figure
+    @test Figure(Legend = (; margin = (1, 2, 3, 4))) isa Figure
+    @test_throws InvalidAttributeError Figure(does_not_exist = 123)
+    @test_throws InvalidAttributeError Figure(title = "not a figure attribute")
+    @test_throws InvalidAttributeError lines(1:10, figure = (does_not_exist = 123,))
 end
 
 @testset "func2string" begin


### PR DESCRIPTION
## Summary
- add validation for unknown `Figure(...)` keyword arguments using the existing `InvalidAttributeError` path
- expose valid `Figure` attribute names from current theme keys plus supported scene/figure keywords
- add regression coverage for direct `Figure(...)` kwargs and `plot(..., figure = (...))` kwargs

Addresses the remaining `Figure` keyword gap from #4217 and fixes #4390. Block kwargs such as `Axis`/`Legend` are already covered by the existing block validation path.

Bounty reference: #4217. If this is accepted for the PayPal bounty, payout route: https://www.paypal.com/paypalme/aogkft

## Tests
- `git diff --check origin/master...HEAD`
- Local focused Makie validation with Julia 1.10.11: `julia --startup-file=no .scratch/run_pipeline_validation.jl` (scratch env develops local `ComputePipeline` and `Makie`, then includes `Makie/test/pipeline.jl`)