### PR TITLE
Allow smaller float types to persist in volume plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated `volume` colormapping to include `lowclip`, `highclip` and `nancolor`. This affects `:absorption`, `:mip` and `:iso` algorithms as well as 3D `contour` plots. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
+- Adjusted `volume` and `color` conversions to preserve `N0f8` and `Float16` types (numbers and colors). This allows users to reduce (v)ram usage by choosing smaller types. [#5660](https://github.com/MakieOrg/Makie.jl/pull/5660)
 
 ## [0.24.11] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Updated `volume` colormapping to include `lowclip`, `highclip` and `nancolor`. This affects `:absorption`, `:mip` and `:iso` algorithms as well as 3D `contour` plots. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
-- Adjusted `volume` and `color` conversions to preserve `N0f8` and `Float16` types (numbers and color eltypes). This allows users to reduce (v)ram usage by choosing smaller types. [#5660](https://github.com/MakieOrg/Makie.jl/pull/5660)
+- Adjusted `volume` conversions to preserve `N0f8` and `Float16` types (numbers and color eltypes). This allows users to reduce (v)ram usage by choosing smaller types. [#5660](https://github.com/MakieOrg/Makie.jl/pull/5660)
 - Adjusted volume `algorithm = :additive` to include the ray step size as a weight. This should allow additive volumes to render without downscaling volume data [#5662](https://github.com/MakieOrg/Makie.jl/pull/5662)
 
 ## [0.24.11] - 2026-05-30

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -509,3 +509,21 @@ end
     end
     @test real_bytesize[] == sizeof(eltype(indexbuffer))
 end
+
+@testset "small float passthrough" begin
+    scene = Scene()
+    p1 = volume!(scene, rand(N0f8, 4,4,4))
+    p2 = volume!(scene, rand(Float16, 4,4,4))
+    p3 = volume!(scene, rand(RGBA{N0f8}, 4,4,4), algorithm = :absorptionrgba)
+    p4 = volume!(scene, rand(RGBA{Float16}, 4,4,4), algorithm = :absorptionrgba)
+    # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
+    # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
+    screen = display(scene, visible = false)
+
+    @test eltype(p1.gl_renderobject[][:volumedata]) === N0f8
+    @test eltype(p2.gl_renderobject[][:volumedata]) === Float16
+    @test eltype(p3.gl_renderobject[][:volumedata]) === RGBA{N0f8}
+    @test eltype(p4.gl_renderobject[][:volumedata]) === RGBA{Float16}
+    # @test eltype(p5.gl_renderobject[][:image]) === RGBA{N0f8}
+    # @test eltype(p6.gl_renderobject[].vertexarray.buffers["intensity"]) === N0f8
+end

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -1,4 +1,4 @@
-using GLMakie.Makie: getscreen
+using Makie: getscreen, N0f8
 
 function project_sp(scene, point)
     point_px = Makie.project(scene, point)
@@ -512,10 +512,10 @@ end
 
 @testset "small float passthrough" begin
     scene = Scene()
-    p1 = volume!(scene, rand(N0f8, 4,4,4))
-    p2 = volume!(scene, rand(Float16, 4,4,4))
-    p3 = volume!(scene, rand(RGBA{N0f8}, 4,4,4), algorithm = :absorptionrgba)
-    p4 = volume!(scene, rand(RGBA{Float16}, 4,4,4), algorithm = :absorptionrgba)
+    p1 = volume!(scene, rand(N0f8, 4, 4, 4))
+    p2 = volume!(scene, rand(Float16, 4, 4, 4))
+    p3 = volume!(scene, rand(RGBA{N0f8}, 4, 4, 4), algorithm = :absorptionrgba)
+    p4 = volume!(scene, rand(RGBA{Float16}, 4, 4, 4), algorithm = :absorptionrgba)
     # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
     # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
     screen = display(scene, visible = false)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -1,4 +1,4 @@
-using Makie: getscreen, N0f8
+using Makie: getscreen, N0f8, RGBA
 
 function project_sp(scene, point)
     point_px = Makie.project(scene, point)
@@ -512,10 +512,10 @@ end
 
 @testset "small float passthrough" begin
     scene = Scene()
-    p1 = volume!(scene, rand(N0f8, 4, 4, 4))
-    p2 = volume!(scene, rand(Float16, 4, 4, 4))
-    p3 = volume!(scene, rand(RGBA{N0f8}, 4, 4, 4), algorithm = :absorptionrgba)
-    p4 = volume!(scene, rand(RGBA{Float16}, 4, 4, 4), algorithm = :absorptionrgba)
+    p1 = volume!(scene, fill(N0f8(0.5), 4, 4, 4)::Array{N0f8, 3})
+    p2 = volume!(scene, fill(Float16(0.5), 4, 4, 4))
+    p3 = volume!(scene, fill(RGBA{N0f8}(0.5, 0.5, 0.5, 0.5), 4, 4, 4), algorithm = :absorptionrgba)
+    p4 = volume!(scene, fill(RGBA{Float16}(0.5, 0.5, 0.5, 0.5), 4, 4, 4), algorithm = :absorptionrgba)
     # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
     # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
     screen = display(scene, visible = false)

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -306,6 +306,18 @@ Note that `heatmap` is slower to render than `image` so `image` should be prefer
     mixin_colormap_attributes()...
 end
 
+# Allow lower precision than just Float32, i.e. Float16, N0f8
+const VolumeFloatTypes = Union{Float32, Float16, N0f8}
+# densities, RGB colors or RGBA colors
+const VolumeElTypes = Union{
+    VolumeFloatTypes,
+    Vec3{<:VolumeFloatTypes},
+    Vec4{<:VolumeFloatTypes},
+    RGB{<:VolumeFloatTypes},
+    RGBA{<:VolumeFloatTypes},
+}
+const VolumeDataType = Array{<:VolumeElTypes, 3}
+
 """
     volume(volume_data)
     volume(x, y, z, volume_data)
@@ -320,8 +332,7 @@ colormap. How exactly the color is derived depends on the algorithm used.
     x::EndPoints,
     y::EndPoints,
     z::EndPoints,
-    # TODO: consider using RGB{N0f8}, RGBA{N0f8} instead of Vec/RGB(A){Float32}
-    volume::AbstractArray{<:Union{Float32, Vec3f, RGB{Float32}, Vec4f, RGBA{Float32}}, 3},
+    volume::VolumeDataType,
 ) begin
     """
     Sets the volume algorithm that is used. Available algorithms are:

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -161,9 +161,8 @@ function meshscatter_boundingbox(_positions, model, transform_marker, marker_bb,
 end
 
 
-function add_alpha(color, alpha)
-    return RGBAf(Colors.color(color), alpha * Colors.alpha(color))
-end
+add_alpha(color, alpha) = add_alpha(Colors.color(color), Colors.alpha(color), alpha)
+add_alpha(rgb, a::T, alpha) where {T} = RGBA(rgb, a * T(alpha))
 
 function register_colormapping_without_color!(attr::ComputeGraph)
     map!(attr, [:colormap, :alpha], [:alpha_colormap, :raw_colormap, :color_mapping, :color_mapping_type]) do icm, a
@@ -208,9 +207,10 @@ function register_colormapping!(attr::ComputeGraph, colorname = :color)
     ) do color, colorscale, alpha
         auto_colorrange = nothing
         if color isa Union{AbstractArray{<:Real}, Real}
-            scaled = el32convert(apply_scale(colorscale, color))
+            scaled = smallfloat_convert.(apply_scale(colorscale, color))
             auto_colorrange = Vec2f(distinct_extrema_nan(scaled))
-            val = clamp.(scaled, -floatmax(Float32), floatmax(Float32))
+            T = eltype(scaled)
+            val = clamp.(scaled, -floatmax(T), floatmax(T))
         elseif color isa AbstractPattern
             val = ShaderAbstractions.Sampler(add_alpha.(to_image(color), alpha), x_repeat = :repeat)
         elseif color isa ShaderAbstractions.Sampler

--- a/Makie/src/conversions.jl
+++ b/Makie/src/conversions.jl
@@ -490,10 +490,14 @@ end
 #                                  VolumeLike                                  #
 ################################################################################
 
-function convert_arguments(
-        ::VolumeLike, x::RangeLike, y::RangeLike, z::RangeLike,
-        data::RealArray{3}
+function convert_arguments(::VolumeLike, x::RangeLike, y::RangeLike, z::RangeLike, data::VolumeDataType)
+    return (
+        to_endpoints(x, "x", VolumeLike), to_endpoints(y, "y", VolumeLike),
+        to_endpoints(z, "z", VolumeLike), data,
     )
+end
+
+function convert_arguments(::VolumeLike, x::RangeLike, y::RangeLike, z::RangeLike, data::RealArray{3})
     return (
         to_endpoints(x, "x", VolumeLike), to_endpoints(y, "y", VolumeLike),
         to_endpoints(z, "z", VolumeLike), el32convert(data),
@@ -502,7 +506,10 @@ end
 
 # TODO: Consider using RGB(A){N0f8} for all of these
 # RGBA/Vec4 is the native data type for :absorptionrgba, :additive
-function convert_arguments(::VolumeLike, x::RangeLike, y::RangeLike, z::RangeLike, data::Array{<:Union{VecTypes{3}, VecTypes{4}, RGB, RGBA}, 3})
+function convert_arguments(
+        ::VolumeLike, x::RangeLike, y::RangeLike, z::RangeLike,
+        data::Array{<:Union{VecTypes{3}, VecTypes{4}, RGB, RGBA}, 3}
+    )
     return (
         to_endpoints(x, "x", VolumeLike), to_endpoints(y, "y", VolumeLike),
         to_endpoints(z, "z", VolumeLike), el32convert(data),
@@ -701,7 +708,7 @@ function convert_arguments(::VolumeLike, x::RealVector, y::RealVector, z::RealVe
         return reshape(A, ntuple(j -> j != i ? 1 : length(A), Val(3)))
     end
 
-    return (map(v -> to_endpoints((first(v), last(v))), (x, y, z))..., el32convert.(f.(_x, _y, _z)))
+    return (map(v -> to_endpoints((first(v), last(v))), (x, y, z))..., smallfloat_convert.(f.(_x, _y, _z)))
 end
 
 function convert_arguments(P::Type{<:AbstractPlot}, r::RealVector, f::Function)
@@ -803,6 +810,12 @@ el32convert(x::Observable) = lift(el32convert, x)
 el32convert(x) = convert(float32type(x), x)
 el32convert(x::Mat{X, Y, T}) where {X, Y, T} = Mat{X, Y, Float32}(x)
 
+smallfloat_convert(x::N0f8) = x
+smallfloat_convert(x::Float16) = x
+smallfloat_convert(x::Real) = Float32(x)
+smallfloat_convert(x::VecTypes) = smallfloat_convert.(x)
+smallfloat_convert(x::RGB) = RGB(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)))
+smallfloat_convert(x::RGBA) = RGB(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)), smallfloat_convert(alpha(x)))
 
 """
     to_triangles(indices)

--- a/Makie/src/conversions.jl
+++ b/Makie/src/conversions.jl
@@ -814,8 +814,8 @@ smallfloat_convert(x::N0f8) = x
 smallfloat_convert(x::Float16) = x
 smallfloat_convert(x::Real) = Float32(x)
 smallfloat_convert(x::VecTypes) = smallfloat_convert.(x)
-smallfloat_convert(x::RGB) = RGB(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)))
-smallfloat_convert(x::RGBA) = RGB(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)), smallfloat_convert(alpha(x)))
+smallfloat_convert(x::Color) = RGB(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)))
+smallfloat_convert(x::TransparentColor) = RGBA(smallfloat_convert(red(x)), smallfloat_convert(green(x)), smallfloat_convert(blue(x)), smallfloat_convert(alpha(x)))
 
 """
     to_triangles(indices)

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -121,6 +121,24 @@ edisplay = Bonito.use_electron_display(devtools = true)
         end
     end
 
+    @testset "small float passthrough" begin
+        scene = Scene()
+        p1 = volume!(scene, rand(N0f8, 4,4,4))
+        p2 = volume!(scene, rand(Float16, 4,4,4))
+        p3 = volume!(scene, rand(RGBA{N0f8}, 4,4,4), algorithm = :absorptionrgba)
+        p4 = volume!(scene, rand(RGBA{Float16}, 4,4,4), algorithm = :absorptionrgba)
+        # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
+        # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
+        screen = display(scene, visible = false)
+        sleep(2)
+
+        @test eltype(p1.wgl_renderobject[][:uniforms][:uniform_color][:data]) === N0f8
+        @test eltype(p2.wgl_renderobject[][:uniforms][:uniform_color][:data]) === Float16
+        @test eltype(p3.wgl_renderobject[][:uniforms][:uniform_color][:data]) === UInt8 # RGBA gets splatted
+        @test_broken eltype(p4.wgl_renderobject[][:uniforms][:uniform_color][:data]) === Float16 # can we allow Float16 to pass to js?
+        # @test eltype(p5.gl_renderobject[][:image]) === RGBA{N0f8}
+        # @test eltype(p6.gl_renderobject[].vertexarray.buffers["intensity"]) === N0f8
+    end
 
     @testset "Tick Events" begin
         function check_tick(tick, state, count)

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -6,6 +6,7 @@ using FileIO
 using WGLMakie, Makie, Test
 using WGLMakie.Bonito
 using ReferenceTests
+using Makie: N0f8
 import Electron
 
 @testset "mimes" begin
@@ -123,10 +124,10 @@ edisplay = Bonito.use_electron_display(devtools = true)
 
     @testset "small float passthrough" begin
         scene = Scene()
-        p1 = volume!(scene, rand(N0f8, 4,4,4))
-        p2 = volume!(scene, rand(Float16, 4,4,4))
-        p3 = volume!(scene, rand(RGBA{N0f8}, 4,4,4), algorithm = :absorptionrgba)
-        p4 = volume!(scene, rand(RGBA{Float16}, 4,4,4), algorithm = :absorptionrgba)
+        p1 = volume!(scene, rand(N0f8, 4, 4, 4))
+        p2 = volume!(scene, rand(Float16, 4, 4, 4))
+        p3 = volume!(scene, rand(RGBA{N0f8}, 4, 4, 4), algorithm = :absorptionrgba)
+        p4 = volume!(scene, rand(RGBA{Float16}, 4, 4, 4), algorithm = :absorptionrgba)
         # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
         # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
         screen = display(scene, visible = false)

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -6,7 +6,7 @@ using FileIO
 using WGLMakie, Makie, Test
 using WGLMakie.Bonito
 using ReferenceTests
-using Makie: N0f8
+using Makie: N0f8, RGBA
 import Electron
 
 @testset "mimes" begin
@@ -124,13 +124,14 @@ edisplay = Bonito.use_electron_display(devtools = true)
 
     @testset "small float passthrough" begin
         scene = Scene()
-        p1 = volume!(scene, rand(N0f8, 4, 4, 4))
-        p2 = volume!(scene, rand(Float16, 4, 4, 4))
-        p3 = volume!(scene, rand(RGBA{N0f8}, 4, 4, 4), algorithm = :absorptionrgba)
-        p4 = volume!(scene, rand(RGBA{Float16}, 4, 4, 4), algorithm = :absorptionrgba)
+        p1 = volume!(scene, fill(N0f8(0.5), 4, 4, 4)::Array{N0f8, 3})
+        p2 = volume!(scene, fill(Float16(0.5), 4, 4, 4))
+        p3 = volume!(scene, fill(RGBA{N0f8}(0.5, 0.5, 0.5, 0.5), 4, 4, 4), algorithm = :absorptionrgba)
+        p4 = volume!(scene, fill(RGBA{Float16}(0.5, 0.5, 0.5, 0.5), 4, 4, 4), algorithm = :absorptionrgba)
         # p5 = mesh!(scene, Rect2f(0,0,1,1), color = rand(RGBA{N0f8}, 4, 4))
         # p6 = scatter!(scene, 1:4, color = rand(N0f8, 4))
-        screen = display(scene, visible = false)
+        display(edisplay, App(scene))
+        Bonito.wait_for(() -> events(scene).window_open[])
         sleep(2)
 
         @test eltype(p1.wgl_renderobject[][:uniforms][:uniform_color][:data]) === N0f8


### PR DESCRIPTION
# Description

Volume data can get big pretty quickly. 1024^3 is already 4GB with Float32 elements. The simplest way of reducing the memory overhead is just use less bits, e.g. Float16 or N0f8. To do that, we need to preserve these types in convert_arguments and colormapping, which this pr does.

~~Changing the types in colormapping might have side effects so I'm keeping this out of #5656.~~ There is a `convert_attribute` method for `color` that sets the type to Float32/RGBAf before colormapping. So it doesn't affect plots that set colors through the `color` attribute, nor does it affect image, heatmap and surface which have their own `convert_arguments` methods, or voxels which use custom colormapping code.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
