### PR TITLE
add option to style WGLMakie's Tooltip just like GLMakie's DataInspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - `WGLMakie.ToolTip` can now be styled with `class` and `css` keyword arguments, and ships a
-  `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#PR](https://github.com/MakieOrg/Makie.jl/pull/PR).
+  `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#5664](https://github.com/MakieOrg/Makie.jl/pull/5664).
 - `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).
 - Fixed `contourf` not rendering non-closed contours [#5651](https://github.com/MakieOrg/Makie.jl/issues/5651).
 - Fixed WGLMakie flickering while continuously resizing a canvas by re-rendering right after the resize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `WGLMakie.ToolTip` can now be styled with `class` and `css` keyword arguments, and ships a
+  `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#PR](https://github.com/MakieOrg/Makie.jl/pull/PR).
 - `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).
 - Fixed `contourf` not rendering non-closed contours [#5651](https://github.com/MakieOrg/Makie.jl/issues/5651).
 - Fixed WGLMakie flickering while continuously resizing a canvas by re-rendering right after the resize.

--- a/ReferenceTests/src/tests/generic_components.jl
+++ b/ReferenceTests/src/tests/generic_components.jl
@@ -548,7 +548,7 @@ end
         sleep(0.15) # wait for WGLMakie
         @test isempty(di.temp_plots) # verify cleanup
         e.mouseposition[] = mp
-        sleep(0.2 + (i == 2)) # wait for WGLMakie, datashader extra slow
+        sleep(0.4 + (i == 2)) # wait for WGLMakie, datashader extra slow
         Makie.step!(st)
     end
 

--- a/WGLMakie/src/datainspector_popup.css
+++ b/WGLMakie/src/datainspector_popup.css
@@ -1,0 +1,51 @@
+/* Opt-in style for WGLMakie.ToolTip that mimics the GLMakie DataInspector popup:
+   a square white box with a black outline and a downward tail at the data point.
+   Use with:  ToolTip(...; class="datainspector-popup", css=DATAINSPECTOR_CSS)      */
+
+.datainspector-popup {
+    position: absolute;
+    display: none;
+    z-index: 10000;
+    pointer-events: none;
+    /* sit centered above the picked point, leaving room for the tail */
+    transform: translate(-50%, calc(-100% - 8px));
+    background: white;
+    color: black;
+    border: 2px solid black;
+    border-radius: 0;
+    padding: 2px 6px;
+    white-space: pre;
+    font-family: "TeXGyreHerosMakie", sans-serif;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.datainspector-popup.show {
+    display: block;
+}
+
+/* downward tail: black outline (::before) + white fill (::after), 1px smaller */
+.datainspector-popup::before,
+.datainspector-popup::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    width: 0;
+    height: 0;
+    border-style: solid;
+}
+
+.datainspector-popup::before {
+    top: 100%;
+    transform: translateX(-50%);
+    border-width: 8px 7px 0 7px;
+    border-color: black transparent transparent transparent;
+}
+
+.datainspector-popup::after {
+    top: calc(100% - 1px);
+    transform: translateX(-50%);
+    border-width: 6px 5px 0 5px;
+    border-color: white transparent transparent transparent;
+}

--- a/WGLMakie/src/datainspector_popup.css
+++ b/WGLMakie/src/datainspector_popup.css
@@ -11,12 +11,12 @@
     transform: translate(-50%, calc(-100% - 8px));
     background: white;
     color: black;
-    border: 2px solid black;
+    border: 1px solid black;
     border-radius: 0;
     padding: 2px 6px;
     white-space: pre;
     font-family: "TeXGyreHerosMakie", sans-serif;
-    font-size: 16px;
+    font-size: 14px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
@@ -39,13 +39,13 @@
 .datainspector-popup::before {
     top: 100%;
     transform: translateX(-50%);
-    border-width: 8px 7px 0 7px;
+    border-width: 6px 5px 0 5px;
     border-color: black transparent transparent transparent;
 }
 
 .datainspector-popup::after {
     top: calc(100% - 1px);
     transform: translateX(-50%);
-    border-width: 6px 5px 0 5px;
+    border-width: 5px 4px 0 4px;
     border-color: white transparent transparent transparent;
 }

--- a/WGLMakie/src/picking.jl
+++ b/WGLMakie/src/picking.jl
@@ -85,10 +85,23 @@ function Makie.pick(::Scene, screen::Screen, r::Rect2)
 end
 
 """
-    ToolTip(figurelike, js_callback; plots=plots_you_want_to_hover)
+    ToolTip(figurelike, js_callback; plots=plots_you_want_to_hover, class="popup",
+css=POPUP_CSS)
 
-Returns a Bonito DOM element, which creates a popup whenever you click on a plot element in `plots`.
-The content of the popup is filled with the return value of js_callback, which can be a string or `HTMLNode`.
+Returns a Bonito DOM element, which creates a popup whenever you click on a plot element in
+`plots`.
+The content of the popup is filled with the return value of js_callback, which can be a string
+or `HTMLNode`.
+
+The popup is styled via `class` (the CSS class on the popup `div`, default `"popup"`) and
+`css` (a stylesheet to load — any `jsrender`-able such as an `Asset`, `Styles` or DOM node;
+default `POPUP_CSS`). To restyle, set both: a class your stylesheet targets, and the
+stylesheet
+itself. Your CSS must handle the `show` class (toggled when the popup is visible).
+
+To match the GLMakie `DataInspector` look, use the bundled preset:
+`ToolTip(fig, callback; plots, class = "datainspector-popup", css = DATAINSPECTOR_CSS)`.
+See [`DATAINSPECTOR_CSS`](@ref).
 
 Usage example:
 
@@ -121,21 +134,46 @@ struct ToolTip
     scene::Scene
     callback::Bonito.JSCode
     plot_uuids::Vector{String}
-    function ToolTip(figlike, callback; plots = nothing)
+    class::String
+    css::Any
+    function ToolTip(figlike, callback; plots = nothing, class = "popup", css = POPUP_CSS)
         scene = Makie.get_scene(figlike)
         if isnothing(plots)
             plots = scene.plots
         end
         all_plots = js_uuid.(filter!(x -> x.inspectable[], Makie.collect_atomic_plots(plots)))
-        return new(scene, callback, all_plots)
+        return new(scene, callback, all_plots, class, css)
     end
 end
 
 const POPUP_CSS = Bonito.Asset(@path joinpath(@__DIR__, "popup.css"))
 
+"""
+    DATAINSPECTOR_CSS
+
+A ready-made `ToolTip` stylesheet that mimics the GLMakie `DataInspector` popup
+(square white box, black outline, downward tail pointing at the data point).
+Pair it with `class = "datainspector-popup"`:
+
+```julia
+ToolTip(fig, callback; plots, class = "datainspector-popup", css = DATAINSPECTOR_CSS)
+```
+"""
+const DATAINSPECTOR_CSS = DOM.span(
+    # load the Makie UI font so the text matches DataInspector exactly
+    Bonito.Styles(
+        Bonito.CSS(
+            "@font-face",
+            "font-family" => "TeXGyreHerosMakie",
+            "src" => Bonito.Asset(Makie.assetpath("fonts", "TeXGyreHerosMakie-Regular.otf")),
+        )
+    ),
+    Bonito.Asset(@path joinpath(@__DIR__, "datainspector_popup.css")),
+)
+
 function Bonito.jsrender(session::Session, tt::ToolTip)
     scene = tt.scene
-    popup = DOM.div("", class = "popup")
+    popup = DOM.div("", class = tt.class)
     Bonito.evaljs(
         session, js"""
             $(scene).then(scene => {
@@ -145,5 +183,5 @@ function Bonito.jsrender(session::Session, tt::ToolTip)
             })
         """
     )
-    return DOM.span(Bonito.jsrender(session, POPUP_CSS), popup)
+    return DOM.span(Bonito.jsrender(session, tt.css), popup)
 end

--- a/docs/src/explanations/backends/wglmakie.md
+++ b/docs/src/explanations/backends/wglmakie.md
@@ -401,6 +401,47 @@ App() do session
 end
 ```
 
