### PR TITLE
use :cycled instead of nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed cycled attributes overriding values that the user set explicitly to a value that happened to coincide with the internal "derive from cycle" default, most notably a `Legend` showing a non-solid linestyle for plots whose linestyle was explicitly `nothing`/`:solid` while a `Cycle([:linestyle])` was active [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267).
+- Adjusted cycled attributes to be marked as `:cycled` instead of `nothing` so that `nothing` doesn't get overridden. This allows e.g. `linestyle = nothing` to be set when `linestyle` is cycled. [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267)
 
 ## [0.24.12] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed cycled attributes overriding values that the user set explicitly to a value that happened to coincide with the internal "derive from cycle" default, most notably a `Legend` showing a non-solid linestyle for plots whose linestyle was explicitly `nothing`/`:solid` while a `Cycle([:linestyle])` was active [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267).
+
 ## [0.24.12] - 2026-06-18
 
 - `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -631,12 +631,26 @@ function add_attributes!(::Type{T}, attr, kwargs) where {T <: Plot}
         for (k, p) in lookup
             # If user explicitly passes values, we should not do anything
             let plotcycle = cycle
-                add_input!(attr, k, get(kwargs, k, nothing)) do key, value
+                # We use the sentinel value `:cycled` (instead of `nothing`) to mark
+                # cycled attributes that the user did *not* set explicitly and which
+                # should therefore be derived from the cycle below. This is important
+                # because `nothing` is itself a valid, user-providable value for some
+                # cycled attributes -- most notably `linestyle = nothing` (and `:solid`,
+                # which `convert_attribute` turns into `nothing`) means "draw a solid
+                # line". If we used `nothing` as the sentinel, such an explicitly
+                # requested solid linestyle would be indistinguishable from "not set"
+                # and would incorrectly be overridden by the cycle. This happens e.g.
+                # for the line plots that `Legend` creates with `linestyle = nothing`,
+                # see https://github.com/MakieOrg/Makie.jl/issues/5267
+                add_input!(attr, k, get(kwargs, k, :cycled)) do key, value
                     palettes = attr.palettes[]
                     if value isa Cycled
                         value = get_cycle_attribute(palettes, key, value.i, plotcycle)
                     end
-                    if !isnothing(value)
+                    # Anything the user set explicitly (including `nothing`) is kept as
+                    # is; only the `:cycled` sentinel triggers deriving the value from
+                    # the cycle.
+                    if value !== :cycled
                         if is_primitive
                             return convert_attribute(value, Key{key}(), Key{name}())
                         else
@@ -791,7 +805,13 @@ function _cycle_position(plot::Plot, plot_iter)
             cp === plot && return pos
             if haskey(cp, :cycle) && !isnothing(cp.cycle[]) && plotfunc(cp) === plotfunc(plot)
                 is_cycling = any(syms) do x
-                    return haskey(cp.attributes.inputs, x) && isnothing(cp.attributes.inputs[x].value)
+                    # A plot only participates in cycling for attribute `x` if the
+                    # user did not set `x` explicitly. We detect this via the
+                    # `:cycled` sentinel that `add_attributes!` stores as the input
+                    # value for unset cycled attributes (see there for why we cannot
+                    # use `nothing` here -- an explicit `linestyle = nothing` must
+                    # count as "set by user", not as "cycling").
+                    return haskey(cp.attributes.inputs, x) && cp.attributes.inputs[x].value === :cycled
                 end
                 if is_cycling
                     pos += 1

--- a/Makie/test/pipeline.jl
+++ b/Makie/test/pipeline.jl
@@ -120,6 +120,34 @@ end
     @test pl2.scaled_color[] == cpalette[1]
 end
 
+@testset "explicit attributes override the cycle (#5267)" begin
+    # When a cycle is active for an attribute, an explicitly set value must always
+    # win over the cycle -- even when that value happens to equal the "derive from
+    # cycle" default. The tricky case is `linestyle`: a solid line is represented
+    # by `nothing`, which used to double as the "not set, derive from cycle" marker.
+    # `Legend` runs into this because it creates its line elements with an explicit
+    # `linestyle = nothing` (solid). See
+    # https://github.com/MakieOrg/Makie.jl/issues/5267
+    f = Figure()
+    ax = Axis(f[1, 1])
+    # The default linestyle palette is [nothing, :dash, :dot, :dashdot, :dashdotdot],
+    # so without an explicit value the second cycling line would get `:dash`.
+    pl1 = lines!(ax, 1:4; cycle = [:linestyle])
+    pl2 = lines!(ax, 1:4; cycle = [:linestyle], linestyle = nothing)
+    pl3 = lines!(ax, 1:4; cycle = [:linestyle], linestyle = :solid)
+    pl4 = lines!(ax, 1:4; cycle = [:linestyle])
+    # The first line cycles and stays solid (palette index 1 is `nothing`).
+    @test pl1.linestyle[] === nothing
+    # The explicitly set solid linestyles must not be overridden by the cycle.
+    @test pl2.linestyle[] === nothing
+    @test pl3.linestyle[] === nothing
+    # Because `pl2` and `pl3` set `linestyle` explicitly, they must not count as
+    # cycling and thus must not advance the cycle. `pl4` is therefore only the
+    # second *cycling* line and gets palette index 2, i.e. `:dash`.
+    expected_dash = Makie.convert_attribute(:dash, Makie.Key{:linestyle}(), Makie.Key{:lines}())
+    @test pl4.linestyle[] == expected_dash
+end
+
 function test_default(arg)
     _, _, pl1 = plot(arg)
 


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/5267
Closes https://github.com/MakieOrg/Makie.jl/pull/5669

There is a bug when a cycle changes the linestyle but the users sets the linestyle to solid explicitly for a plot.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
