### PR TITLE
Update Colorbar to compute graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Refactored `Axis` to use the compute graph [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
   - **minor breaking** Custom interactions that manipulated `ax.targetlimits` should now update `ax.localxlimits` and `ax.localylimits` instead and read from either `ax.targetlimits` or `sharedxlimits` and `sharedylimits`. Otherwise they will not correctly update linked axes.
   - Redisplaying a figure after emptying an axis now resets its limits if they aren't set to specific values.
-- Refactored `Colorbar` to use the comptue graph [#5678](https://github.com/MakieOrg/Makie.jl/pull/5678)
+- Refactored `Colorbar` to use the compute graph [#5678](https://github.com/MakieOrg/Makie.jl/pull/5678)
   - **minor breaking** `extract_colormap(plot)` is now expected to return a `Dict` containing the `color`, `colormap`, `colorrange`, `colorscale`, `lowclip` and `highclip` attributes of the given plot. Returning a `Makie.ColorMapping` still works but is considered deprecated.
   - **minor breaking** The `limits` attribute has been deprecated in favor of `colorrange`
 - Fixed an issue where Observable outputs of compute nodes that cycle back into the compute graph could discard updates of other Observable outputs. [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 - Refactored `Axis` to use the compute graph [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
   - **minor breaking** Custom interactions that manipulated `ax.targetlimits` should now update `ax.localxlimits` and `ax.localylimits` instead and read from either `ax.targetlimits` or `sharedxlimits` and `sharedylimits`. Otherwise they will not correctly update linked axes.
   - Redisplaying a figure after emptying an axis now resets its limits if they aren't set to specific values.
+- Refactored `Colorbar` to use the comptue graph [#5678](https://github.com/MakieOrg/Makie.jl/pull/5678)
+  - **minor breaking** `extract_colormap(plot)` is now expected to return a `Dict` containing the `color`, `colormap`, `colorrange`, `colorscale`, `lowclip` and `highclip` attributes of the given plot. Returning a `Makie.ColorMapping` still works but is considered deprecated.
 - Fixed an issue where Observable outputs of compute nodes that cycle back into the compute graph could discard updates of other Observable outputs. [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
 - Added `ComputePipeline.set_type!(node, type)` for initializing the type of a compute graph node [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
 - Added `ExplicitUpdate` wrapper to control update propagation for computations in the compute graph. Also added an option for forcefully propagate updates from input nodes. [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
   - Redisplaying a figure after emptying an axis now resets its limits if they aren't set to specific values.
 - Refactored `Colorbar` to use the comptue graph [#5678](https://github.com/MakieOrg/Makie.jl/pull/5678)
   - **minor breaking** `extract_colormap(plot)` is now expected to return a `Dict` containing the `color`, `colormap`, `colorrange`, `colorscale`, `lowclip` and `highclip` attributes of the given plot. Returning a `Makie.ColorMapping` still works but is considered deprecated.
+  - **minor breaking** The `limits` attribute has been deprecated in favor of `colorrange`
 - Fixed an issue where Observable outputs of compute nodes that cycle back into the compute graph could discard updates of other Observable outputs. [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
 - Added `ComputePipeline.set_type!(node, type)` for initializing the type of a compute graph node [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)
 - Added `ExplicitUpdate` wrapper to control update propagation for computations in the compute graph. Also added an option for forcefully propagate updates from input nodes. [#5546](https://github.com/MakieOrg/Makie.jl/pull/5546)

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -623,8 +623,7 @@ function calculated_attributes!(::Type{Heatmap}, plot::HeatmapShader)
     return
 end
 
-extract_colormap_recursive(plot::HeatmapShader) = extract_colormap_recursive(plot.plots[1])
-
+extract_colorbar_attributes(plot::HeatmapShader) = extract_colorbar_attributes_with_defaults(plot.plots[1])
 
 function resample_image(x, y, image, max_resolution, limits)
     # extent of the image in data coordinates (same as limits)

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -623,7 +623,7 @@ function calculated_attributes!(::Type{Heatmap}, plot::HeatmapShader)
     return
 end
 
-extract_colorbar_attributes(plot::HeatmapShader) = extract_colorbar_attributes_with_defaults(plot.plots[1])
+extract_colormap(plot::HeatmapShader) = extract_colormap(plot.plots[1])
 
 function resample_image(x, y, image, max_resolution, limits)
     # extent of the image in data coordinates (same as limits)

--- a/Makie/src/basic_recipes/voxels.jl
+++ b/Makie/src/basic_recipes/voxels.jl
@@ -109,19 +109,17 @@ function register_voxel_colormapping!(attr)
     add_constant!(attr, :fetch_pixel, false) # for CairoMakie
     if isnothing(attr[:color][])
         map!(
-            attr, [:colormap, :alpha, :lowclip, :highclip],
-            [:alpha_colormap, :voxel_colormap, :color_mapping_type]
+            attr, [:colormap, :alpha, :lowclip, :highclip], :voxel_colormap
         ) do cmap, alpha, lowclip, highclip
             N = 253 + (lowclip === automatic) + (highclip === automatic)
-            acm = add_alpha.(resample_cmap(cmap, N), alpha)
-            vcm = acm
+            cm = add_alpha.(resample_cmap(cmap, N), alpha)
             if lowclip !== automatic
-                vcm = [to_color(lowclip); vcm]
+                cm = [to_color(lowclip); cm]
             end
             if highclip !== automatic
-                vcm = [vcm; to_color(highclip)]
+                cm = [cm; to_color(highclip)]
             end
-            return acm, vcm, colormapping_type(colormap)
+            return cm
         end
     else
         register_computation!(attr, [:color, :alpha], [:voxel_color]) do (color, alpha), changed, cached

--- a/Makie/src/basic_recipes/voxels.jl
+++ b/Makie/src/basic_recipes/voxels.jl
@@ -108,16 +108,20 @@ function register_voxel_colormapping!(attr)
     # TODO: Is resolving this immediately fine?
     add_constant!(attr, :fetch_pixel, false) # for CairoMakie
     if isnothing(attr[:color][])
-        register_computation!(attr, [:colormap, :alpha, :lowclip, :highclip], [:voxel_colormap]) do (cmap, alpha, lowclip, highclip), changed, cached_load
+        map!(
+            attr, [:colormap, :alpha, :lowclip, :highclip],
+            [:alpha_colormap, :voxel_colormap, :color_mapping_type]
+        ) do cmap, alpha, lowclip, highclip
             N = 253 + (lowclip === automatic) + (highclip === automatic)
-            cm = add_alpha.(resample_cmap(cmap, N), alpha)
+            acm = add_alpha.(resample_cmap(cmap, N), alpha)
+            vcm = acm
             if lowclip !== automatic
-                cm = [to_color(lowclip); cm]
+                vcm = [to_color(lowclip); vcm]
             end
             if highclip !== automatic
-                cm = [cm; to_color(highclip)]
+                vcm = [vcm; to_color(highclip)]
             end
-            return (cm,)
+            return acm, vcm, colormapping_type(colormap)
         end
     else
         register_computation!(attr, [:color, :alpha], [:voxel_color]) do (color, alpha), changed, cached

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -213,7 +213,7 @@ function register_colormapping_without_color!(attr::ComputeGraph)
     for key in (:lowclip, :highclip)
         sym = Symbol(key, :_color)
         map!(attr, [key, :alpha_colormap], sym) do input, cmap
-            if input === automatic
+            if input === automatic || input === nothing
                 return ifelse(key == :lowclip, first(cmap), last(cmap))
             else
                 return to_color(input)

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -719,12 +719,21 @@ function initialize_block_arguments!(
     end
 
     if length(converted_names) != length(attr.converted[])
-        error(
-            "Failed to construct Block: Expected $(length(converted_names)) converted \
-            argument(s) to map to `$converted_names` but got $(length(attr.converted[])): \
-            $(attr.converted[]). This means that `$T` did not correctly convert the given \
-            arguments."
-        )
+        if length(converted_names) == 0
+            error(
+                "Failed to construct Block: Expected no arguments but got: $(attr.converted[]). \
+                If $T is a primitive block, a workaround method $T(fig_or_scene, args...) maybe \
+                missing or failed to be called. If $T is a Complex/Block recipe, it is likely not \
+                declaring its arguments in `@Block Name (args...)."
+            )
+        else
+            error(
+                "Failed to construct Block: Expected $(length(converted_names)) converted \
+                argument(s) to map to `$converted_names` but got $(length(attr.converted[])): \
+                $(attr.converted[]). This means that `$T` did not correctly convert the given \
+                arguments."
+            )
+        end
     end
 
     # splat to defined names

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -7,6 +7,19 @@ function colorbar_check(keys, kwargs_keys)
     return
 end
 
+# compat
+extract_colormap(::AbstractPlot) = nothing
+function extract_colormap_recursive(plot::AbstractPlot)
+    result = extract_colormap(plot)
+    if isnothing(result)
+        for child in plot.plots
+            child_result = extract_colormap_recursive(child)
+            isnothing(child_result) || return child_result
+        end
+    end
+    return result
+end
+
 function extract_colorbar_attributes(plot::Arrows2D)
     map!(plot, [:tailcolor, :shaftcolor, :tipcolor, :color], :raw_merged_color) do a, b, c, d
         return [default_automatic(a, d); default_automatic(b, d); default_automatic(c, d)]
@@ -17,6 +30,7 @@ end
 extract_colorbar_attributes(plot::Voxels) = (color = plot.chunk, colorrange = plot.value_limits)
 extract_colorbar_attributes(plot::StreamPlot) = extract_colorbar_attributes_with_defaults(plot.plots[1])
 extract_colorbar_attributes(plot::VolumeSlices) = (color = plot[4],)
+extract_colorbar_attributes(plot::Hexbin) = (color = plot.count_hex,)
 
 _normalize_clipcolor(x) = x in (nothing, :auto, automatic) ? automatic : x
 function extract_colorbar_attributes(plot::Union{Contourf, Tricontourf})
@@ -24,6 +38,7 @@ function extract_colorbar_attributes(plot::Union{Contourf, Tricontourf})
     map!(_normalize_clipcolor, plot, :extendhigh, :cb_highclip)
     return (
         color = plot.computed_levels,
+        colormap = plot.computed_colormap,
         colorrange = plot.computed_colorrange,
         lowclip = plot.cb_lowclip,
         highclip = plot.cb_highclip,
@@ -84,20 +99,37 @@ function extract_colorbar_attributes_with_defaults(plot::AbstractPlot)
 end
 
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
-    _cmap = extract_colorbar_attributes(plot)
     cmap = Dict{Symbol, Any}()
-    for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
-        if haskey(_cmap, name)
-            cmap[name] = _cmap[name]
-        elseif haskey(plot, name)
-            push!(cmap, name => plot[name])
+
+    dep_cmap = extract_colormap_recursive(plot)
+    if !isnothing(dep_cmap)
+        @warn "`extract_colormap` is deprecated in favor of `extract_colorbar_attributes`"
+        cmap[:values] = dep_cmap.color
+        cmap[:colormap] = dep_cmap.raw_colormap
+        cmap[:colorrange] = dep_cmap.colorrange
+        cmap[:scale] = dep_cmap.scale
+        cmap[:lowclip] = dep_cmap.lowclip
+        cmap[:highclip] = dep_cmap.highclip
+    else
+        _cmap = extract_colorbar_attributes(plot)
+        for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
+            if haskey(_cmap, name)
+                cmap[name] = _cmap[name]
+            elseif haskey(plot, name)
+                push!(cmap, name => plot[name])
+            end
+        end
+        if !haskey(cmap, :color) && haskey(plot, :raw_color)
+            cmap[:values] = plot.raw_color
         end
     end
+
     haskey(cmap, :colorscale) && (cmap[:scale] = pop!(cmap, :colorscale))
     haskey(cmap, :color) && (cmap[:values] = pop!(cmap, :color))
 
-    colorbar_check(keys(cmap), keys(kwargs))
-
+    cmap_keys = collect(keys(cmap))
+    haskey(cmap, :colorrange) && push!(cmap_keys, :limits)
+    colorbar_check(cmap_keys, keys(kwargs))
     func = plotfunc(plot)
     # if isnothing(cmap)
     #     error("Neither $(func) nor any of its children use a colormap. Cannot create a Colorbar from this plot, please create it manually.
@@ -123,6 +155,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
     map!(cb, [:size, :vertical], :autosize) do sz, vertical
         return vertical ? (sz, nothing) : (nothing, sz)
     end
+    ComputePipeline.set_type!(cb.autosize, Any)
     map!(identity, blockscene, cb.layoutobservables.autosize, cb.autosize)
 
     add_input!(cb, :computedbbox, cb.layoutobservables.computedbbox)
@@ -130,12 +163,28 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
 
     # Run the normal color(map) processing. This either uses the inputs given
     # to `Colorbar()` explicitly, or the inputs extracted from a plot.
-    ComputePipeline.alias!(cb.attributes, :scale, :colorscale)
-    register_colormapping!(cb.attributes, :values)
+    register_colormapping_without_color!(cb.attributes)
+    register_computation!(
+        cb.attributes, [:values, :colorrange, :limits], [:resolved_colorrange]
+    ) do (values, _colorrange, limits), changed, @nospecialize(cached)
+        colorrange = if changed.limits && (limits !== automatic)
+            @warn("Colorbar :limits has been deprecated in favor of :colorrange.")
+            limits
+        else
+            _colorrange
+        end
+        if colorrange === automatic || colorrange === nothing
+            return (Vec2d(distinct_extrema_nan(values)...),)
+        else
+            low = colorrange[1] in (automatic, nothing) ? minimum(values) : colorrange[1]
+            high = colorrange[2] in (automatic, nothing) ? maximum(values) : colorrange[2]
+            return (Vec2d(low, high),)
+        end
+    end
 
     map!(
         cb,
-        [:color_mapping, :color_mapping_type, :scaled_color, :nsteps, :scaled_colorrange],
+        [:color_mapping, :color_mapping_type, :values, :nsteps, :resolved_colorrange],
         :cb_colors
     ) do mapping, mapping_type, values, n, limits
         if mapping_type === Makie.continuous
@@ -183,7 +232,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
 
     map!(
         cb,
-        [:barbox, :vertical, :cb_colors, :colorscale, :color_mapping_type],
+        [:barbox, :vertical, :cb_colors, :scale, :color_mapping_type],
         [:xrange, :yrange]
     ) do bb, vertical, colors, scale, mapping_type
         xmin, ymin = minimum(bb)
@@ -195,11 +244,11 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         mini, maxi = extrema(s_scaled)
         s_scaled = (s_scaled .- mini) ./ (maxi - mini)
         if vertical
-            xrange = LinRange(xmin, xmax, 2)
+            xrange = collect(LinRange(xmin, xmax, 2))
             yrange = s_scaled .* (ymax - ymin) .+ ymin
         else
             xrange = s_scaled .* (xmax - xmin) .+ xmin
-            yrange = LinRange(ymin, ymax, 2)
+            yrange = collect(LinRange(ymin, ymax, 2))
         end
         return xrange, yrange
     end
@@ -226,7 +275,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         blockscene,
         cb.xrange, cb.yrange, cb.continuous_pixels;
         colormap = cb.alpha_colormap,
-        colorrange = cb.scaled_colorrange,
+        colorrange = cb.colorrange,
         visible = cb.show_cats,
         inspectable = false
     )
@@ -238,7 +287,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         blockscene,
         cb.xlims, cb.ylims, cb.continuous_pixels;
         colormap = cb.alpha_colormap,
-        colorrange = cb.scaled_colorrange,
+        colorrange = cb.colorrange,
         visible = cb.show_continuous,
         inspectable = false
     )
@@ -252,9 +301,9 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
             return [Polygon([lt, rt, et]), Polygon([lb, rb, eb])]
         else
             br, tr = rightline(box)
-            er = ((b .+ t) ./ 2) .+ Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
+            er = ((br .+ tr) ./ 2) .+ Point2f(sqrt(sum((tr .- br) .^ 2)) * sin(pi / 3), 0)
             bl, tl = leftline(box)
-            el = ((b .+ t) ./ 2) .- Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
+            el = ((bl .+ tl) ./ 2) .- Point2f(sqrt(sum((tl .- bl) .^ 2)) * sin(pi / 3), 0)
             return [Polygon([br, tr, er]), Polygon([bl, tl, el])]
         end
     end
@@ -319,13 +368,13 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         end
     end
 
-    ticks = Observable{Any}()
     map!(cb, [:cb_colors, :color_mapping_type, :ticks], :finalticks) do cs, type, ticks
         # For categorical we just enumerate
         return type === Makie.categorical ? (1:length(cs), string.(cs)) : ticks
     end
+    ComputePipeline.set_type!(cb.finalticks, Any)
 
-    map!(cb, [:cb_colors, :color_mapping_type, :scaled_colorrange], :ticklimits) do cs, type, limits
+    map!(cb, [:cb_colors, :color_mapping_type, :resolved_colorrange], :ticklimits) do cs, type, limits
         return type === Makie.categorical ? (0.5, length(cs) + 0.5) : limits
     end
 
@@ -346,7 +395,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         spinecolor = :transparent, spinevisible = false, flip_vertical_label = cb.flip_vertical_label,
         minorticksvisible = cb.minorticksvisible, minortickalign = cb.minortickalign,
         minorticksize = cb.minorticksize, minortickwidth = cb.minortickwidth,
-        minortickcolor = cb.minortickcolor, minorticks = cb.minorticks, scale = cb.colorscale
+        minortickcolor = cb.minortickcolor, minorticks = cb.minorticks, scale = cb.scale
     )
 
     cb.axis = axis

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -7,107 +7,30 @@ function colorbar_check(keys, kwargs_keys)
     return
 end
 
-function extract_colormap(@nospecialize(plot::AbstractPlot))
-    minimal_keys = (:color, :colormap, :colorrange)
-
-    if all(key -> haskey(plot, key), minimal_keys)
-        # TODO: maybe we should check that all or none of the outputs of
-        # register_colormapping!() are available?
-
-        if plot.color[] isa Union{AbstractArray{<:Colorant}, ShaderAbstractions.Sampler, AbstractPattern, Colorant}
-            return nothing
-        end
-
-        haskey(plot, :alpha) || add_constant!(plot, :alpha, 1.0)
-        haskey(plot, :lowclip) || add_constant!(plot, :lowclip, automatic)
-        haskey(plot, :highclip) || add_constant!(plot, :highclip, automatic)
-        haskey(plot, :nan_color) || add_constant!(plot, :nan_color, RGBAf(0, 0, 0, 0))
-        haskey(plot, :colorscale) || add_constant!(plot, :colorscale, identity)
-
-        if !haskey(plot, :scaled_colorrange)
-            register_colormapping!(plot.attributes)
-        end
-
-        isnothing(plot.scaled_colorrange[]) && return nothing
-
-        return (
-            color = plot.color,
-            colormap = plot.alpha_colormap,
-            colorscale = plot.colorscale,
-            mapping = plot.color_mapping,
-            colorrange = plot.scaled_colorrange,
-            lowclip = plot.lowclip,
-            highclip = plot.highclip,
-            color_mapping_type = plot.color_mapping_type
-        )
+function extract_colorbar_attributes(plot::Arrows2D)
+    map!(plot, [:tailcolor, :shaftcolor, :tipcolor, :color], :raw_merged_color) do a, b, c, d
+        return [default_automatic(a, d); default_automatic(b, d); default_automatic(c, d)]
     end
+    return (; color = plot.raw_merged_color)
 end
 
-function extract_colormap(plot::ComputePlots)
-    return (
-        color = plot.scaled_color,
-        colormap = plot.alpha_colormap,
-        colorscale = plot.colorscale,
-        mapping = plot.color_mapping,
-        colorrange = plot.scaled_colorrange,
-        lowclip = plot.lowclip,
-        highclip = plot.highclip,
-        color_mapping_type = plot.color_mapping_type
-    )
-end
-
-function extract_colormap(plot::Arrows2D)
-    map!(plot, [:scaled_tailcolor, :scaled_shaftcolor, :scaled_tipcolor], :scaled_merged_color) do a, b, c
-        return [a; b; c]
-    end
-    return (
-        color = plot.scaled_merged_color,
-        colormap = plot.alpha_colormap,
-        colorscale = plot.colorscale,
-        mapping = plot.color_mapping,
-        colorrange = plot.scaled_colorrange,
-        lowclip = plot.lowclip,
-        highclip = plot.highclip,
-        color_mapping_type = plot.color_mapping_type
-    )
-end
-
-function extract_colormap(plot::Voxels)
-    return (
-        color = plot.chunk,
-        colormap = plot.alpha_colormap,
-        colorscale = plot.colorscale,
-        mapping = nothing, # not supported
-        colorrange = plot.value_limits,
-        lowclip = plot.lowclip,
-        highclip = plot.highclip,
-        color_mapping_type = plot.color_mapping_type
-    )
-end
-
-extract_colormap(plot::StreamPlot) = extract_colormap(plot.plots[1])
-extract_colormap(plot::VolumeSlices) = extract_colormap(plot.plots[1])
+extract_colorbar_attributes(plot::Voxels) = (color = plot.chunk, colorrange = plot.value_limits)
+extract_colorbar_attributes(plot::StreamPlot) = extract_colorbar_attributes_with_defaults(plot.plots[1])
+extract_colorbar_attributes(plot::VolumeSlices) = (color = plot[4],)
 
 _normalize_clipcolor(x) = x in (nothing, :auto, automatic) ? automatic : x
-function extract_colormap(plot::Union{Contourf, Tricontourf})
-    map!(plot, :computed_colormap, [:alpha_colormap, :color_mapping]) do cm
-        return to_colormap(cm), cm.values
-    end
+function extract_colorbar_attributes(plot::Union{Contourf, Tricontourf})
     map!(_normalize_clipcolor, plot, :extendlow, :cb_lowclip)
     map!(_normalize_clipcolor, plot, :extendhigh, :cb_highclip)
     return (
         color = plot.computed_levels,
-        colormap = plot.alpha_colormap,
-        colorscale = plot.colorscale,
-        mapping = plot.color_mapping,
-        colorrange = plot.computed_colorrange, # missing colorscale?
+        colorrange = plot.computed_colorrange,
         lowclip = plot.cb_lowclip,
         highclip = plot.cb_highclip,
-        color_mapping_type = banded
     )
 end
 
-function extract_colormap(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
+function extract_colorbar_attributes(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
     # Users may use transparency to make layered isosurfaces visible. Because
     # 3D contours often accumulate the color of an isosurface over multiple
     # samples one typically needs very low alpha values for this, which would
@@ -118,42 +41,70 @@ function extract_colormap(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, 
     return (
         color = plot.value_levels,
         colormap = plot.opaque_colormap,
-        colorscale = plot.colorscale,
-        mapping = nothing,
-        colorrange = plot.padded_colorrange, # missing colorscale?
-        lowclip = automatic,
-        highclip = automatic,
-        color_mapping_type = continuous
+        colorrange = plot.padded_colorrange,
     )
 end
 
-function extract_colormap_recursive(@nospecialize(plot::T)) where {T <: AbstractPlot}
-    cmap = extract_colormap(plot)
-    if !isnothing(cmap)
-        return cmap
-    else
-        colormaps = [extract_colormap_recursive(child) for child in plot.plots]
-        if length(colormaps) == 1
-            return colormaps[1]
-        elseif isempty(colormaps)
-            return nothing
-        else
-            error("Multiple colormaps found for plot $(plot), please specify which one to use manually. Please overload `Makie.extract_colormap(::$(T))` to allow for the automatic creation of a Colorbar.")
+# TODO: compat for ColorMapping
+
+"""
+    extract_colorbar_attributes(plot)
+
+This function extract plot attributes relevant for constructing a `Colorbar`.
+It is meant to be extended for recipes that do not use the default names.
+
+The function should return a dict-like object (one implementing `getindex` and `haskey`)
+containing `name => attribute` pairs. It may contain any of the following names:
+- `:colormap`: The colormap of the plot.
+- `:color`: The color values that the colormap applies to.
+- `:colorrange`: The colorrange of the plot, i.e. the extrema of `color`.
+- `:colorscale`: The colorscale of plot.
+- `:lowclip`: The lowclip of the plot.
+- `:highclip`: The highclip of the plot.
+
+Any missing `name` will default to the appropriate `plot[name]` attribute if it
+exists, or to the default defined by `Colorbar`.
+
+Note that you can use `extract_colorbar_attributes_with_defaults(plot)` to
+extract attributes with defaults from a child plot.
+"""
+extract_colorbar_attributes(::AbstractPlot) = NamedTuple()
+
+function extract_colorbar_attributes_with_defaults(plot::AbstractPlot)
+    _cmap = extract_colorbar_attributes(plot)
+    cmap = Dict{Symbol, Any}()
+    for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
+        if haskey(_cmap, name)
+            cmap[name] = _cmap[name]
+        elseif haskey(plot, name)
+            push!(cmap, name => plot[name])
         end
     end
+    return cmap
 end
 
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
-    colorbar_check((:colormap, :limits, :highclip, :lowclip), keys(kwargs))
-
-    cmap = extract_colormap_recursive(plot)
-    func = plotfunc(plot)
-    if isnothing(cmap)
-        error("Neither $(func) nor any of its children use a colormap. Cannot create a Colorbar from this plot, please create it manually.
-        If this is a recipe, one needs to overload `Makie.extract_colormap(::$(Plot{func}))` to allow for the automatic creation of a Colorbar.")
+    _cmap = extract_colorbar_attributes(plot)
+    cmap = Dict{Symbol, Any}()
+    for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
+        if haskey(_cmap, name)
+            cmap[name] = _cmap[name]
+        elseif haskey(plot, name)
+            push!(cmap, name => plot[name])
+        end
     end
+    haskey(cmap, :colorscale) && (cmap[:scale] = pop!(cmap, :colorscale))
+    haskey(cmap, :color) && (cmap[:values] = pop!(cmap, :color))
 
-    if to_value(cmap.color) isa Union{AbstractVector{<:Colorant}, Colorant}
+    colorbar_check(keys(cmap), keys(kwargs))
+
+    func = plotfunc(plot)
+    # if isnothing(cmap)
+    #     error("Neither $(func) nor any of its children use a colormap. Cannot create a Colorbar from this plot, please create it manually.
+    #     If this is a recipe, one needs to overload `Makie.extract_colormap(::$(Plot{func}))` to allow for the automatic creation of a Colorbar.")
+    # end
+
+    if haskey(cmap, :values) && to_value(cmap[:values]) isa Union{AbstractArray{<:Colorant}, Colorant, ShaderAbstractions.Sampler, AbstractPattern}
         error(
             """Plot $(func)'s color attribute uses colors directly, so it can't be used to create a Colorbar, since no numbers are mapped to a color via the colormap.
                  Please create the colorbar manually e.g. via `Colorbar(f[1, 2], colorrange=the_range, colormap=the_colormap)`..
@@ -161,11 +112,7 @@ function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
         )
     end
 
-    return Colorbar(
-        fig_or_scene;
-        plot_data = cmap,
-        kwargs...
-    )
+    return Colorbar(fig_or_scene; cmap..., kwargs...)
 end
 
 block_kwargs(::Type{Colorbar}) = Set([:plot_data])
@@ -181,36 +128,14 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
     add_input!(cb, :computedbbox, cb.layoutobservables.computedbbox)
     map!(round_to_IRect2D, cb, :computedbbox, :framebox)
 
-    cmap = ComputePipeline.ComputeGraphView(cb.attributes, :color_mapping)
-    if plot_data isa NamedTuple
-        add_input!(cmap, :color, plot_data.color)
-        add_input!(cmap, :colormap, plot_data.colormap)
-        add_input!(cmap, :scale, plot_data.colorscale)
-        add_input!(cmap, :mapping, plot_data.mapping)
-        add_input!(cmap, :colorrange, plot_data.colorrange)
-        add_input!(cmap, :lowclip, plot_data.lowclip)
-        add_input!(cmap, :highclip, plot_data.highclip)
-        add_input!(cmap, :color_mapping_type, plot_data.color_mapping_type)
-    else
-        # Old way without Colormapping. We keep it, to be able to create a colormap directly
-        map!(cmap, [cb.limits, cb.colorrange], :colorrange) do limits, colorrange
-            if all(!isnothing, (limits, colorrange))
-                error("Both colorrange + limits are set, please only set one, they're aliases. colorrange: $(colorrange), limits: $(limits)")
-            end
-            return something(limits, colorrange, (0.0, 1.0))
-        end
-        add_constant!(cmap, :color, Float64[])
-        map!(c -> c isa Union{Nothing, Automatic} ? automatic : to_color(c), cmap, cb.lowclip, :lowclip)
-        map!(c -> c isa Union{Nothing, Automatic} ? automatic : to_color(c), cmap, cb.highclip, :highclip)
-        map!(to_colormap, cmap, cb.colormap, :colormap)
-        map!(identity, cmap, cb.scale, :scale)
-        map!(cm -> cm isa PlotUtils.ColorGradient ? cm.values : nothing, cmap, cb.colormap, :mapping)
-        map!(colormapping_type, cmap, cb.colormap, :color_mapping_type)
-    end
+    # Run the normal color(map) processing. This either uses the inputs given
+    # to `Colorbar()` explicitly, or the inputs extracted from a plot.
+    ComputePipeline.alias!(cb.attributes, :scale, :colorscale)
+    register_colormapping!(cb.attributes, :values)
 
     map!(
         cb,
-        [cmap.mapping, cmap.color_mapping_type, cmap.color, :nsteps, cmap.colorrange],
+        [:color_mapping, :color_mapping_type, :scaled_color, :nsteps, :scaled_colorrange],
         :cb_colors
     ) do mapping, mapping_type, values, n, limits
         if mapping_type === Makie.continuous
@@ -239,8 +164,8 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         end
     end
 
-    map!(x -> x !== automatic, cb, cmap.lowclip, :lowclip_tri_visible)
-    map!(x -> x !== automatic, cb, cmap.highclip, :highclip_tri_visible)
+    map!(x -> x !== automatic, cb, :lowclip, :lowclip_tri_visible)
+    map!(x -> x !== automatic, cb, :highclip, :highclip_tri_visible)
 
     map!(
         cb, [:highclip_tri_visible, :lowclip_tri_visible, :framebox, :vertical], :tri_heights
@@ -258,7 +183,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
 
     map!(
         cb,
-        [:barbox, :vertical, :cb_colors, cmap.scale, cmap.color_mapping_type],
+        [:barbox, :vertical, :cb_colors, :colorscale, :color_mapping_type],
         [:xrange, :yrange]
     ) do bb, vertical, colors, scale, mapping_type
         xmin, ymin = minimum(bb)
@@ -279,11 +204,10 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         return xrange, yrange
     end
 
-
     # for continuous colormaps we sample a 1d image
     # to avoid white lines when rendering vector graphics
     map!(
-        cb, [:vertical, :cb_colors, cmap.color_mapping_type], :continuous_pixels
+        cb, [:vertical, :cb_colors, :color_mapping_type], :continuous_pixels
     ) do vertical, colors, mapping_type
         if mapping_type !== Makie.categorical
             colors = (colors[1:(end - 1)] .+ colors[2:end]) ./ 2
@@ -294,15 +218,15 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
 
     # TODO, implement interpolate = true for irregular grids in CairoMakie
     # Then, we can just use heatmap! and don't need the image plot!
-    map!(cb, cmap.color_mapping_type, [:show_cats, :show_continuous]) do type
+    map!(cb, :color_mapping_type, [:show_cats, :show_continuous]) do type
         return (type !== continuous, type === continuous)
     end
 
     heatmap!(
         blockscene,
         cb.xrange, cb.yrange, cb.continuous_pixels;
-        colormap = cmap.colormap,
-        colorrange = cmap.colorrange,
+        colormap = cb.alpha_colormap,
+        colorrange = cb.scaled_colorrange,
         visible = cb.show_cats,
         inspectable = false
     )
@@ -313,8 +237,8 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
     image!(
         blockscene,
         cb.xlims, cb.ylims, cb.continuous_pixels;
-        colormap = cmap.colormap,
-        colorrange = cmap.colorrange,
+        colormap = cb.alpha_colormap,
+        colorrange = cb.scaled_colorrange,
         visible = cb.show_continuous,
         inspectable = false
     )
@@ -335,7 +259,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         end
     end
 
-    map!(cb, [cmap.highclip, cmap.lowclip], :clip_tri_colors) do hc, lc
+    map!(cb, [:highclip, :lowclip], :clip_tri_colors) do hc, lc
         return [
             to_color(hc isa Automatic || isnothing(hc) ? :transparent : hc),
             to_color(lc isa Automatic || isnothing(lc) ? :transparent : lc)
@@ -396,12 +320,12 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
     end
 
     ticks = Observable{Any}()
-    map!(cb, [:cb_colors, cmap.color_mapping_type, :ticks], :finalticks) do cs, type, ticks
+    map!(cb, [:cb_colors, :color_mapping_type, :ticks], :finalticks) do cs, type, ticks
         # For categorical we just enumerate
         return type === Makie.categorical ? (1:length(cs), string.(cs)) : ticks
     end
 
-    map!(cb, [:cb_colors, cmap.color_mapping_type, cmap.colorrange], :ticklimits) do cs, type, limits
+    map!(cb, [:cb_colors, :color_mapping_type, :scaled_colorrange], :ticklimits) do cs, type, limits
         return type === Makie.categorical ? (0.5, length(cs) + 0.5) : limits
     end
 
@@ -422,7 +346,7 @@ function initialize_block!(cb::Colorbar; plot_data = nothing)
         spinecolor = :transparent, spinevisible = false, flip_vertical_label = cb.flip_vertical_label,
         minorticksvisible = cb.minorticksvisible, minortickalign = cb.minortickalign,
         minorticksize = cb.minorticksize, minortickwidth = cb.minortickwidth,
-        minortickcolor = cb.minortickcolor, minorticks = cb.minorticks, scale = cmap.scale
+        minortickcolor = cb.minortickcolor, minorticks = cb.minorticks, scale = cb.colorscale
     )
 
     cb.axis = axis

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -49,7 +49,7 @@ function extract_colormap_recursive(plot::AbstractPlot)
     result = extract_colormap(plot)
     # don't jump to child plots if the user provided a method (not defaulted)
     if result isa ColorMapping || colorbar_attributes_complete(result) || !haskey(plot, :defaulted)
-        return result
+        return add_default_colorbar_attributes(result, plot)
     else
         child_results = extract_colormap_recursive.(plot.plots)
         if length(child_results) == 0
@@ -162,8 +162,7 @@ function add_default_colorbar_attributes(cm::ColorMapping, @nospecialize(plot))
 end
 
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
-    _cmap = extract_colormap_recursive(plot)
-    cmap = add_default_colorbar_attributes(_cmap, plot)
+    cmap = extract_colormap_recursive(plot)
     pop!(cmap, :defaulted, nothing)
 
     func = plotfunc(plot)

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -34,14 +34,34 @@ function extract_colormap(@nospecialize(plot::AbstractPlot))
     return add_default_colorbar_attributes(_extract_colormap(plot), plot)
 end
 
-_extract_colormap(@nospecialize(::AbstractPlot)) = Dict{Symbol, Any}()
+_extract_colormap(@nospecialize(::AbstractPlot)) = Dict{Symbol, Any}(:defaulted => true)
+
+function colorbar_attributes_complete(dictlike)
+    # TODO: Should this be less strict?
+    # Technically colorrange can be derived from colors, and colors are
+    # unnecessary with colorrange unless the colormap is categorical.
+    # lowclip, highclip and colorscale are generally more niche
+    full = (:colormap, :color, :colorrange, :colorscale, :lowclip, :highclip)
+    return issubset(full, keys(dictlike))
+end
 
 function extract_colormap_recursive(plot::AbstractPlot)
     result = extract_colormap(plot)
-    if isnothing(result)
-        for child in plot.plots
-            child_result = extract_colormap_recursive(child)
-            isnothing(child_result) || return child_result
+    # don't jump to child plots if the user provided a method (not defaulted)
+    if result isa ColorMapping || colorbar_attributes_complete(result) || !haskey(plot, :defaulted)
+        return result
+    else
+        child_results = extract_colormap_recursive.(plot.plots)
+        if length(child_results) == 0
+            return Dict{Symbol, Any}()
+        elseif length(child_results) == 1
+            return only(child_results)
+        else
+            error(
+                "Multiple colormaps found for plot $(plot), please specify which one to use " *
+                    "manually. Please overload `Makie.extract_colormap(::$(T))` to allow for " *
+                    "the automatic creation of a Colorbar."
+            )
         end
     end
     return result
@@ -130,6 +150,7 @@ function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
 
     haskey(cmap, :colorscale) && (cmap[:scale] = pop!(cmap, :colorscale))
     haskey(cmap, :color) && (cmap[:values] = pop!(cmap, :color))
+    pop!(cmap, :defaulted, nothing)
 
     cmap_keys = collect(keys(cmap))
     haskey(cmap, :colorrange) && push!(cmap_keys, :limits)

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -75,10 +75,22 @@ function _extract_colormap(plot::Arrows2D)
 end
 
 _extract_colormap(plot::Voxels) = Dict{Symbol, Any}(:color => plot.chunk, :colorrange => plot.value_limits)
+_extract_colormap(plot::Surface) = Dict{Symbol, Any}(:color => plot.raw_color)
 _extract_colormap(plot::VolumeSlices) = Dict{Symbol, Any}(:color => plot[4])
-_extract_colormap(plot::Hexbin) = Dict{Symbol, Any}(:color => plot.count_hex)
 
+# These could also use _extract_colormap
 extract_colormap(plot::StreamPlot) = extract_colormap(plot.plots[1])
+extract_colormap(plot::Spy) = extract_colormap(plot.plots[1])
+extract_colormap(plot::Dendrogram) = extract_colormap(plot.plots[1])
+extract_colormap(plot::Density) = extract_colormap(plot.plots[1])
+
+function _extract_colormap(plot::Voronoiplot)
+    if plot.plots[1] isa Voronoiplot
+        return extract_colormap(plot.plots[1])
+    else
+        return Dict{Symbol, Any}(:color => plot.color)
+    end
+end
 
 _normalize_clipcolor(x) = x in (nothing, :auto, automatic) ? automatic : x
 function _extract_colormap(plot::Union{Contourf, Tricontourf})
@@ -91,6 +103,11 @@ function _extract_colormap(plot::Union{Contourf, Tricontourf})
         :lowclip => plot.cb_lowclip,
         :highclip => plot.cb_highclip,
     )
+end
+
+# TODO: plot missing lowclip, highclip handling?
+function _extract_colormap(plot::Union{Contour, Contour3d})
+    return Dict{Symbol, Any}(:color => plot.zlevels, :colorrange => plot.computed_colorrange)
 end
 
 function _extract_colormap(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -48,7 +48,7 @@ end
 function extract_colormap_recursive(plot::AbstractPlot)
     result = extract_colormap(plot)
     # don't jump to child plots if the user provided a method (not defaulted)
-    if result isa ColorMapping || colorbar_attributes_complete(result) || !haskey(plot, :defaulted)
+    if result isa ColorMapping || colorbar_attributes_complete(result) || !haskey(result, :defaulted)
         return add_default_colorbar_attributes(result, plot)
     else
         child_results = extract_colormap_recursive.(plot.plots)

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -7,97 +7,125 @@ function colorbar_check(keys, kwargs_keys)
     return
 end
 
-function extract_colorrange(@nospecialize(plot::AbstractPlot))::Vec2{Float64}
-    if haskey(plot, :calculated_colors) && plot.calculated_colors[] isa Makie.ColorMapping
-        return plot.calculated_colors[].colorrange[]
-    elseif haskey(plot, :colorrange) && !(plot.colorrange[] isa Makie.Automatic)
-        return plot.colorrange[]
-    else
-        error("colorrange not found and calculated_colors for the plot is missing or is not a proper color map. Heatmaps and images should always contain calculated_colors[].colorrange")
+function extract_colormap(@nospecialize(plot::AbstractPlot))
+    minimal_keys = (:color, :colormap, :colorrange)
+
+    if all(key -> haskey(plot, key), minimal_keys)
+        # TODO: maybe we should check that all or none of the outputs of
+        # register_colormapping!() are available?
+
+        if plot.color[] isa Union{AbstractArray{<:Colorant}, ShaderAbstractions.Sampler, AbstractPattern, Colorant}
+            return nothing
+        end
+
+        haskey(plot, :alpha) || add_constant!(plot, :alpha, 1.0)
+        haskey(plot, :lowclip) || add_constant!(plot, :lowclip, automatic)
+        haskey(plot, :highclip) || add_constant!(plot, :highclip, automatic)
+        haskey(plot, :nan_color) || add_constant!(plot, :nan_color, RGBAf(0, 0, 0, 0))
+        haskey(plot, :colorscale) || add_constant!(plot, :colorscale, identity)
+
+        if !haskey(plot, :scaled_colorrange)
+            register_colormapping!(plot.attributes)
+        end
+
+        isnothing(plot.scaled_colorrange[]) && return nothing
+
+        return (
+            color = plot.color,
+            colormap = plot.alpha_colormap,
+            colorscale = plot.colorscale,
+            mapping = plot.color_mapping,
+            colorrange = plot.scaled_colorrange,
+            lowclip = plot.lowclip,
+            highclip = plot.highclip,
+            color_mapping_type = plot.color_mapping_type
+        )
     end
 end
 
-
-function extract_colormap(plot::Arrows2D)
-    return ColorMapping(
-        plot.color[], plot.color, plot.colormap, plot.scaled_colorrange,
-        get(plot, :colorscale, Observable(identity)),
-        get(plot, :alpha, Observable(1.0)),
-        get(plot, :highclip, Observable(automatic)),
-        get(plot, :lowclip, Observable(automatic)),
-        get(plot, :nan_color, Observable(RGBAf(0, 0, 0, 0))),
+function extract_colormap(plot::ComputePlots)
+    return (
+        color = plot.scaled_color,
+        colormap = plot.alpha_colormap,
+        colorscale = plot.colorscale,
+        mapping = plot.color_mapping,
+        colorrange = plot.scaled_colorrange,
+        lowclip = plot.lowclip,
+        highclip = plot.highclip,
+        color_mapping_type = plot.color_mapping_type
     )
 end
 
-function extract_colormap(plot::Union{Arrows3D, StreamPlot})
-    return extract_colormap(plot.plots[1])
-end
-
-function extract_colormap(@nospecialize(plot::AbstractPlot))
-    has_colorrange = haskey(plot, :colorrange) && !(plot.colorrange[] isa Makie.Automatic)
-    if haskey(plot, :calculated_colors) && plot.calculated_colors[] isa Makie.ColorMapping
-        return plot.calculated_colors[]
-    elseif has_colorrange && all(x -> haskey(plot, x), [:colormap, :colorrange, :color]) && plot.color[] isa AbstractVector{<:Colorant}
-        return ColorMapping(
-            plot.color[], plot.color, plot.colormap, plot.colorrange,
-            get(plot, :colorscale, Observable(identity)),
-            get(plot, :alpha, Observable(1.0)),
-            get(plot, :highclip, Observable(automatic)),
-            get(plot, :lowclip, Observable(automatic)),
-            get(plot, :nan_color, Observable(RGBAf(0, 0, 0, 0))),
-        )
-    else
-        return nothing
+function extract_colormap(plot::Arrows2D)
+    map!(plot, [:scaled_tailcolor, :scaled_shaftcolor, :scaled_tipcolor], :scaled_merged_color) do a, b, c
+        return [a; b; c]
     end
+    return (
+        color = plot.scaled_merged_color,
+        colormap = plot.alpha_colormap,
+        colorscale = plot.colorscale,
+        mapping = plot.color_mapping,
+        colorrange = plot.scaled_colorrange,
+        lowclip = plot.lowclip,
+        highclip = plot.highclip,
+        color_mapping_type = plot.color_mapping_type
+    )
 end
-extract_colormap(@nospecialize(plot::ComputePlots)) = get_colormapping(plot)
 
-function extract_colormap(plot::Plot{volumeslices})
-    return extract_colormap(plot.plots[1])
+function extract_colormap(plot::Voxels)
+    return (
+        color = plot.chunk,
+        colormap = plot.alpha_colormap,
+        colorscale = plot.colorscale,
+        mapping = nothing, # not supported
+        colorrange = plot.value_limits,
+        lowclip = plot.lowclip,
+        highclip = plot.highclip,
+        color_mapping_type = plot.color_mapping_type
+    )
 end
 
+extract_colormap(plot::StreamPlot) = extract_colormap(plot.plots[1])
+extract_colormap(plot::VolumeSlices) = extract_colormap(plot.plots[1])
+
+_normalize_clipcolor(x) = x in (nothing, :auto, automatic) ? automatic : x
 function extract_colormap(plot::Union{Contourf, Tricontourf})
-    levels = ComputePipeline.get_observable!(plot.computed_levels)
-    limits = lift(l -> (l[1], l[end]), levels)
-    function extend_color(color, computed)
-        color === nothing && return automatic
-        color == :auto || color == automatic && return computed
-        return computed
+    map!(plot, :computed_colormap, [:alpha_colormap, :color_mapping]) do cm
+        return to_colormap(cm), cm.values
     end
-    elow = lift(extend_color, plot.extendlow, plot.computed_lowcolor)
-    ehigh = lift(extend_color, plot.extendhigh, plot.computed_highcolor)
-    return ColorMapping(
-        levels[], levels, plot.computed_colormap, limits,
-        plot.colorscale, Observable(1.0), elow, ehigh, plot.nan_color
+    map!(_normalize_clipcolor, plot, :extendlow, :cb_lowclip)
+    map!(_normalize_clipcolor, plot, :extendhigh, :cb_highclip)
+    return (
+        color = plot.computed_levels,
+        colormap = plot.alpha_colormap,
+        colorscale = plot.colorscale,
+        mapping = plot.color_mapping,
+        colorrange = plot.computed_colorrange, # missing colorscale?
+        lowclip = plot.cb_lowclip,
+        highclip = plot.cb_highclip,
+        color_mapping_type = banded
     )
 end
 
 function extract_colormap(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
-    levels = ComputePipeline.get_observable!(plot.value_levels)
     # Users may use transparency to make layered isosurfaces visible. Because
     # 3D contours often accumulate the color of an isosurface over multiple
     # samples one typically needs very low alpha values for this, which would
     # make the colors in the colormap very faint. To keep the Colorbar useful,
     # we remove user alpha here. (The recipe also uses `alpha = 0` to remove
     # samples outside of isosurfaces. This is preserved here)
-    colormap = map(cm -> RGBAf.(Colors.color.(cm), Colors.alpha.(cm) .> 0.0f0), plot.computed_colormap)
-    return ColorMapping(
-        levels[], levels, colormap, plot.padded_colorrange, plot.colorscale,
-        Observable(1.0), Observable(automatic), Observable(automatic), plot.nan_color
+    map!(cm -> RGBAf.(Colors.color.(cm), Colors.alpha.(cm) .> 0.0f0), plot, :computed_colormap, :opaque_colormap)
+    return (
+        color = plot.value_levels,
+        colormap = plot.opaque_colormap,
+        colorscale = plot.colorscale,
+        mapping = nothing,
+        colorrange = plot.padded_colorrange, # missing colorscale?
+        lowclip = automatic,
+        highclip = automatic,
+        color_mapping_type = continuous
     )
 end
-
-function extract_colormap(plot::Voxels)
-    limits = plot.value_limits
-    # TODO: does this need padding for lowclip and highclip?
-    discretized_values = map(lims -> range(lims[1], lims[2], length = 253), plot, limits)
-
-    return ColorMapping(
-        discretized_values[], discretized_values, plot.colormap, limits, plot.colorscale,
-        plot.alpha, plot.lowclip, plot.highclip, Observable(:transparent)
-    )
-end
-
 
 function extract_colormap_recursive(@nospecialize(plot::T)) where {T <: AbstractPlot}
     cmap = extract_colormap(plot)
@@ -110,9 +138,6 @@ function extract_colormap_recursive(@nospecialize(plot::T)) where {T <: Abstract
         elseif isempty(colormaps)
             return nothing
         else
-            # Prefer ColorMapping if in doubt!
-            cmaps = filter(x -> x isa ColorMapping, colormaps)
-            length(cmaps) == 1 && return cmaps[1]
             error("Multiple colormaps found for plot $(plot), please specify which one to use manually. Please overload `Makie.extract_colormap(::$(T))` to allow for the automatic creation of a Colorbar.")
         end
     end
@@ -120,14 +145,12 @@ end
 
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
     colorbar_check((:colormap, :limits, :highclip, :lowclip), keys(kwargs))
+
     cmap = extract_colormap_recursive(plot)
     func = plotfunc(plot)
     if isnothing(cmap)
         error("Neither $(func) nor any of its children use a colormap. Cannot create a Colorbar from this plot, please create it manually.
         If this is a recipe, one needs to overload `Makie.extract_colormap(::$(Plot{func}))` to allow for the automatic creation of a Colorbar.")
-    end
-    if !(cmap isa ColorMapping)
-        error("extract_colormap(::$(Plot{func})) returned an invalid value: $cmap. Needs to return either a `Makie.ColorMapping`.")
     end
 
     if to_value(cmap.color) isa Union{AbstractVector{<:Colorant}, Colorant}
@@ -140,108 +163,104 @@ function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
 
     return Colorbar(
         fig_or_scene;
-        colormap = cmap,
+        plot_data = cmap,
         kwargs...
     )
 end
 
-function initialize_block!(cb::Colorbar)
+block_kwargs(::Type{Colorbar}) = Set([:plot_data])
+
+function initialize_block!(cb::Colorbar; plot_data = nothing)
     blockscene = cb.blockscene
 
-    onany(blockscene, cb.size, cb.vertical) do sz, vertical
-        if vertical
-            cb.layoutobservables.autosize[] = (sz, nothing)
-        else
-            cb.layoutobservables.autosize[] = (nothing, sz)
-        end
+    map!(cb, [:size, :vertical], :autosize) do sz, vertical
+        return vertical ? (sz, nothing) : (nothing, sz)
     end
+    map!(identity, blockscene, cb.layoutobservables.autosize, cb.autosize)
 
-    framebox = lift(round_to_IRect2D, blockscene, cb.layoutobservables.computedbbox)
+    add_input!(cb, :computedbbox, cb.layoutobservables.computedbbox)
+    map!(round_to_IRect2D, cb, :computedbbox, :framebox)
 
-    # TODO, always convert to ColorMapping!
-    if cb.colormap[] isa ColorMapping
-        cmap = cb.colormap[]
+    cmap = ComputePipeline.ComputeGraphView(cb.attributes, :color_mapping)
+    if plot_data isa NamedTuple
+        add_input!(cmap, :color, plot_data.color)
+        add_input!(cmap, :colormap, plot_data.colormap)
+        add_input!(cmap, :scale, plot_data.colorscale)
+        add_input!(cmap, :mapping, plot_data.mapping)
+        add_input!(cmap, :colorrange, plot_data.colorrange)
+        add_input!(cmap, :lowclip, plot_data.lowclip)
+        add_input!(cmap, :highclip, plot_data.highclip)
+        add_input!(cmap, :color_mapping_type, plot_data.color_mapping_type)
     else
         # Old way without Colormapping. We keep it, to be able to create a colormap directly
-        limits = lift(blockscene, cb.limits, cb.colorrange) do limits, colorrange
+        map!(cmap, [cb.limits, cb.colorrange], :colorrange) do limits, colorrange
             if all(!isnothing, (limits, colorrange))
                 error("Both colorrange + limits are set, please only set one, they're aliases. colorrange: $(colorrange), limits: $(limits)")
             end
-            return something(limits, colorrange, (0, 1))
+            return something(limits, colorrange, (0.0, 1.0))
         end
-        alpha = Observable(1.0) # dont have these as fields in Colorbar
-        nan_color = Observable(RGBAf(0, 0, 0, 0))
-        cmap = ColorMapping(
-            Float64[], Observable(Float64[]), cb.colormap, limits,
-            cb.scale, alpha, cb.lowclip, cb.highclip, nan_color
-        )
+        add_constant!(cmap, :color, Float64[])
+        map!(c -> c isa Union{Nothing, Automatic} ? automatic : to_color(c), cmap, cb.lowclip, :lowclip)
+        map!(c -> c isa Union{Nothing, Automatic} ? automatic : to_color(c), cmap, cb.highclip, :highclip)
+        map!(to_colormap, cmap, cb.colormap, :colormap)
+        map!(identity, cmap, cb.scale, :scale)
+        map!(cm -> cm isa PlotUtils.ColorGradient ? cm.values : nothing, cmap, cb.colormap, :mapping)
+        map!(colormapping_type, cmap, cb.colormap, :color_mapping_type)
     end
 
-    colormap = lift(cmap.raw_colormap, cmap.colormap, cmap.mapping) do rcm, cm, mapping
-        if isnothing(mapping)
-            return rcm
-        else
-            # if there is a mapping, we want to apply it to the colormap, which is already done for cmap.colormap (by calling to_colormap(cgrad(...)))
-            # In the future, we may want to use cmap.mapping to do this ourselves
-            return cm
-        end
-    end
-    limits = cmap.colorrange
-    colors = lift(
-        blockscene, cmap.mapping, cmap.color_mapping_type, cmap.color, cb.nsteps, limits;
-        ignore_equal_values = true
+    map!(
+        cb,
+        [cmap.mapping, cmap.color_mapping_type, cmap.color, :nsteps, cmap.colorrange],
+        :cb_colors
     ) do mapping, mapping_type, values, n, limits
-        if mapping === nothing
-            if mapping_type === Makie.banded
+        if mapping_type === Makie.continuous
+            return convert(Vector{Float64}, LinRange(limits..., n))
+        elseif mapping_type === Makie.banded
+            if isnothing(mapping)
                 error("Banded without a mapping is invalid. Please use colormap=cgrad(...; categorical=true)")
-            elseif mapping_type === Makie.categorical
+            else # PlotUtils.ColorGradient
+                # Mapping is always 0..1, but color should be scaled
+                return limits[1] .+ (mapping .* (limits[2] - limits[1]))
+            end
+        elseif mapping_type === Makie.categorical
+            if isnothing(mapping)
                 # First we find all unique values,
                 # then we throw out NaNs that are rendered independently anyway
                 # then we clamp the remaining values to the limits,
                 # remove remaining duplicates and sort
                 vals = sort(unique(clamp.(filter(!isnan, unique(values)), limits...)))
                 return convert(Vector{Float64}, vals)
-            else
-                return convert(Vector{Float64}, LinRange(limits..., n))
+            else # PlotUtils.ColorGradient
+                error("PlotUtils.ColorGradient should not be used for categorical colormaps")
             end
         else
-            if mapping_type === Makie.categorical
-                # This is because cmap.mapping comes from cgrad.values, which doesn't encode categorical colormapping correctly
-                error("Mapping should not be used for categorical colormaps")
-            end
-            if mapping_type === Makie.continuous
-                # we need at least nsteps, to correctly sample from the colormap (which has the mapping applied already)
-                return convert(Vector{Float64}, LinRange(limits..., n))
-            else
-                # Mapping is always 0..1, but color should be scaled
-                return limits[1] .+ (mapping .* (limits[2] - limits[1]))
-            end
-            return
+            # unreachable
+            error("Unknown mapping type $mapping_type")
         end
     end
 
-    lowclip_tri_visible = lift(x -> !(x isa Automatic), blockscene, cmap.lowclip; ignore_equal_values = true)
-    highclip_tri_visible = lift(x -> !(x isa Automatic), blockscene, cmap.highclip; ignore_equal_values = true)
-    tri_heights = lift(blockscene, highclip_tri_visible, lowclip_tri_visible, framebox; ignore_equal_values = true) do hv, lv, box
-        if cb.vertical[]
-            return (lv * width(box), hv * width(box))
-        else
-            return (lv * height(box), hv * height(box))
-        end .* sin(pi / 3)
+    map!(x -> x !== automatic, cb, cmap.lowclip, :lowclip_tri_visible)
+    map!(x -> x !== automatic, cb, cmap.highclip, :highclip_tri_visible)
+
+    map!(
+        cb, [:highclip_tri_visible, :lowclip_tri_visible, :framebox, :vertical], :tri_heights
+    ) do hv, lv, box, vertical
+        return (lv, hv) .* ifelse(vertical, width(box), height(box)) .* sin(pi/3)
     end
 
-    barbox = lift(blockscene, framebox; ignore_equal_values = true) do fbox
-        if cb.vertical[]
-            return BBox(left(fbox), right(fbox), bottom(fbox) + tri_heights[][1], top(fbox) - tri_heights[][2])
+    map!(cb, [:framebox, :vertical, :tri_heights], :barbox) do fbox, vertical, tri_heights
+        if vertical
+            return BBox(left(fbox), right(fbox), bottom(fbox) + tri_heights[1], top(fbox) - tri_heights[2])
         else
-            return BBox(left(fbox) + tri_heights[][1], right(fbox) - tri_heights[][2], bottom(fbox), top(fbox))
+            return BBox(left(fbox) + tri_heights[1], right(fbox) - tri_heights[2], bottom(fbox), top(fbox))
         end
     end
 
-    xrange = Observable(Float32[]; ignore_equal_values = true)
-    yrange = Observable(Float32[]; ignore_equal_values = true)
-
-    function update_xyrange(bb, v, colors, scale, mapping_type)
+    map!(
+        cb,
+        [:barbox, :vertical, :cb_colors, cmap.scale, cmap.color_mapping_type],
+        [:xrange, :yrange]
+    ) do bb, vertical, colors, scale, mapping_type
         xmin, ymin = minimum(bb)
         xmax, ymax = maximum(bb)
         if mapping_type == Makie.categorical
@@ -250,175 +269,151 @@ function initialize_block!(cb::Colorbar)
         s_scaled = scale.(colors)
         mini, maxi = extrema(s_scaled)
         s_scaled = (s_scaled .- mini) ./ (maxi - mini)
-        if v
-            xrange[] = LinRange(xmin, xmax, 2)
-            yrange[] = s_scaled .* (ymax - ymin) .+ ymin
+        if vertical
+            xrange = LinRange(xmin, xmax, 2)
+            yrange = s_scaled .* (ymax - ymin) .+ ymin
         else
-            xrange[] = s_scaled .* (xmax - xmin) .+ xmin
-            yrange[] = LinRange(ymin, ymax, 2)
+            xrange = s_scaled .* (xmax - xmin) .+ xmin
+            yrange = LinRange(ymin, ymax, 2)
         end
-        return
+        return xrange, yrange
     end
 
-    update_xyrange(barbox[], cb.vertical[], colors[], cmap.scale[], cmap.color_mapping_type[])
-    onany(update_xyrange, blockscene, barbox, cb.vertical, colors, cmap.scale, cmap.color_mapping_type)
 
     # for continuous colormaps we sample a 1d image
     # to avoid white lines when rendering vector graphics
-    continuous_pixels = lift(
-        blockscene, cb.vertical, colors,
-        cmap.color_mapping_type
-    ) do v, colors, mapping_type
+    map!(
+        cb, [:vertical, :cb_colors, cmap.color_mapping_type], :continuous_pixels
+    ) do vertical, colors, mapping_type
         if mapping_type !== Makie.categorical
             colors = (colors[1:(end - 1)] .+ colors[2:end]) ./ 2
         end
         n = length(colors)
-        return v ? reshape((colors), 1, n) : reshape((colors), n, 1)
+        return vertical ? reshape((colors), 1, n) : reshape((colors), n, 1)
     end
-    # TODO, implement interpolate = true for irregular grics in CairoMakie
+
+    # TODO, implement interpolate = true for irregular grids in CairoMakie
     # Then, we can just use heatmap! and don't need the image plot!
-    show_cats = Observable(false; ignore_equal_values = true)
-    show_continuous = Observable(false; ignore_equal_values = true)
-    on(blockscene, cmap.color_mapping_type; update = true) do type
-        if type === continuous
-            show_continuous[] = true
-            show_cats[] = false
-        else
-            show_continuous[] = false
-            show_cats[] = true
-        end
+    map!(cb, cmap.color_mapping_type, [:show_cats, :show_continuous]) do type
+        return (type !== continuous, type === continuous)
     end
+
     heatmap!(
         blockscene,
-        xrange, yrange, continuous_pixels;
-        colormap = colormap,
-        colorrange = limits,
-        visible = show_cats,
+        cb.xrange, cb.yrange, cb.continuous_pixels;
+        colormap = cmap.colormap,
+        colorrange = cmap.colorrange,
+        visible = cb.show_cats,
         inspectable = false
     )
+
+    map!(extrema, cb, :xrange, :xlims)
+    map!(extrema, cb, :yrange, :ylims)
+
     image!(
         blockscene,
-        lift(extrema, xrange), lift(extrema, yrange), continuous_pixels;
-        colormap = colormap,
-        colorrange = limits,
-        visible = show_continuous,
+        cb.xlims, cb.ylims, cb.continuous_pixels;
+        colormap = cmap.colormap,
+        colorrange = cmap.colorrange,
+        visible = cb.show_continuous,
         inspectable = false
     )
 
-    highclip_tri = lift(blockscene, barbox, cb.spinewidth) do box, spinewidth
-        if cb.vertical[]
-            lb, rb = topline(box)
-            l = lb
-            r = rb
-            t = ((l .+ r) ./ 2) .+ Point2f(0, sqrt(sum((r .- l) .^ 2)) * sin(pi / 3))
-            [l, r, t]
-        else
-            b, t = rightline(box)
-            r = ((b .+ t) ./ 2) .+ Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
-            [t, b, r]
-        end
-    end
-
-    highclip_tri_color = lift(blockscene, cmap.highclip) do hc
-        to_color(hc isa Automatic || isnothing(hc) ? :transparent : hc)
-    end
-
-    poly!(
-        blockscene, highclip_tri, color = highclip_tri_color,
-        strokecolor = :transparent,
-        visible = highclip_tri_visible, inspectable = false
-    )
-
-    lowclip_tri = lift(blockscene, barbox, cb.spinewidth) do box, spinewidth
-        if cb.vertical[]
+    map!(cb, [:barbox, :vertical], :clip_tris) do box, vertical
+        if vertical
+            lt, rt = topline(box)
+            et = ((lt .+ rt) ./ 2) .+ Point2f(0, sqrt(sum((rt .- lt) .^ 2)) * sin(pi / 3))
             lb, rb = bottomline(box)
-            l = lb
-            r = rb
-            t = ((l .+ r) ./ 2) .- Point2f(0, sqrt(sum((r .- l) .^ 2)) * sin(pi / 3))
-            [l, r, t]
+            eb = ((lb .+ rb) ./ 2) .- Point2f(0, sqrt(sum((rb .- lb) .^ 2)) * sin(pi / 3))
+            return [Polygon([lt, rt, et]), Polygon([lb, rb, eb])]
         else
-            b, t = leftline(box)
-            l = ((b .+ t) ./ 2) .- Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
-            [b, t, l]
+            br, tr = rightline(box)
+            er = ((b .+ t) ./ 2) .+ Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
+            bl, tl = leftline(box)
+            el = ((b .+ t) ./ 2) .- Point2f(sqrt(sum((t .- b) .^ 2)) * sin(pi / 3), 0)
+            return [Polygon([br, tr, er]), Polygon([bl, tl, el])]
         end
     end
 
-    lowclip_tri_color = lift(blockscene, cmap.lowclip) do lc
-        to_color(lc isa Automatic || isnothing(lc) ? :transparent : lc)
+    map!(cb, [cmap.highclip, cmap.lowclip], :clip_tri_colors) do hc, lc
+        return [
+            to_color(hc isa Automatic || isnothing(hc) ? :transparent : hc),
+            to_color(lc isa Automatic || isnothing(lc) ? :transparent : lc)
+        ]
     end
 
     poly!(
-        blockscene, lowclip_tri, color = lowclip_tri_color,
-        strokecolor = :transparent,
-        visible = lowclip_tri_visible, inspectable = false
+        blockscene, cb.clip_tris, color = cb.clip_tri_colors,
+        strokecolor = :transparent, inspectable = false
     )
 
-    borderpoints = lift(blockscene, barbox, highclip_tri_visible, lowclip_tri_visible) do bb, hcv, lcv
-        if cb.vertical[]
+    map!(
+        cb,
+        [:barbox, :highclip_tri_visible, :lowclip_tri_visible, :vertical, :clip_tris],
+        :borderpoints
+    ) do bb, hcv, lcv, vertical, clip_tris
+        if vertical
             points = [bottomright(bb), topright(bb)]
             if hcv
-                push!(points, highclip_tri[][3])
+                push!(points, clip_tris[1].exterior[3])
             end
             append!(points, [topleft(bb), bottomleft(bb)])
             if lcv
-                push!(points, lowclip_tri[][3])
+                push!(points, clip_tris[2].exterior[3])
             end
             push!(points, bottomright(bb))
-            points
+            return points
         else
             points = [bottomleft(bb), bottomright(bb)]
             if hcv
-                push!(points, highclip_tri[][3])
+                push!(points, clip_tris[1].exterior[3])
             end
             append!(points, [topright(bb), topleft(bb)])
             if lcv
-                push!(points, lowclip_tri[][3])
+                push!(points, clip_tris[2].exterior[3])
             end
             push!(points, bottomleft(bb))
-            points
+            return points
         end
     end
 
-    lines!(blockscene, borderpoints, linewidth = cb.spinewidth, color = cb.topspinecolor, inspectable = false)
+    lines!(blockscene, cb.borderpoints, linewidth = cb.spinewidth, color = cb.topspinecolor, inspectable = false)
 
-    axispoints = lift(blockscene, barbox, cb.vertical, cb.flipaxis) do scenearea,
-            vertical, flipaxis
-
+    map!(cb, [:barbox, :vertical, :flipaxis], :axispoints) do scenearea, vertical, flipaxis
         if vertical
             if flipaxis
-                (bottomright(scenearea), topright(scenearea))
+                return (bottomright(scenearea), topright(scenearea))
             else
-                (bottomleft(scenearea), topleft(scenearea))
+                return (bottomleft(scenearea), topleft(scenearea))
             end
         else
             if flipaxis
-                (topleft(scenearea), topright(scenearea))
+                return (topleft(scenearea), topright(scenearea))
             else
-                (bottomleft(scenearea), bottomright(scenearea))
+                return (bottomleft(scenearea), bottomright(scenearea))
             end
         end
-
     end
 
     ticks = Observable{Any}()
-    map!(ticks, colors, cmap.color_mapping_type, cb.ticks) do cs, type, ticks
+    map!(cb, [:cb_colors, cmap.color_mapping_type, :ticks], :finalticks) do cs, type, ticks
         # For categorical we just enumerate
-        type === Makie.categorical ? (1:length(cs), string.(cs)) : ticks
+        return type === Makie.categorical ? (1:length(cs), string.(cs)) : ticks
     end
 
-    lims = lift(colors, cmap.color_mapping_type, limits) do cs, type, limits
+    map!(cb, [:cb_colors, cmap.color_mapping_type, cmap.colorrange], :ticklimits) do cs, type, limits
         return type === Makie.categorical ? (0.5, length(cs) + 0.5) : limits
     end
 
     axis = LineAxis(
         blockscene, ComputePipeline.ComputeGraphView(cb.attributes, :axis),
-        endpoints = axispoints, flipped = cb.flipaxis,
-        limits = lims, ticklabelalign = cb.ticklabelalign, label = cb.label,
+        endpoints = cb.axispoints, flipped = cb.flipaxis,
+        limits = cb.ticklimits, ticklabelalign = cb.ticklabelalign, label = cb.label,
         labelpadding = cb.labelpadding, labelvisible = cb.labelvisible, labelsize = cb.labelsize,
         labelcolor = cb.labelcolor, labelrotation = cb.labelrotation,
         labelfont = cb.labelfont, ticklabelfont = cb.ticklabelfont,
         dim_convert = nothing, # TODO, we should also have a dim convert for Colorbar
-        ticks = ticks, tickformat = cb.tickformat,
+        ticks = cb.finalticks, tickformat = cb.tickformat,
         ticklabelsize = cb.ticklabelsize, ticklabelsvisible = cb.ticklabelsvisible, ticksize = cb.ticksize,
         ticksvisible = cb.ticksvisible, ticklabelpad = cb.ticklabelpad, tickalign = cb.tickalign,
         ticklabelrotation = cb.ticklabelrotation,
@@ -432,9 +427,9 @@ function initialize_block!(cb::Colorbar)
 
     cb.axis = axis
 
-    onany(blockscene, cb.attributes.axis.protrusion, cb.vertical, cb.flipaxis) do axprotrusion,
-            vertical, flipaxis
-
+    map!(
+        cb, [cb.attributes.axis.protrusion, :vertical, :flipaxis], :protrusions
+    ) do axprotrusion, vertical, flipaxis
         left, right, top, bottom = 0.0f0, 0.0f0, 0.0f0, 0.0f0
 
         if vertical
@@ -451,25 +446,12 @@ function initialize_block!(cb::Colorbar)
             end
         end
 
-        rs = GridLayoutBase.RectSides{Float32}(left, right, bottom, top)
-        if rs != cb.layoutobservables.protrusions[]
-            cb.layoutobservables.protrusions[] = rs
-        end
+        return GridLayoutBase.RectSides{Float32}(left, right, bottom, top)
     end
+    map!(identity, cb.layoutobservables.protrusions, cb.protrusions)
 
-    # trigger protrusions with one of the attributes
-    notify(ComputePipeline.get_observable!(cb.vertical))
-    # We set everything via the ColorMapping now. To be backwards compatible, we always set those fields:
-    if (cb.colormap[] isa ColorMapping)
-        on(x -> cb.limits = x, cb.blockscene, convert(Observable{Any}, limits), update = true)
-        on(x -> cb.colormap = x, cb.blockscene, convert(Observable{Any}, cmap.colormap), update = true)
-        on(x -> cb.highclip = x, cb.blockscene, convert(Observable{Any}, cmap.highclip), update = true)
-        on(x -> cb.lowclip = x, cb.blockscene, convert(Observable{Any}, cmap.lowclip), update = true)
-        on(x -> cb.scale = x, cb.blockscene, convert(Observable{Any}, cmap.scale), update = true)
-    end
     # trigger bbox
     notify(cb.layoutobservables.suggestedbbox)
-    notify(barbox)
 
     return
 end

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -111,8 +111,8 @@ end
 function add_default_colorbar_attributes(cm::ColorMapping, @nospecialize(plot))
     Base.depwarn(
         "`extract_colormap(plot::$(typeof(plot)))` should no longer return a `Makie.ColorMapping`." *
-        "Instead it should return a `Dict{Symbol, Any}()` containing colormap related attributes. " *
-        "See `?Makie.extract_colormap`", :extract_colormap
+            "Instead it should return a `Dict{Symbol, Any}()` containing colormap related attributes. " *
+            "See `?Makie.extract_colormap`", :extract_colormap
     )
     cmap = Dict{Symbol, Any}()
     cmap[:values] = cm.color
@@ -217,7 +217,7 @@ function initialize_block!(cb::Colorbar)
     map!(
         cb, [:highclip_tri_visible, :lowclip_tri_visible, :framebox, :vertical], :tri_heights
     ) do hv, lv, box, vertical
-        return (lv, hv) .* ifelse(vertical, width(box), height(box)) .* sin(pi/3)
+        return (lv, hv) .* ifelse(vertical, width(box), height(box)) .* sin(pi / 3)
     end
 
     map!(cb, [:framebox, :vertical, :tri_heights], :barbox) do fbox, vertical, tri_heights
@@ -309,7 +309,7 @@ function initialize_block!(cb::Colorbar)
     map!(cb, [:highclip, :lowclip], :clip_tri_colors) do hc, lc
         return [
             to_color(hc isa Automatic || isnothing(hc) ? :transparent : hc),
-            to_color(lc isa Automatic || isnothing(lc) ? :transparent : lc)
+            to_color(lc isa Automatic || isnothing(lc) ? :transparent : lc),
         ]
     end
 

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -7,8 +7,35 @@ function colorbar_check(keys, kwargs_keys)
     return
 end
 
-# compat
-extract_colormap(::AbstractPlot) = nothing
+"""
+    extract_colormap(plot)
+
+This function extracts plot attributes relevant for constructing a `Colorbar`.
+It is meant to be extended for recipes that do not use the default names for
+the respective attributes.
+
+The function should return a `Dict{Symbol, Any}` containing `name => attribute`
+pairs. It should contain:
+- `:colormap`: The colormap of the plot.
+- `:color`: The color values that the colormap applies to.
+- `:colorrange`: The colorrange of the plot, i.e. the extrema of `color`.
+- `:colorscale`: The colorscale of plot.
+- `:lowclip`: The lowclip of the plot.
+- `:highclip`: The highclip of the plot.
+
+`Makie.add_default_colorbar_attributes!(dict, plot)` can be used to fill out
+attributes that use the default names. (I.e. the names listed as keys above.)
+Alternatively `Makie._extract_colormap(plot)` can be implemented with an
+incomplete set of attributes instead. The default `Makie.extract_colormap`
+method will then add the remaining defaults. If the returned dict is incomplete
+the `Colorbar` constructor will also attempt to add the missing attributes.
+"""
+function extract_colormap(@nospecialize(plot::AbstractPlot))
+    return add_default_colorbar_attributes(_extract_colormap(plot), plot)
+end
+
+_extract_colormap(@nospecialize(::AbstractPlot)) = Dict{Symbol, Any}()
+
 function extract_colormap_recursive(plot::AbstractPlot)
     result = extract_colormap(plot)
     if isnothing(result)
@@ -20,32 +47,33 @@ function extract_colormap_recursive(plot::AbstractPlot)
     return result
 end
 
-function extract_colorbar_attributes(plot::Arrows2D)
+function _extract_colormap(plot::Arrows2D)
     map!(plot, [:tailcolor, :shaftcolor, :tipcolor, :color], :raw_merged_color) do a, b, c, d
         return [default_automatic(a, d); default_automatic(b, d); default_automatic(c, d)]
     end
-    return (; color = plot.raw_merged_color)
+    return Dict{Symbol, Any}(:color => plot.raw_merged_color)
 end
 
-extract_colorbar_attributes(plot::Voxels) = (color = plot.chunk, colorrange = plot.value_limits)
-extract_colorbar_attributes(plot::StreamPlot) = extract_colorbar_attributes_with_defaults(plot.plots[1])
-extract_colorbar_attributes(plot::VolumeSlices) = (color = plot[4],)
-extract_colorbar_attributes(plot::Hexbin) = (color = plot.count_hex,)
+_extract_colormap(plot::Voxels) = Dict{Symbol, Any}(:color => plot.chunk, :colorrange => plot.value_limits)
+_extract_colormap(plot::VolumeSlices) = Dict{Symbol, Any}(:color => plot[4])
+_extract_colormap(plot::Hexbin) = Dict{Symbol, Any}(:color => plot.count_hex)
+
+extract_colormap(plot::StreamPlot) = extract_colormap(plot.plots[1])
 
 _normalize_clipcolor(x) = x in (nothing, :auto, automatic) ? automatic : x
-function extract_colorbar_attributes(plot::Union{Contourf, Tricontourf})
+function _extract_colormap(plot::Union{Contourf, Tricontourf})
     map!(_normalize_clipcolor, plot, :extendlow, :cb_lowclip)
     map!(_normalize_clipcolor, plot, :extendhigh, :cb_highclip)
-    return (
-        color = plot.computed_levels,
-        colormap = plot.computed_colormap,
-        colorrange = plot.computed_colorrange,
-        lowclip = plot.cb_lowclip,
-        highclip = plot.cb_highclip,
+    return Dict{Symbol, Any}(
+        :color => plot.computed_levels,
+        :colormap => plot.computed_colormap,
+        :colorrange => plot.computed_colorrange,
+        :lowclip => plot.cb_lowclip,
+        :highclip => plot.cb_highclip,
     )
 end
 
-function extract_colorbar_attributes(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
+function _extract_colormap(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
     # Users may use transparency to make layered isosurfaces visible. Because
     # 3D contours often accumulate the color of an isosurface over multiple
     # samples one typically needs very low alpha values for this, which would
@@ -53,76 +81,52 @@ function extract_colorbar_attributes(plot::Contour{<:Tuple{X, Y, Z, Vol}}) where
     # we remove user alpha here. (The recipe also uses `alpha = 0` to remove
     # samples outside of isosurfaces. This is preserved here)
     map!(cm -> RGBAf.(Colors.color.(cm), Colors.alpha.(cm) .> 0.0f0), plot, :computed_colormap, :opaque_colormap)
-    return (
-        color = plot.value_levels,
-        colormap = plot.opaque_colormap,
-        colorrange = plot.padded_colorrange,
+    return Dict{Symbol, Any}(
+        :color => plot.value_levels,
+        :colormap => plot.opaque_colormap,
+        :colorrange => plot.padded_colorrange,
     )
 end
 
-# TODO: compat for ColorMapping
-
-"""
-    extract_colorbar_attributes(plot)
-
-This function extract plot attributes relevant for constructing a `Colorbar`.
-It is meant to be extended for recipes that do not use the default names.
-
-The function should return a dict-like object (one implementing `getindex` and `haskey`)
-containing `name => attribute` pairs. It may contain any of the following names:
-- `:colormap`: The colormap of the plot.
-- `:color`: The color values that the colormap applies to.
-- `:colorrange`: The colorrange of the plot, i.e. the extrema of `color`.
-- `:colorscale`: The colorscale of plot.
-- `:lowclip`: The lowclip of the plot.
-- `:highclip`: The highclip of the plot.
-
-Any missing `name` will default to the appropriate `plot[name]` attribute if it
-exists, or to the default defined by `Colorbar`.
-
-Note that you can use `extract_colorbar_attributes_with_defaults(plot)` to
-extract attributes with defaults from a child plot.
-"""
-extract_colorbar_attributes(::AbstractPlot) = NamedTuple()
-
-function extract_colorbar_attributes_with_defaults(plot::AbstractPlot)
-    _cmap = extract_colorbar_attributes(plot)
-    cmap = Dict{Symbol, Any}()
+function add_default_colorbar_attributes(attr::Dict{Symbol, Any}, @nospecialize(plot))
+    return add_default_colorbar_attributes(attr, attr, plot)
+end
+function add_default_colorbar_attributes(attr, @nospecialize(plot))
+    return add_default_colorbar_attributes(Dict{Symbol, Any}(), attr, plot)
+end
+function add_default_colorbar_attributes(output, overwrites, @nospecialize(plot))
     for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
-        if haskey(_cmap, name)
-            cmap[name] = _cmap[name]
+        if haskey(overwrites, name)
+            output[name] = overwrites[name]
         elseif haskey(plot, name)
-            push!(cmap, name => plot[name])
+            push!(output, name => plot[name])
         end
     end
+    if !haskey(output, :color) && haskey(plot, :raw_color)
+        output[:values] = plot.raw_color
+    end
+    return output
+end
+
+function add_default_colorbar_attributes(cm::ColorMapping, @nospecialize(plot))
+    Base.depwarn(
+        "`extract_colormap(plot::$(typeof(plot)))` should no longer return a `Makie.ColorMapping`." *
+        "Instead it should return a `Dict{Symbol, Any}()` containing colormap related attributes. " *
+        "See `?Makie.extract_colormap`", :extract_colormap
+    )
+    cmap = Dict{Symbol, Any}()
+    cmap[:values] = cm.color
+    cmap[:colormap] = cm.raw_colormap
+    cmap[:colorrange] = cm.colorrange
+    cmap[:scale] = cm.scale
+    cmap[:lowclip] = cm.lowclip
+    cmap[:highclip] = cm.highclip
     return cmap
 end
 
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
-    cmap = Dict{Symbol, Any}()
-
-    dep_cmap = extract_colormap_recursive(plot)
-    if !isnothing(dep_cmap)
-        @warn "`extract_colormap` is deprecated in favor of `extract_colorbar_attributes`"
-        cmap[:values] = dep_cmap.color
-        cmap[:colormap] = dep_cmap.raw_colormap
-        cmap[:colorrange] = dep_cmap.colorrange
-        cmap[:scale] = dep_cmap.scale
-        cmap[:lowclip] = dep_cmap.lowclip
-        cmap[:highclip] = dep_cmap.highclip
-    else
-        _cmap = extract_colorbar_attributes(plot)
-        for name in [:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip]
-            if haskey(_cmap, name)
-                cmap[name] = _cmap[name]
-            elseif haskey(plot, name)
-                push!(cmap, name => plot[name])
-            end
-        end
-        if !haskey(cmap, :color) && haskey(plot, :raw_color)
-            cmap[:values] = plot.raw_color
-        end
-    end
+    _cmap = extract_colormap_recursive(plot)
+    cmap = add_default_colorbar_attributes(_cmap, plot)
 
     haskey(cmap, :colorscale) && (cmap[:scale] = pop!(cmap, :colorscale))
     haskey(cmap, :color) && (cmap[:values] = pop!(cmap, :color))
@@ -131,10 +135,6 @@ function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
     haskey(cmap, :colorrange) && push!(cmap_keys, :limits)
     colorbar_check(cmap_keys, keys(kwargs))
     func = plotfunc(plot)
-    # if isnothing(cmap)
-    #     error("Neither $(func) nor any of its children use a colormap. Cannot create a Colorbar from this plot, please create it manually.
-    #     If this is a recipe, one needs to overload `Makie.extract_colormap(::$(Plot{func}))` to allow for the automatic creation of a Colorbar.")
-    # end
 
     if haskey(cmap, :values) && to_value(cmap[:values]) isa Union{AbstractArray{<:Colorant}, Colorant, ShaderAbstractions.Sampler, AbstractPattern}
         error(
@@ -147,9 +147,7 @@ function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
     return Colorbar(fig_or_scene; cmap..., kwargs...)
 end
 
-block_kwargs(::Type{Colorbar}) = Set([:plot_data])
-
-function initialize_block!(cb::Colorbar; plot_data = nothing)
+function initialize_block!(cb::Colorbar)
     blockscene = cb.blockscene
 
     map!(cb, [:size, :vertical], :autosize) do sz, vertical

--- a/Makie/src/makielayout/blocks/colorbar.jl
+++ b/Makie/src/makielayout/blocks/colorbar.jl
@@ -140,7 +140,7 @@ function add_default_colorbar_attributes(output, overwrites, @nospecialize(plot)
         end
     end
     if !haskey(output, :color) && haskey(plot, :raw_color)
-        output[:values] = plot.raw_color
+        output[:color] = plot.raw_color
     end
     return output
 end
@@ -152,10 +152,10 @@ function add_default_colorbar_attributes(cm::ColorMapping, @nospecialize(plot))
             "See `?Makie.extract_colormap`", :extract_colormap
     )
     cmap = Dict{Symbol, Any}()
-    cmap[:values] = cm.color
+    cmap[:color] = cm.color
     cmap[:colormap] = cm.raw_colormap
     cmap[:colorrange] = cm.colorrange
-    cmap[:scale] = cm.scale
+    cmap[:colorscale] = cm.scale
     cmap[:lowclip] = cm.lowclip
     cmap[:highclip] = cm.highclip
     return cmap
@@ -164,15 +164,24 @@ end
 function Colorbar(fig_or_scene, plot::AbstractPlot; kwargs...)
     _cmap = extract_colormap_recursive(plot)
     cmap = add_default_colorbar_attributes(_cmap, plot)
+    pop!(cmap, :defaulted, nothing)
+
+    func = plotfunc(plot)
+    if !colorbar_attributes_complete(cmap)
+        error(
+            "Could not extract a complete set of colormapping attributes from $func. \
+            `extract_colormap(plot)` should produce: \n   \
+            (:color, :colormap, :colorrange, :colorscale, :lowclip, :highclip). \n\
+            Produced = $(keys(cmap))"
+        )
+    end
 
     haskey(cmap, :colorscale) && (cmap[:scale] = pop!(cmap, :colorscale))
     haskey(cmap, :color) && (cmap[:values] = pop!(cmap, :color))
-    pop!(cmap, :defaulted, nothing)
 
     cmap_keys = collect(keys(cmap))
     haskey(cmap, :colorrange) && push!(cmap_keys, :limits)
     colorbar_check(cmap_keys, keys(kwargs))
-    func = plotfunc(plot)
 
     if haskey(cmap, :values) && to_value(cmap[:values]) isa Union{AbstractArray{<:Colorant}, Colorant, ShaderAbstractions.Sampler, AbstractPattern}
         error(

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -943,15 +943,21 @@ Colorbar(fig_or_scene, contourf::Makie.Contourf; kwargs...)
         "The colormap that the colorbar uses."
         colormap = @inherit(:colormap, :viridis)
         "The range of values depicted in the colorbar."
-        limits = nothing
-        "The range of values depicted in the colorbar."
-        colorrange = nothing
+        colorrange = automatic
+        """
+        Sets the color values of the Colorbar. The number of unique color values will set the number
+        of categories for a categorical colormap. If `colorrange` is not given, this will set a
+        default colorrange.
+        """
+        values = [0, 1]
         "The color of the high clip triangle."
-        highclip = nothing
+        highclip = automatic
         "The color of the low clip triangle."
-        lowclip = nothing
+        lowclip = automatic
         "The axis scale"
         scale = identity
+        "Sets the alpha value of the colormap."
+        alpha = 1.0
 
 
         "The align mode of the colorbar in its parent GridLayout."
@@ -974,6 +980,13 @@ Colorbar(fig_or_scene, contourf::Makie.Contourf; kwargs...)
         "The width or height of the colorbar, depending on if it's vertical or horizontal, unless overridden by `width` / `height`"
         size = 12
     end
+end
+
+# TODO: not used
+function deprecated_attributes(::Type{Colorbar})
+    return (
+        (; attribute = :limits, message = "`limits` has been removed in favor of `colorrange` in Makie v0.25.", error = true),
+    )
 end
 
 @Block Label begin

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -942,6 +942,8 @@ Colorbar(fig_or_scene, contourf::Makie.Contourf; kwargs...)
 
         "The colormap that the colorbar uses."
         colormap = @inherit(:colormap, :viridis)
+        "Deprecated in favor of `colorrange`. (The range of values depicted in the colorbar.)"
+        limits = automatic
         "The range of values depicted in the colorbar."
         colorrange = automatic
         """

--- a/Makie/test/SceneLike/Colorbar.jl
+++ b/Makie/test/SceneLike/Colorbar.jl
@@ -1,0 +1,244 @@
+function verify_colorbar_defaults(fig::Figure, plot; kwargs...)
+    cb = Colorbar(fig[1, 2], plot)
+    return verify_colorbar_defaults(cb, plot; kwargs...)
+end
+
+function verify_colorbar_defaults(
+        cb::Colorbar, plot;
+        color = plot.color, colorrange = plot.colorrange,
+        colormap = plot.colormap, colorscale = plot.colorscale,
+        lowclip = plot.lowclip, highclip = plot.highclip,
+        color_mapping_type = Makie.colormapping_type(colormap[])
+    )
+    @testset "$(Makie.plotsym(typeof(plot)))" begin
+        # @test cb.values.parent.inputs[1] == color
+        @test cb.values.parent.inputs[1] == color
+        @test cb.colorrange.parent.inputs[1] == colorrange
+        @test cb.colormap.parent.inputs[1] == colormap
+        @test cb.scale.parent.inputs[1] == colorscale
+        @test cb.lowclip.parent.inputs[1] == lowclip
+        @test cb.highclip.parent.inputs[1] == highclip
+        @test cb.color_mapping_type[] == color_mapping_type
+    end
+    return
+end
+
+@testset "Colorbar from plots" begin
+    @testset "Basic recipes" begin
+        f,a,p = ablines([1, 2, 3], [1, 1., 2], color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        # no colormapping
+        # f,a,p = annotation(rand(Point2f, 3), text = string.(1:3), color = 1:3)
+        # verify_colorbar_defaults(f, p)
+
+        # arc - single element
+
+        f,a,p = arrows2d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(cb, p, color = p.raw_merged_color)
+
+        f,a,p = arrows3d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = band(1:3, 0:2, 1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = barplot(1:3, 1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        # no colormapping
+        # f,a,p = bracket(1:3, 0:2, 1:3, 1:3, color = 1:3)
+        # verify_colorbar_defaults(f, p)
+
+        f,a,p = contourf([1 2; 3 4])
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(
+            cb, p, color = p.computed_levels, colormap = p.computed_colormap,
+            colorrange = p.computed_colorrange, lowclip = p.cb_lowclip, highclip = p.cb_highclip
+        )
+
+        f,a,p = contour([1 2; 3 4])
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(cb, p, color = p.zlevels, colorrange = p.computed_colorrange)
+
+        f,a,p = contour3d([1 2; 3 4])
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(cb, p, color = p.zlevels, colorrange = p.computed_colorrange)
+
+        f,a,p = contour(collect(reshape(1:8, 2, 2, 2)))
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(
+            cb, p, color = p.value_levels, colorrange = p.padded_colorrange,
+            colormap = p.opaque_colormap
+        )
+
+        f,a,p = datashader(rand(Point2f, 100))
+        cb = Colorbar(f[1, 2], p)
+        @testset "DataShader" begin
+            @test cb.values[] == p.canvas[].pixelbuffer
+            @test cb.colorrange[] == p.raw_colorrange[]
+            @test cb.colormap[] == Makie.to_colormap(p.colormap[])
+            @test cb.scale[] == p.colorscale[]
+            @test cb.lowclip[] == p.lowclip[]
+            @test cb.highclip[] == p.highclip[]
+            @test cb.color_mapping_type[] == Makie.continuous
+        end
+
+        f,a,p = heatmap(Resampler([1 2; 3 4]))
+        verify_colorbar_defaults(f, p.plots[1], color = p.plots[1].raw_color)
+
+        f,a,p = errorbars(1:3, 0:2, ones(3), color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = rangebars(1:3, 0:2, 1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = hlines(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = vlines(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = hspan(0:2, 1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = vspan(0:2, 1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = pathtext(1:3, [1, 2, 1], text = "123", color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = pie(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p.plots[1])
+
+        f,a,p = poly([Rect2f(0,0,1,1), Rect2f(1,1,1,1)], color = 1:2)
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # not colormapped
+        # f,a,p = rainclouds(rand(1:2, 100), rand(100), color = 1:2)
+
+        f,a,p = scatterlines(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        # not colormapped
+        # f,a,p = series(rand(5, 3))
+
+        f,a,p = spy([1 2; 3 4])
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # 3 args, 5 colors...?
+        f,a,p = stairs(1:3, color = 1:5)
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # stem has multiple independent colormaps (and no lowclip/highclip) so it's
+        # not clear how this should interact with Colorbar
+        # f,a,p = stem(1:3, color = 1:3)
+
+        f,a,p = streamplot(xy -> Vec2f(xy[2], -xy[1]), Rect2f(-1,-1,2,2))
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # also unclear
+        # f,a,p = textlabel(1:3, text = ["A", "B", "C"], text_color = 1:3)
+
+        # not compatible with per-element attributes
+        # f,a,p = timeseries(1)
+
+        # also unclear
+        # f,a,p = tooltip(1:3, 1:3, text = ["A", "B", "C"], textcolor = 1:3)
+
+        f,a,p = tricontourf(rand(10), rand(10), 1:10)
+        cb = Colorbar(f[1, 2], p)
+        verify_colorbar_defaults(
+            cb, p, color = p.computed_levels, colormap = p.computed_colormap,
+            colorrange = p.computed_colorrange, lowclip = p.cb_lowclip, highclip = p.cb_highclip
+        )
+
+        # also unclear
+        # f,a,p = triplot(rand(Point2f, 10), triangle_color = 1:10)
+
+        # TODO: This should probably use p.volume instead of stepping down
+        f,a,p = volumeslices(1:2, 1:2, 1:2, reshape(1:8, 2,2,2))
+        verify_colorbar_defaults(f, p.plots[1], color = p.plots[1].raw_color)
+
+        f,a,p = voronoiplot([1 2; 3 4])
+        verify_colorbar_defaults(f, p.plots[1])
+
+        f,a,p = waterfall(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        # may support, but doesn't make much sense?
+        # wireframe
+    end
+
+    @testset "Stats Plots" begin
+        cats = rand(1:3, 100)
+        vals = rand(100)
+        f,a,p = boxplot(cats, vals, color = cats)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = crossbar(1:3, 1:3, 0:2, 2:4, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = dendrogram(Point2f.(1:4, 0), [(1, 2), (3, 4), (5, 6)], groups = [1, 1, 2, 2])
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # colormapping not implemented?
+        # qqplot, qqnorm
+
+        f,a,p = density(vals, color = :x)
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # not really supported
+        # f,a,p = ecdfplot(vals, color = 1:201)
+        # verify_colorbar_defaults(f, p.plots[1])
+
+        f,a,p = hexbin(rand(Point2f, 100))
+        verify_colorbar_defaults(f, p.plots[1])
+
+        f,a,p = hist(vals, color = 1:15)
+        verify_colorbar_defaults(f, p.plots[1])
+
+        # not really supported
+        # f,a,p = stephist(vals, color = 1:33)
+        # verify_colorbar_defaults(f, p.plots[1])
+
+        # doesn't support colormap
+        # violin
+    end
+
+    @testset "Primitives" begin
+        f,a,p = text(1:3, text = ["A", "B", "C"], color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = scatter(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = lines(1:4, color = 1:4)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = linesegments(1:4, color = 1:4)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = mesh(Rect2f(0,0,1,1), color = 1:4)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = meshscatter(1:3, color = 1:3)
+        verify_colorbar_defaults(f, p)
+
+        f,a,p = image([1 2; 3 4])
+        verify_colorbar_defaults(f, p, color = p.raw_color)
+
+        f,a,p = heatmap([1 2; 3 4])
+        verify_colorbar_defaults(f, p, color = p.raw_color)
+
+        f,a,p = surface([1 2; 3 4])
+        verify_colorbar_defaults(f, p, color = p.raw_color)
+
+        f,a,p = volume(collect(reshape(1:8, 2,2,2)))
+        verify_colorbar_defaults(f, p, color = p.raw_color)
+
+        f,a,p = voxels(collect(reshape(1:8, 2,2,2)))
+        verify_colorbar_defaults(f, p, color = p.chunk, colorrange = p.value_limits)
+    end
+end

--- a/Makie/test/SceneLike/Colorbar.jl
+++ b/Makie/test/SceneLike/Colorbar.jl
@@ -25,7 +25,7 @@ end
 
 @testset "Colorbar from plots" begin
     @testset "Basic recipes" begin
-        f,a,p = ablines([1, 2, 3], [1, 1., 2], color = 1:3)
+        f, a, p = ablines([1, 2, 3], [1, 1.0, 2], color = 1:3)
         verify_colorbar_defaults(f, p)
 
         # no colormapping
@@ -34,46 +34,46 @@ end
 
         # arc - single element
 
-        f,a,p = arrows2d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
+        f, a, p = arrows2d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(cb, p, color = p.raw_merged_color)
 
-        f,a,p = arrows3d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
+        f, a, p = arrows3d(rand(Point2f, 3), rand(Vec2f, 3), color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = band(1:3, 0:2, 1:3, color = 1:3)
+        f, a, p = band(1:3, 0:2, 1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = barplot(1:3, 1:3, color = 1:3)
+        f, a, p = barplot(1:3, 1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
         # no colormapping
         # f,a,p = bracket(1:3, 0:2, 1:3, 1:3, color = 1:3)
         # verify_colorbar_defaults(f, p)
 
-        f,a,p = contourf([1 2; 3 4])
+        f, a, p = contourf([1 2; 3 4])
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(
             cb, p, color = p.computed_levels, colormap = p.computed_colormap,
             colorrange = p.computed_colorrange, lowclip = p.cb_lowclip, highclip = p.cb_highclip
         )
 
-        f,a,p = contour([1 2; 3 4])
+        f, a, p = contour([1 2; 3 4])
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(cb, p, color = p.zlevels, colorrange = p.computed_colorrange)
 
-        f,a,p = contour3d([1 2; 3 4])
+        f, a, p = contour3d([1 2; 3 4])
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(cb, p, color = p.zlevels, colorrange = p.computed_colorrange)
 
-        f,a,p = contour(collect(reshape(1:8, 2, 2, 2)))
+        f, a, p = contour(collect(reshape(1:8, 2, 2, 2)))
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(
             cb, p, color = p.value_levels, colorrange = p.padded_colorrange,
             colormap = p.opaque_colormap
         )
 
-        f,a,p = datashader(rand(Point2f, 100))
+        f, a, p = datashader(rand(Point2f, 100))
         cb = Colorbar(f[1, 2], p)
         @testset "DataShader" begin
             @test cb.values[] == p.canvas[].pixelbuffer
@@ -85,57 +85,57 @@ end
             @test cb.color_mapping_type[] == Makie.continuous
         end
 
-        f,a,p = heatmap(Resampler([1 2; 3 4]))
+        f, a, p = heatmap(Resampler([1 2; 3 4]))
         verify_colorbar_defaults(f, p.plots[1], color = p.plots[1].raw_color)
 
-        f,a,p = errorbars(1:3, 0:2, ones(3), color = 1:3)
+        f, a, p = errorbars(1:3, 0:2, ones(3), color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = rangebars(1:3, 0:2, 1:3, color = 1:3)
+        f, a, p = rangebars(1:3, 0:2, 1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = hlines(1:3, color = 1:3)
+        f, a, p = hlines(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = vlines(1:3, color = 1:3)
+        f, a, p = vlines(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = hspan(0:2, 1:3, color = 1:3)
+        f, a, p = hspan(0:2, 1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = vspan(0:2, 1:3, color = 1:3)
+        f, a, p = vspan(0:2, 1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = pathtext(1:3, [1, 2, 1], text = "123", color = 1:3)
+        f, a, p = pathtext(1:3, [1, 2, 1], text = "123", color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = pie(1:3, color = 1:3)
+        f, a, p = pie(1:3, color = 1:3)
         verify_colorbar_defaults(f, p.plots[1])
 
-        f,a,p = poly([Rect2f(0,0,1,1), Rect2f(1,1,1,1)], color = 1:2)
+        f, a, p = poly([Rect2f(0, 0, 1, 1), Rect2f(1, 1, 1, 1)], color = 1:2)
         verify_colorbar_defaults(f, p.plots[1])
 
         # not colormapped
         # f,a,p = rainclouds(rand(1:2, 100), rand(100), color = 1:2)
 
-        f,a,p = scatterlines(1:3, color = 1:3)
+        f, a, p = scatterlines(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
         # not colormapped
         # f,a,p = series(rand(5, 3))
 
-        f,a,p = spy([1 2; 3 4])
+        f, a, p = spy([1 2; 3 4])
         verify_colorbar_defaults(f, p.plots[1])
 
         # 3 args, 5 colors...?
-        f,a,p = stairs(1:3, color = 1:5)
+        f, a, p = stairs(1:3, color = 1:5)
         verify_colorbar_defaults(f, p.plots[1])
 
         # stem has multiple independent colormaps (and no lowclip/highclip) so it's
         # not clear how this should interact with Colorbar
         # f,a,p = stem(1:3, color = 1:3)
 
-        f,a,p = streamplot(xy -> Vec2f(xy[2], -xy[1]), Rect2f(-1,-1,2,2))
+        f, a, p = streamplot(xy -> Vec2f(xy[2], -xy[1]), Rect2f(-1, -1, 2, 2))
         verify_colorbar_defaults(f, p.plots[1])
 
         # also unclear
@@ -147,7 +147,7 @@ end
         # also unclear
         # f,a,p = tooltip(1:3, 1:3, text = ["A", "B", "C"], textcolor = 1:3)
 
-        f,a,p = tricontourf(rand(10), rand(10), 1:10)
+        f, a, p = tricontourf(rand(10), rand(10), 1:10)
         cb = Colorbar(f[1, 2], p)
         verify_colorbar_defaults(
             cb, p, color = p.computed_levels, colormap = p.computed_colormap,
@@ -158,13 +158,13 @@ end
         # f,a,p = triplot(rand(Point2f, 10), triangle_color = 1:10)
 
         # TODO: This should probably use p.volume instead of stepping down
-        f,a,p = volumeslices(1:2, 1:2, 1:2, reshape(1:8, 2,2,2))
+        f, a, p = volumeslices(1:2, 1:2, 1:2, reshape(1:8, 2, 2, 2))
         verify_colorbar_defaults(f, p.plots[1], color = p.plots[1].raw_color)
 
-        f,a,p = voronoiplot([1 2; 3 4])
+        f, a, p = voronoiplot([1 2; 3 4])
         verify_colorbar_defaults(f, p.plots[1])
 
-        f,a,p = waterfall(1:3, color = 1:3)
+        f, a, p = waterfall(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
         # may support, but doesn't make much sense?
@@ -174,29 +174,29 @@ end
     @testset "Stats Plots" begin
         cats = rand(1:3, 100)
         vals = rand(100)
-        f,a,p = boxplot(cats, vals, color = cats)
+        f, a, p = boxplot(cats, vals, color = cats)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = crossbar(1:3, 1:3, 0:2, 2:4, color = 1:3)
+        f, a, p = crossbar(1:3, 1:3, 0:2, 2:4, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = dendrogram(Point2f.(1:4, 0), [(1, 2), (3, 4), (5, 6)], groups = [1, 1, 2, 2])
+        f, a, p = dendrogram(Point2f.(1:4, 0), [(1, 2), (3, 4), (5, 6)], groups = [1, 1, 2, 2])
         verify_colorbar_defaults(f, p.plots[1])
 
         # colormapping not implemented?
         # qqplot, qqnorm
 
-        f,a,p = density(vals, color = :x)
+        f, a, p = density(vals, color = :x)
         verify_colorbar_defaults(f, p.plots[1])
 
         # not really supported
         # f,a,p = ecdfplot(vals, color = 1:201)
         # verify_colorbar_defaults(f, p.plots[1])
 
-        f,a,p = hexbin(rand(Point2f, 100))
+        f, a, p = hexbin(rand(Point2f, 100))
         verify_colorbar_defaults(f, p.plots[1])
 
-        f,a,p = hist(vals, color = 1:15)
+        f, a, p = hist(vals, color = 1:15)
         verify_colorbar_defaults(f, p.plots[1])
 
         # not really supported
@@ -208,37 +208,37 @@ end
     end
 
     @testset "Primitives" begin
-        f,a,p = text(1:3, text = ["A", "B", "C"], color = 1:3)
+        f, a, p = text(1:3, text = ["A", "B", "C"], color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = scatter(1:3, color = 1:3)
+        f, a, p = scatter(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = lines(1:4, color = 1:4)
+        f, a, p = lines(1:4, color = 1:4)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = linesegments(1:4, color = 1:4)
+        f, a, p = linesegments(1:4, color = 1:4)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = mesh(Rect2f(0,0,1,1), color = 1:4)
+        f, a, p = mesh(Rect2f(0, 0, 1, 1), color = 1:4)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = meshscatter(1:3, color = 1:3)
+        f, a, p = meshscatter(1:3, color = 1:3)
         verify_colorbar_defaults(f, p)
 
-        f,a,p = image([1 2; 3 4])
+        f, a, p = image([1 2; 3 4])
         verify_colorbar_defaults(f, p, color = p.raw_color)
 
-        f,a,p = heatmap([1 2; 3 4])
+        f, a, p = heatmap([1 2; 3 4])
         verify_colorbar_defaults(f, p, color = p.raw_color)
 
-        f,a,p = surface([1 2; 3 4])
+        f, a, p = surface([1 2; 3 4])
         verify_colorbar_defaults(f, p, color = p.raw_color)
 
-        f,a,p = volume(collect(reshape(1:8, 2,2,2)))
+        f, a, p = volume(collect(reshape(1:8, 2, 2, 2)))
         verify_colorbar_defaults(f, p, color = p.raw_color)
 
-        f,a,p = voxels(collect(reshape(1:8, 2,2,2)))
+        f, a, p = voxels(collect(reshape(1:8, 2, 2, 2)))
         verify_colorbar_defaults(f, p, color = p.chunk, colorrange = p.value_limits)
     end
 end

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -52,10 +52,10 @@ end
     cb = Colorbar(fig[1, 2], hm)
 
     @test hm.scaled_colorrange[] == Vec(-0.5, 0.5)
-    @test cb.limits[] == Vec(-0.5, 0.5)
+    @test cb.resolved_colorrange[] == Vec(-0.5, 0.5)
 
     hm.colorrange = Float32.((-1, 1))
-    @test cb.limits[] == Vec(-1, 1)
+    @test cb.resolved_colorrange[] == Vec(-1, 1)
 
     # TODO: This doesn't work anymore because colorbar doesn't use the same observable
     # cb.limits[] = Float32.((-2, 2))
@@ -183,13 +183,13 @@ end
 end
 
 @testset "Colorbar plot object kwarg clash" begin
-    for attr in (:colormap, :limits)
+    for attr in (:colormap, :colorrange, :limits)
         f, ax, p = scatter(1:10, 1:10, color = 1:10, colorrange = (1, 10))
         Colorbar(f[2, 1], p)
         @test_throws ErrorException Colorbar(f[2, 1], p; Dict(attr => nothing)...)
     end
 
-    for attr in (:colormap, :limits, :highclip, :lowclip)
+    for attr in (:colormap, :colorrange, :limits, :highclip, :lowclip)
         for F in (heatmap, contourf)
             f, ax, p = F(1:10, 1:10, randn(10, 10))
             Colorbar(f[1, 2], p)
@@ -460,13 +460,13 @@ end
     @testset "Recipes" begin
         f, ax, pl = barplot(1:3; color = 1:3)
         cbar = Colorbar(f[1, 2], pl)
-        @test cbar.limits[] == Vec(1.0, 3.0)
+        @test cbar.resolved_colorrange[] == Vec(1.0, 3.0)
 
         let data = fill(1.0, 2, 2, 2)
             data[1] = 3.0
             f, ax, pl = volumeslices(1:2, 1:2, 1:2, data)
             cbar = Colorbar(f[1, 2], pl)
-            @test cbar.limits[] == Vec(1.0, 3.0)
+            @test cbar.resolved_colorrange[] == Vec(1.0, 3.0)
         end
     end
 end

--- a/Makie/test/plots/primitives.jl
+++ b/Makie/test/plots/primitives.jl
@@ -16,9 +16,9 @@ end
     color = range(0, 1, length = length(directions))
     fig, ax, pl = arrows2d(points, directions; color = color)
     cbar = Colorbar(fig[1, 2], pl)
-    @test cbar.limits[] == Vec2f(0, 1)
+    @test cbar.resolved_colorrange[] == Vec2d(0, 1)
     pl.colorrange = (0.5, 0.6)
-    @test cbar.limits[] ≈ Vec2f(0.5, 0.6)
+    @test cbar.resolved_colorrange[] ≈ Vec2d(0.5, 0.6)
 end
 
 @testset "voxels" begin

--- a/ReferenceTests/src/tests/block_recipes.jl
+++ b/ReferenceTests/src/tests/block_recipes.jl
@@ -56,6 +56,12 @@ BLOCK_UPDATES = let
         Legend => :bgcolor,
         # not settable
         Colorbar => :colormap,
+        Colorbar => :values,
+        Colorbar => :colorrange,
+        Colorbar => :limits,
+        Colorbar => :lowclip,
+        Colorbar => :highclip,
+        Colorbar => :scale,
         # avoid
         Axis3 => :zoommode, Toggle => :toggleduration,
     ]
@@ -168,7 +174,7 @@ BLOCK_UPDATES = let
     # includes a bunch of layoutobservables, Legend entry defaults, formatters,
     # dim_converts, ...
     # not counted: skipped hotkey updates, visible updates from true to true
-    @test length(skipped) == 93 # out of 719
+    @test length(skipped) == 90 # out of 719
 
     settings
 end

--- a/docs/src/reference/blocks/colorbar.md
+++ b/docs/src/reference/blocks/colorbar.md
@@ -77,6 +77,41 @@ fig
 
 We can't use `cgrad(...; categorical=true)` for this, since it has an ambiguous meaning for true categorical values.
 
+### Interfacing with Recipes
+
+To create a Colorbar from a plot various colormapping attributes need to be extracted.
+This is done by the `Makie.extract_colormap(plot)` function.
+The default implementation will look up `color`, `colormap`, `colorrange`, `colorscale`, `lowclip` and `highclip` in the given plot.
+If all of them are available, the Colorbar will be constructed using them.
+Otherwise, they will be extracted from the plots child plot if only one child exists.
+
+If this process returns incorrect attributes (for example if `color` is not used for color mapping) or fails to generate a complete set of attributes a custom overload for `Makie.extract_colormap` is necessary.
+The method should simply return a `Dict{Symbol, Any}()` containing the relevant attributes.
+
+```julia
+function Makie.extract_colormap(plot::MyPlot)
+    return Dict{Symbol, Any}(
+        :color => plot.my_color,
+        :colormap => plot.my_colormap,
+        :colorrange => plot.my_colorrange,
+        :colorscale => plot.colorscale,
+        :lowclip => plot.lowclip,
+        :highclip => plot.highclip,
+    )
+end
+```
+
+The attributes that use their default names (here: colorscale, lowclip and highclip) can also be added with `Makie.add_default_colorbar_attributes(dict, plot)`.
+Alternatively, a method for `Makie._extract_colormap(plot)` can be implemented without them.
+This will cause the default method for `extract_colormap` to be called, which automatically adds attributes with default names.
+(Attributes that already have an entry in the dict will not be overwritten.)
+
+Plots with multiple may implement something like `Makie.extract_colormap(p::MyPlot) = Makie.extract_colormap(p.plots[1])` to specify which child plot to extract attributes from.
+
+!!! note
+    Prior to Makie 0.25 `extract_colormap` was expected to return a `Makie.ColorMapping`.
+    This still works but is now deprecated.
+
 ## Attributes
 
 ```@attrdocs


### PR DESCRIPTION
# Description

This contains functional changes with respect to how colormapping data/attributes are extracted from plots and used by `Colorbar`.

#### Before

`extract_colormap(plot)` is called recursively, returning a `ColorMapping` if implemented. Only one child is allowed to produce an output when recursion happens. Primitive plots produce `ColorMapping` without recomputing. Recipe plots, by default, try to build their of `ColorMapping` using default names like `plot.color`, `plot.colormap` etc. Custom implementation are added when non-default names are used and/or more processing is needed. All of these cause compute node -> Observable transitions.

In Colorbar most (but not all) the content of `ColorMapping` is used to build the Colorbar. At the some of fields overwrite `Colorbar` attributes (limits, colormap, highclip, lowclip, scale). (This makes limits post-(color)scale if Colorbar derives from a plot and pre-(color)scale if it does.)

When constructing a Colorbar without a plot, a `ColorMapping` is created using Colorbar attributes.

#### After

Colorbar now always processes color(mapping) using `register_colormapping_without_color!()` which is also used for plots. To allow this, `alpha` and `values` (color values) have been added. Color values + colorrange are handled separately from plots because plots apply colorscale too early for Colorbar.

When constructing a `Colorbar` from a plot `extract_colormap(_recursive)` is still used to gather the relevant attributes. It now primarily expects a dict containing the relevant attributes, but `ColorMapping` still works with a depwarn. The default `extract_colormap` now grabs all the relevant colormap attributes from the plot (with default names). If that set of attributes is incomplete, a set is generated from each child plot. If that yields one set of attributes it's returned, otherwise an error is thrown (like before).

Users can overwrite `extract_colormap` or `_extract_colormap` to define the colormap attributes themselves. The latter method will use a default `extract_colormap` that adds missing attributes with default names. The former should do that itself. If it doesn't, attributes can be sourced from different plots when one implements `extract_colormap(plot) = extract_colormap(plot.plots[1])` which might rarely be problematic? `extract_colormap_recursive` will also try to fill out missing attributes using default names and an error will be thrown if that does not yield a full set.

Any attributes that were grabbed set the matching Colorbar attributes and trigger an error if they are manually set. Any attributes that are not extracted fall back to Colorbar defaults. (Currently all but alpha are required)

#### Other functional changes

- highclip and lowclip triangles are now part of the same `poly` plot (using two Polygons)
- `limits` has been marked as deprecated in favor of the duplicate Colorbar attribute `colorrange`

#### TODO

- [x] reconsider changes to `extract_colormap`
- ~~maybe fix slight shift of Colorbars with lowclip/highclip~~

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