+Or use the bundled `DATAINSPECTOR_CSS` to match GLMakie's `DataInspector` exactly,
+with no custom CSS:
+
+```julia
+App() do session
+    f, ax, pl = scatter(1:4, markersize=20, color=Float32[0.3, 0.4, 0.5, 0.6])
+    cb = js"""(plot, index) => {
+        const a = plot.geometry.attributes.wgl_positions;
+        const i = index * a.itemSize;
+        let s = `x: ${a.array[i].toFixed(3)}\ny: ${a.array[i+1].toFixed(3)}`;
+        if (a.itemSize > 2) s += `\nz: ${a.array[i+2].toFixed(3)}`;
+        return s;
+    }"""
+    tooltip = WGLMakie.ToolTip(f, cb; plots=pl,
+                               class="datainspector-popup", css=WGLMakie.DATAINSPECTOR_CSS)
+    return DOM.div(f, tooltip)
+end
+```
+
+The popup's appearance can be customized by passing your own CSS class and stylesheet via
+class and css. The default look comes from the bundled popup.css; here we use a plain
+square white box instead (your stylesheet must style both the class and its .show state):
+
+```@example wglmakie
+App() do session
+    f, ax, pl = scatter(1:4, markersize=20, color=Float32[0.3, 0.4, 0.5, 0.6])
+    style = DOM.style("""
+        .mytip {
+            position: absolute; display: none;
+            background: white; color: black;
+            border: 1px solid black; border-radius: 0;
+            padding: 2px 6px; font-family: sans-serif;
+        }
+        .mytip.show { display: block; }
+    """)
+    cb = js"""(plot, index) => "point " + index"""
+    tooltip = WGLMakie.ToolTip(f, cb; plots=pl, class="mytip", css=style)
+    return DOM.div(f, tooltip)
+end
+```
+
 ## Styling
 
 Bonito allows loading arbitrary CSS, and `DOM.xxx` wraps all existing HTML tags.

