### PR TITLE
Match PolarAxis grid/spine defaults to Axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Adjusted volume `algorithm = :additive` to include the ray step size as a weight. This should allow additive volumes to render without downscaling volume data [#5662](https://github.com/MakieOrg/Makie.jl/pull/5662)
+- Adjusted `PolarAxis` defaults to match `Axis`: lightened grid colors (fallback major grid is now `RGBAf(0, 0, 0, 0.12)`, was black at 50%; minor grid is now `RGBAf(0, 0, 0, 0.05)`, was black at 20%) and reduced the default `spinewidth` from `2` to `1`.
 
 ## [0.24.11] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Adjusted volume `algorithm = :additive` to include the ray step size as a weight. This should allow additive volumes to render without downscaling volume data [#5662](https://github.com/MakieOrg/Makie.jl/pull/5662)
-- Adjusted `PolarAxis` defaults to match `Axis`: lightened grid colors (fallback major grid is now `RGBAf(0, 0, 0, 0.12)`, was black at 50%; minor grid is now `RGBAf(0, 0, 0, 0.05)`, was black at 20%) and reduced the default `spinewidth` from `2` to `1`.
+- Adjusted `PolarAxis` defaults to match `Axis`: lightened grid colors (fallback major grid is now `RGBAf(0, 0, 0, 0.12)`, was black at 50%; minor grid is now `RGBAf(0, 0, 0, 0.05)`, was black at 20%), reduced the default `spinewidth` from `2` to `1`, and matched the title `titlefont` (now `:bold`) and `titlesize` fallback (now the plain `fontsize` instead of `1.2 × fontsize`).
 
 ## [0.24.11] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed some errors with the color accumulation of `:absorption`, `:absorptionrgba` and `:indexedabsorption` algorithms in `volume` plots. Renders should no longer over sample thin regions (corners and edges of the volume bounding box) and otherwise be brighter. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Added `samples` as a `volume` attribute for controlling the number of ray samples and added `absorption` as a multiplier for sampled colors with `:additive`. [#5656](https://github.com/MakieOrg/Makie.jl/pull/5656)
 - Adjusted volume `algorithm = :additive` to include the ray step size as a weight. This should allow additive volumes to render without downscaling volume data [#5662](https://github.com/MakieOrg/Makie.jl/pull/5662)
-- Adjusted `PolarAxis` defaults to match `Axis`: lightened grid colors (fallback major grid is now `RGBAf(0, 0, 0, 0.12)`, was black at 50%; minor grid is now `RGBAf(0, 0, 0, 0.05)`, was black at 20%), reduced the default `spinewidth` from `2` to `1`, and matched the title `titlefont` (now `:bold`) and `titlesize` fallback (now the plain `fontsize` instead of `1.2 × fontsize`).
+- Adjusted `PolarAxis` defaults to match `Axis`: lightened grid colors (fallback major grid is now `RGBAf(0, 0, 0, 0.12)`, was black at 50%; minor grid is now `RGBAf(0, 0, 0, 0.05)`, was black at 20%), reduced the default `spinewidth` from `2` to `1`, and matched the title `titlefont` (now `:bold`), `titlesize` fallback (now the plain `fontsize` instead of `1.2 × fontsize`), and `titlegap` (now `4`, and correctly inheriting `(:Axis, :titlegap)` instead of `(:Axis, :titlesize)`).
 
 ## [0.24.11] - 2026-05-30
 

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -2360,7 +2360,7 @@ end
         "The title of the plot"
         title = ""
         "The gap between the title and the top of the axis"
-        titlegap::Float32 = inherit(scene, (:Axis, :titlesize), map(x -> x / 2, inherit(scene, :fontsize, 16)))
+        titlegap::Float32 = inherit(scene, (:Axis, :titlegap), 4)
         "The alignment of the title.  Can be any of `:center`, `:left`, or `:right`."
         titlealign = :center
         "The fontsize of the title."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -2190,7 +2190,7 @@ end
         # Spine
 
         "The width of the spine."
-        spinewidth::Float32 = 2
+        spinewidth::Float32 = 1
         "The color of the spine."
         spinecolor = :black
         "Controls whether the spine is visible."
@@ -2317,7 +2317,7 @@ end
         gridz::Float32 = -100
 
         "The color of the `r` grid."
-        rgridcolor = inherit(scene, (:Axis, :xgridcolor), (:black, 0.5))
+        rgridcolor = inherit(scene, (:Axis, :xgridcolor), RGBAf(0, 0, 0, 0.12))
         "The linewidth of the `r` grid."
         rgridwidth::Float32 = inherit(scene, (:Axis, :xgridwidth), 1)
         "The linestyle of the `r` grid."
@@ -2326,7 +2326,7 @@ end
         rgridvisible::Bool = inherit(scene, (:Axis, :xgridvisible), true)
 
         "The color of the `r` minor grid."
-        rminorgridcolor = inherit(scene, (:Axis, :xminorgridcolor), (:black, 0.2))
+        rminorgridcolor = inherit(scene, (:Axis, :xminorgridcolor), RGBAf(0, 0, 0, 0.05))
         "The linewidth of the `r` minor grid."
         rminorgridwidth::Float32 = inherit(scene, (:Axis, :xminorgridwidth), 1)
         "The linestyle of the `r` minor grid."
@@ -2337,7 +2337,7 @@ end
         # Theta minor and major grid
 
         "The color of the `theta` grid."
-        thetagridcolor = inherit(scene, (:Axis, :ygridcolor), (:black, 0.5))
+        thetagridcolor = inherit(scene, (:Axis, :ygridcolor), RGBAf(0, 0, 0, 0.12))
         "The linewidth of the `theta` grid."
         thetagridwidth::Float32 = inherit(scene, (:Axis, :ygridwidth), 1)
         "The linestyle of the `theta` grid."
@@ -2347,7 +2347,7 @@ end
 
 
         "The color of the `theta` minor grid."
-        thetaminorgridcolor = inherit(scene, (:Axis, :yminorgridcolor), (:black, 0.2))
+        thetaminorgridcolor = inherit(scene, (:Axis, :yminorgridcolor), RGBAf(0, 0, 0, 0.05))
         "The linewidth of the `theta` minor grid."
         thetaminorgridwidth::Float32 = inherit(scene, (:Axis, :yminorgridwidth), 1)
         "The linestyle of the `theta` minor grid."

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -2364,9 +2364,9 @@ end
         "The alignment of the title.  Can be any of `:center`, `:left`, or `:right`."
         titlealign = :center
         "The fontsize of the title."
-        titlesize::Float32 = inherit(scene, (:Axis, :titlesize), map(x -> 1.2x, inherit(scene, :fontsize, 16)))
+        titlesize::Float32 = inherit(scene, (:Axis, :titlesize), inherit(scene, :fontsize, 16))
         "The font of the title."
-        titlefont = inherit(scene, (:Axis, :titlefont), inherit(scene, :font, Makie.defaultfont()))
+        titlefont = inherit(scene, (:Axis, :titlefont), :bold)
         "The color of the title."
         titlecolor = inherit(scene, (:Axis, :titlecolor), inherit(scene, :textcolor, :black))
         "Controls if the title is visible."


### PR DESCRIPTION
## Description

`PolarAxis` grid colors, spine width, and title styling have always differed from `Axis`. These fallbacks were chosen independently when `PolarAxis` was first introduced (#2990 / #3154) and were never harmonized with the long-standing `Axis` defaults. There is no documented rationale for the drift, and the result is that a default `PolarAxis` renders noticeably darker grids, a thicker spine, and a larger non-bold title compared to a regular `Axis`.

This aligns them:

| attribute | old PolarAxis fallback | new (matches Axis) |
| --- | --- | --- |
| major grid color | black @ 50% | `RGBAf(0, 0, 0, 0.12)` |
| minor grid color | black @ 20% | `RGBAf(0, 0, 0, 0.05)` |
| `spinewidth` | `2` | `1` |
| `titlefont` | regular (default font) | `:bold` |
| `titlesize` | `1.2 × fontsize` (≈19.2) | `fontsize` (16) |
| `titlegap` | `fontsize / 2` (≈8), inheriting the wrong `(:Axis, :titlesize)` key | `4`, inheriting `(:Axis, :titlegap)` |

The `inherit(scene, (:Axis, ...), fallback)` lookups are kept intact, so theming an `Axis` value still flows through to `PolarAxis` — only the fallbacks changed. Grid width/style/visibility fallbacks already matched `Axis`.

## Comparison

```julia
using CairoMakie

fig = Figure(size = (450, 450), figure_padding = 10)
ax = PolarAxis(fig[1, 1];
    title = "PolarAxis Title",
    rminorgridvisible = true,
    thetaminorgridvisible = true,
)
lines!(ax, range(0, 2pi, length = 200), range(0, 1, length = 200), color = :tomato)
fig
```

| `master` (before) | this PR (after) |
| --- | --- |
| <img width="900" height="900" alt="polar_main" src="https://github.com/user-attachments/assets/2e77449e-6006-47a0-b7cf-57529da3c2d0" /> | <img width="900" height="900" alt="polar_pr" src="https://github.com/user-attachments/assets/13945287-fab2-4241-8a94-58911b6f963e" /> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in `CHANGELOG.md` (for new features and breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
