### PR TITLE
Weigh volume samples for `:additive` by step size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated `volume` colormapping to include `lowclip`, `highclip` and `nancolor`. This affects `:absorption`, `:mip` and `:iso` algorithms as well as 3D `contour` plots. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
+- Adjusted volume `algorithm = :additive` to include the ray step size as a weight. This should allow additive volumes to render without downscaling volume data [#5662](https://github.com/MakieOrg/Makie.jl/pull/5662)
 
 ## [0.24.11] - 2026-05-30
 

--- a/GLMakie/assets/shader/volume.frag
+++ b/GLMakie/assets/shader/volume.frag
@@ -162,9 +162,10 @@ vec4 additivergba(vec3 front, vec3 dir)
 {
     vec3 pos = front;
     vec4 integrated_color = vec4(0., 0., 0., 0.);
+    float step_size = length(dir);
     int i = 0;
     for (i; i < num_samples ; ++i) {
-        vec4 density = texture(volumedata, pos);
+        vec4 density = step_size * texture(volumedata, pos);
         integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - density);
         pos += dir;
     }

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -110,7 +110,7 @@ end
     volume(f[2, 1], -10 .. 10, -10 .. 10, -10 .. 10, data, algorithm = :absorption, absorption = 2)
     volume(f[1, 2], -10 .. 10, -10 .. 10, -10 .. 10, data; algorithm = :mip)
     volume(f[2, 2], -10 .. 10, -10 .. 10, -10 .. 10, rgba_data; algorithm = :absorptionrgba, absorption = 2)
-    volume(f[1, 3], -10 .. 10, -10 .. 10, -10 .. 10, add_data; algorithm = :additive, absorption = 0.05)
+    volume(f[1, 3], -10 .. 10, -10 .. 10, -10 .. 10, add_data; algorithm = :additive, absorption = 10)
     volume(
         f[2, 3], -10 .. 10, -10 .. 10, -10 .. 10, index_data;
         algorithm = :indexedabsorption, colormap = Makie.resample(to_colormap(:viridis), N), absorption = 2
@@ -794,9 +794,8 @@ end
     )
 
     volume(
-        f[1, 3], -10 .. 10, -10 .. 10, -10 .. 10, rgba_data;
-        clip_planes = attr.clip_planes, axis = attr.axis,
-        algorithm = :additive, absorption = 0.01
+        f[1, 3], -10 .. 10, -10 .. 10, -10 .. 10, rgba_data; attr...,
+        algorithm = :additive
     )
     volume(
         f[2, 3], -10 .. 10, -10 .. 10, -10 .. 10, index_data; attr...,

--- a/WGLMakie/assets/volume.frag
+++ b/WGLMakie/assets/volume.frag
@@ -212,9 +212,10 @@ vec4 additivergba(vec3 front, vec3 dir)
 {
     vec3 pos = front;
     vec4 integrated_color = vec4(0., 0., 0., 0.);
+    float step_size = length(dir);
     int i = 0;
     for (i; i < num_samples ; ++i) {
-        vec4 density = texture(uniform_color, pos);
+        vec4 density = step_size * texture(uniform_color, pos);
         integrated_color = 1.0 - (1.0 - integrated_color) * (1.0 - density);
         pos += dir;
     }

--- a/docs/src/reference/plots/volume.md
+++ b/docs/src/reference/plots/volume.md
@@ -63,8 +63,8 @@ data = map([(x,y,z) for x in r, y in r, z in r]) do (x,y,z)
 end
 
 f = Figure(backgroundcolor = :black, size = (700, 400))
-volume(f[1, 1], data, algorithm = :absorptionrgba, absorption = 20)
-volume(f[1, 2], data, algorithm = :additive)
+volume(f[1, 1], data, algorithm = :absorptionrgba, absorption = 10)
+volume(f[1, 2], data, algorithm = :additive, absorption = 10)
 f
 ```
 


### PR DESCRIPTION
# Description

When throwing normal RGBA values at `:additive` you usually get junk. Typically just a white blob, sometimes weird interference patterns. With the same data on master:

<img width="628" height="516" alt="Screenshot from 2026-06-07 19-38-27" src="https://github.com/user-attachments/assets/c237e434-92a9-4bbf-87ef-fd1a2d10ab6a" />

This happens because samples colors directly and overshoots `RGB(1, 1, 1)` (white) by a lot. Adding a `step_size = length(dir)` multiplier to the sampled color (like all absorption algorithms) adjusts this to more reasonable ranges, producing:

<img width="628" height="516" alt="Screenshot from 2026-06-07 19-38-18" src="https://github.com/user-attachments/assets/34e9bac1-317b-48ad-84b9-1b4a02b44ca4" />

I'm separating this from #5656 because I have absolutely no clue what `additive` is trying to do and thus I can't say this is fixing anything.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