--- a/docs/src/explanations/backends/wglmakie.md
+++ b/docs/src/explanations/backends/wglmakie.md
@@ -382,7 +382,8 @@ App() do session
         // the plot object is currently just the raw THREEJS mesh
         console.log(plot)
         // Which can be used to extract e.g. position or color:
-        const {pos, color} = plot.geometry.attributes
+        const pos = plot.geometry.attributes.wgl_positions
+        const color = plot.geometry.attributes.vertex_color
         console.log(pos)
         console.log(color)
         const x = pos.array[index*2] // everything is a flat array in JS


### PR DESCRIPTION
the offline WGLMakie ToolTip has a grey background, rounded corners, and no triangle:

<img width="722" height="508" alt="Screenshot 2026-06-08 at 10 33 21 AM" src="https://github.com/user-attachments/assets/cc4c177b-38bc-4fc6-884a-246b28dc4e52" />

whereas the GLMakie DataInspector looks like this:
<img width="586" height="444" alt="Screenshot 2026-06-08 at 10 22 49 AM" src="https://github.com/user-attachments/assets/1bc03f4d-c21a-4f92-8de7-c652b6190e11" />

this PR adds two fields to the WGLMakie ToolTip struct and two corresponding keyword arguments to permit the developer to style it as they wish, and specifically provides a stylesheet which matches GLMakie DataInspector.  the default stays the same though so as not to be breaking.

so with this PR it is possible to make WGLMakie ToolTip look like this:

<img width="554" height="418" alt="Screenshot 2026-06-08 at 10 42 59 AM" src="https://github.com/user-attachments/assets/dc7b3045-5350-486e-ad76-bbc82f7d3e7c" />

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

should this PR be merged (hopefully!), i have a follow on PR which adds the option to show the tooltip when hovering, just like in GLMakie, instead of having to click.