### PR TITLE
feat(dendrogram): add absolute attribute to keep input leaf positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added an `absolute` attribute to `dendrogram` that keeps the input leaf positions instead of translating the root to `origin`, making it easy to align leaves to e.g. heatmap rows or columns [#5666](https://github.com/MakieOrg/Makie.jl/pull/5666).
 - `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).
 - Fixed `contourf` not rendering non-closed contours [#5651](https://github.com/MakieOrg/Makie.jl/issues/5651).
 - Fixed WGLMakie flickering while continuously resizing a canvas by re-rendering right after the resize.

--- a/Makie/src/stats/dendrogram.jl
+++ b/Makie/src/stats/dendrogram.jl
@@ -30,8 +30,18 @@ Note that this recipe is still experimental and subject to change in the future.
     Can be `:down`, `:right`, `:up`, `:left` or a float.
     """
     rotation = :down
-    "Sets the position of the tree root."
+    "Sets the position of the tree root (when `absolute = false`)."
     origin = Point2d(0)
+    """
+    Controls how the given node positions are interpreted. With the default
+    `absolute = false`, positions are treated as relative and the whole tree is
+    translated so that the root ends up at `origin`. With `absolute = true`, the
+    input coordinates are kept as given, so leaf nodes stay at their specified
+    positions. This makes it easy to align leaves to other plot elements such as
+    heatmap rows or columns. `rotation`, `width`, `depth` and `origin` still apply
+    on top, with `origin` acting as an additional offset.
+    """
+    absolute = false
     """
     Scales the dendrogram so that the maximum distance between leaf nodes is `width`.
     By default no scaling is applied, i.e. the width of the dendrogram is defined
@@ -155,9 +165,9 @@ function Makie.plot!(plot::Dendrogram)
         end
     end
 
-    inputs = [:nodes, :origin, :rotation, :branch_shape, :branch_colors, :transform_func, :width, :depth]
+    inputs = [:nodes, :origin, :rotation, :branch_shape, :branch_colors, :transform_func, :width, :depth, :absolute]
 
-    map!(plot.attributes, inputs, [:node_points, :line_points, :line_colors]) do nodes, _origin, rotation, branch_shape, branch_colors, tf, width, depth
+    map!(plot.attributes, inputs, [:node_points, :line_points, :line_colors]) do nodes, _origin, rotation, branch_shape, branch_colors, tf, width, depth, absolute
 
         ps = Point2d[]
         origin = to_ndim(Vec2f, _origin, 0)
@@ -193,8 +203,10 @@ function Makie.plot!(plot::Dendrogram)
         # parse scaling
         scale = Vec2d(_parse_dendrogram_scale(nodes, width), _parse_dendrogram_scale(nodes, depth))
 
-        # move root to (0, 0), scale, then rotate, then move to origin
-        root_pos = nodes[end].position
+        # move root to (0, 0), scale, then rotate, then move to origin. With
+        # absolute = true the input coordinates are kept as given, so leaves stay
+        # at their specified positions.
+        root_pos = absolute ? Point2d(0) : nodes[end].position
         for (i, p) in enumerate(ps)
             ps[i] = R * (scale .* (p - root_pos)) + origin
         end

--- a/Makie/test/conversions/conversions.jl
+++ b/Makie/test/conversions/conversions.jl
@@ -523,4 +523,22 @@ end
     ys = rand(10)
     merges = [(i, i + 1) for i in 1:20]
     @test Makie.convert_arguments(Dendrogram, xs, ys, merges) == Makie.convert_arguments(Dendrogram, Point2.(xs, ys), merges)
+
+    @testset "absolute positioning" begin
+        leaves = Point2f[(1, 0), (2, 0), (3, 0), (4, 0)]
+        merges = [(1, 2), (3, 4), (5, 6)]
+
+        # absolute = true keeps the input leaf coordinates (default rotation is identity)
+        p = dendrogram(leaves, merges; absolute = true).plot
+        @test Makie.dendrogram_node_positions(p)[][1:4] == Point2d[(1, 0), (2, 0), (3, 0), (4, 0)]
+
+        # default behavior translates the tree so the root sits at the origin
+        p2 = dendrogram(leaves, merges).plot
+        @test Makie.dendrogram_node_positions(p2)[][end] == Point2d(0, 0)
+        @test Makie.dendrogram_node_positions(p2)[][1:4] != Point2d[(1, 0), (2, 0), (3, 0), (4, 0)]
+
+        # origin still offsets in absolute mode
+        p3 = dendrogram(leaves, merges; absolute = true, origin = Point2f(10, 5)).plot
+        @test Makie.dendrogram_node_positions(p3)[][1:4] == Point2d[(11, 5), (12, 5), (13, 5), (14, 5)]
+    end
 end

--- a/docs/src/reference/plots/dendrogram.md
+++ b/docs/src/reference/plots/dendrogram.md
@@ -7,8 +7,6 @@ dendrogram
 ## Examples
 
 ```@figure
-using CairoMakie
-
 # Relative positions of leaf nodes
 # These positions will be translated to place the root node at `origin`
 leaves = Point2f[
@@ -31,8 +29,6 @@ dendrogram(leaves, merges)
 ```
 
 ```@figure
-using CairoMakie
-
 leaves = Point2f[(1,0), (2,0.5), (3,1), (4,2), (5,0)]
 merges = [(1, 2), (6, 3), (4, 5), (7, 8)]
 
@@ -53,8 +49,6 @@ f
 
 
 ```@figure
-using CairoMakie
-
 leaves = Point2f[(1,0), (2,0.5), (3,1), (4,2), (5,0)]
 merges = [(1, 2), (6, 3), (4, 5), (7, 8)]
 
@@ -64,14 +58,42 @@ f
 ```
 
 ```@figure
-using CairoMakie
-
 leaves = Point2f[(1,0), (2,0.5), (3,1), (4,2), (5,0)]
 merges = [(1, 2), (6, 3), (4, 5), (7, 8)]
 
 f = Figure()
 a = PolarAxis(f[1, 1])
 dendrogram!(a, leaves, merges, linewidth = 3, color = :black, linestyle = :dash, origin = Point2f(0, 1))
+f
+```
+
+By default the tree is translated so that its root sits at `origin`, which means
+the leaf positions depend on the structure of the tree. Pass `absolute = true` to
+keep the input coordinates as given instead. This makes it easy to align the
+leaves to other plot elements such as the rows and columns of a heatmap: place the
+leaves at `1:n` and link the axes.
+
+```@figure
+n = 8
+leaves = Point2f.(1:n, 0)
+merges_rows = [(1,2), (3,4), (5,6), (7,8), (9,10), (11,12), (13,14)]
+merges_cols = [(1,2), (9,3), (10,4), (5,6), (12,7), (13,8), (11,14)]
+data = [abs(i - j) for i in 1:n, j in 1:n]
+
+f = Figure()
+ax_left = Axis(f[1, 1], width = 80)
+ax_bot = Axis(f[2, 2], height = 80, yreversed = true)
+ax_h = Axis(f[1, 2], width = 300, height = 300, xticks = 1:n, yticks = 1:n)
+lw = ax_h.spinewidth[]
+dendrogram!(ax_left, leaves, merges_rows, rotation = :right, absolute = true, color = :black, linewidth = lw)
+dendrogram!(ax_bot, leaves, merges_cols, rotation = :down, absolute = true, color = :black, linewidth = lw)
+heatmap!(ax_h, 1:n, 1:n, data)
+linkyaxes!(ax_left, ax_h)
+linkxaxes!(ax_bot, ax_h)
+hidedecorations!(ax_left); hidespines!(ax_left)
+hidedecorations!(ax_bot); hidespines!(ax_bot)
+colgap!(f.layout, 6); rowgap!(f.layout, 6)
+resize_to_layout!(f)
 f
 ```
 


### PR DESCRIPTION
Fixes #5123

By default a dendrogram is translated so its root ends up at `origin`, which means the leaf positions depend on the structure of the tree rather than on the coordinates you pass. That makes it awkward to line the leaves up with something else, like the rows of a heatmap. The issue has a workaround that manually computes `origin` from the rotated root position.

`absolute = true` skips that recentering and keeps the input coordinates as given, so leaves stay where you put them. Place them at `1:n` and link the axes:

```julia
n = 8
leaves = Point2f.(1:n, 0)
merges_rows = [(1,2), (3,4), (5,6), (7,8), (9,10), (11,12), (13,14)]
merges_cols = [(1,2), (9,3), (10,4), (5,6), (12,7), (13,8), (11,14)]
data = [abs(i - j) for i in 1:n, j in 1:n]

f = Figure()
ax_left = Axis(f[1, 1], width = 80)
ax_bot = Axis(f[2, 2], height = 80, yreversed = true)
ax_h = Axis(f[1, 2], width = 300, height = 300, xticks = 1:n, yticks = 1:n)
lw = ax_h.spinewidth[]
dendrogram!(ax_left, leaves, merges_rows; rotation = :right, absolute = true, color = :black, linewidth = lw)
dendrogram!(ax_bot, leaves, merges_cols; rotation = :down, absolute = true, color = :black, linewidth = lw)
heatmap!(ax_h, 1:n, 1:n, data)
linkyaxes!(ax_left, ax_h)
linkxaxes!(ax_bot, ax_h)
hidedecorations!(ax_left); hidespines!(ax_left)
hidedecorations!(ax_bot); hidespines!(ax_bot)
colgap!(f.layout, 6); rowgap!(f.layout, 6)
resize_to_layout!(f)
f
```

<img width="435" height="441" alt="pr_dendro" src="https://github.com/user-attachments/assets/2572f4c8-60f3-4807-b336-1b60f784f4a9" />
