### PR TITLE
Support non-identity axis scales in ablines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `ablines` now works under non-identity axis scales (e.g. log), drawing a subdivided curve instead of erroring [#5685](https://github.com/MakieOrg/Makie.jl/pull/5685).
+
 ## [0.24.12] - 2026-06-18
 
 - `text` now validates `align` and errors with a clear message for invalid values like `align = :center` [#4651](https://github.com/MakieOrg/Makie.jl/pull/4651).

--- a/Makie/src/basic_recipes/ablines.jl
+++ b/Makie/src/basic_recipes/ablines.jl
@@ -3,30 +3,74 @@
 
 Creates a line defined by `f(x) = slope * x + intercept` crossing a whole `Scene` with 2D projection at its current limits.
 You can pass one or multiple intercepts or slopes.
+
+Under a non-identity axis scale the line is drawn as a subdivided curve, so it stays correct on e.g. log axes.
 """
 @recipe ABLines (intercept, slope) begin
-    documented_attributes(LineSegments)...
+    documented_attributes(Lines)...
 end
 
-function Makie.plot!(p::ABLines)
-    scene = Makie.parent_scene(p)
-    transf = transform_func(scene)
-    is_identity_transform(transf) || throw(ArgumentError("ABLines is only defined for the identity transform, not $(typeof(transf))."))
+const N_ABLINE_SUBDIVISIONS = 256
 
+function Makie.plot!(p::ABLines)
     add_axis_limits!(p)
 
-    map!(p.attributes, [:axis_limits, :intercept, :slope], :points) do lims, intercept, slope
+    map!(
+        p.attributes,
+        [:axis_limits, :axis_limits_transformed, :intercept, :slope, :transform_func],
+        :points
+    ) do lims, lims_transformed, intercept, slope, transf
         points = Point2d[]
         broadcast_foreach(intercept, slope) do intercept, slope
-            f(x) = intercept + slope * x
-            xmin, xmax = first.(extrema(lims))
-            push!(points, Point2d(xmin, intercept + slope * xmin))
-            push!(points, Point2d(xmax, intercept + slope * xmax))
+            append_abline_curve!(points, lims, lims_transformed, transf, intercept, slope)
         end
         return points
     end
-    linesegments!(p, Attributes(p), p.points)
+
+    for attr in (:color, :linewidth)
+        map!(p.attributes, [attr, :intercept, :slope, :transform_func], Symbol(attr, :_expanded)) do val, intercept, slope, transf
+            return expand_per_abline(val, n_ablines(intercept, slope), points_per_abline(transf))
+        end
+    end
+
+    lines!(
+        p, Attributes(p), p.points,
+        color = p.color_expanded, linewidth = p.linewidth_expanded,
+        transformation = :inherit_model
+    )
     return p
+end
+
+points_per_abline(transf) = (is_identity_transform(transf) ? 2 : N_ABLINE_SUBDIVISIONS) + 1
+
+n_ablines(intercept, slope) = max(_broadcast_length(intercept), _broadcast_length(slope))
+_broadcast_length(x) = x isa AbstractArray ? length(x) : 1
+
+function expand_per_abline(val, n, points_per_line)
+    val isa AbstractArray && length(val) == n || return val
+    return repeat(val, inner = points_per_line)
+end
+
+function append_abline_curve!(points, lims, lims_transformed, transf, intercept, slope)
+    f(x) = intercept + slope * x
+
+    if is_identity_transform(transf)
+        xmin, xmax = first.(extrema(lims))
+        push!(points, Point2d(xmin, f(xmin)), Point2d(xmax, f(xmax)), Point2d(NaN))
+        return
+    end
+
+    xscale, yscale = transf[1], transf[2]
+    inv_xscale = inverse_transform(xscale)
+    xtmin, xtmax = first.(extrema(lims_transformed))
+
+    y_interval = defined_interval(yscale)
+    transformed_y(x) = (y = f(x); y in y_interval ? _apply_y_transform(transf, y) : NaN)
+    for xt in range(xtmin, xtmax, length = N_ABLINE_SUBDIVISIONS)
+        push!(points, Point2d(xt, transformed_y(inv_xscale(xt))))
+    end
+    push!(points, Point2d(NaN))
+    return
 end
 
 data_limits(::ABLines) = Rect3d(Point3f(NaN), Vec3f(NaN))

--- a/Makie/test/plots/primitives.jl
+++ b/Makie/test/plots/primitives.jl
@@ -1,11 +1,35 @@
 @testset "ablines" begin
     # Test ablines with 0 dim arrays
+    finite(points) = filter(p -> all(isfinite, p), points)
+
     f, ax, pl = ablines(fill(0), fill(1))
     reset_limits!(ax)
     points = pl.plots[1][1]
-    @test Point2f.(points[]) == [Point2f(0), Point2f(10)]
+    @test finite(Point2f.(points[])) == [Point2f(0), Point2f(10)]
     limits!(ax, 5, 15, 6, 17)
-    @test Point2f.(points[]) == [Point2f(5), Point2f(15)]
+    @test finite(Point2f.(points[])) == [Point2f(5), Point2f(15)]
+
+    @testset "non-identity transform" begin
+        f = Figure()
+        ax = Axis(f[1, 1], xscale = log10, yscale = log10)
+        scatter!(ax, [1, 10, 100], [1, 10, 100])
+        pl = ablines!(ax, 0.0, 2.0)
+        reset_limits!(ax)
+        points = finite(pl.plots[1][1][])
+        @test length(points) > 2
+        @test all(p -> p[2] - p[1] ≈ log10(2.0), points)
+    end
+
+    @testset "NaN for points outside the scale domain" begin
+        f = Figure()
+        ax = Axis(f[1, 1], yscale = log10)
+        scatter!(ax, [1, 2, 3, 4], [1, 10, 100, 1000])
+        pl = ablines!(ax, -50.0, 50.0)
+        reset_limits!(ax)
+        points = pl.plots[1][1][]
+        @test count(p -> any(isnan, p), points) > 0
+        @test count(p -> all(isfinite, p), points) > 0
+    end
 end
 
 @testset "arrows" begin

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -2147,6 +2147,48 @@ end
     f
 end
 
+@reference_test "ablines with transform_func" begin
+    f = Figure(size = (600, 500))
+
+    ax = Axis(f[1, 1], title = "identity")
+    ablines!(ax, [0.0, 1.0, 2.0], [1.0, -0.5, 0.25], color = [:orange, :red, :purple], linewidth = 3)
+    limits!(ax, 0, 10, -2, 6)
+
+    ax = Axis(f[1, 2], xscale = log10, title = "log x")
+    ablines!(ax, 0.0, 0.002, color = :orange, linewidth = 3)
+    limits!(ax, 1, 1000, 0, 3)
+
+    ax = Axis(f[1, 3], yscale = log10, title = "log y, crosses zero")
+    ablines!(ax, -50.0, 50.0, color = :orange, linewidth = 3)
+    limits!(ax, 1, 4, 1, 200)
+
+    ax = Axis(f[2, 1], xscale = log10, yscale = log10, title = "log-log, zero intercept")
+    ablines!(ax, [0.0, 0.0, 0.0], [1.0, 3.0, 0.3], color = [:orange, :red, :purple], linewidth = [2, 4, 6])
+    limits!(ax, 1, 100, 0.1, 1000)
+
+    ax = Axis(f[2, 2], xscale = log10, yscale = log10, title = "log-log, nonzero intercept")
+    ablines!(ax, 5.0, 1.0, color = :teal, linewidth = 3)
+    limits!(ax, 1, 100, 1, 1000)
+
+    ax = Axis(f[2, 3], xscale = log10, title = "log x, negative slope")
+    ablines!(ax, 5.0, -0.001, color = :red, linewidth = 3)
+    limits!(ax, 1, 1000, 0, 6)
+
+    ax = Axis(f[3, 1], xscale = sqrt, title = "sqrt x")
+    ablines!(ax, 0.0, 1.0, color = :orange, linewidth = 3)
+    limits!(ax, 0, 100, 0, 100)
+
+    ax = Axis(f[3, 2], yscale = sqrt, title = "sqrt y")
+    ablines!(ax, 0.0, 1.0, color = :orange, linewidth = 3)
+    limits!(ax, 0, 100, 0, 100)
+
+    ax = Axis(f[3, 3], xscale = log10, yscale = log10, title = "log-log, multiple intercepts")
+    ablines!(ax, [1.0, 10.0, 100.0], 1.0, color = [:orange, :red, :purple], linewidth = 3)
+    limits!(ax, 1, 100, 1, 1000)
+
+    f
+end
+
 @reference_test "Color Patterns" begin
     f = Figure()
     a = Axis(f[1, 1], aspect = DataAspect()) #autolimitaspect = 1)

--- a/docs/src/reference/plots/ablines.md
+++ b/docs/src/reference/plots/ablines.md
@@ -10,6 +10,40 @@ ablines!([1, 2, 3], [1, 1.5, 2], color = [:red, :orange, :pink], linestyle=:dash
 current_figure()
 ```
 
+## Non-identity axis scales
+
+`ablines` defines `f(x) = slope * x + intercept` in data coordinates, so under a non-identity scale (such as `log10`) the line generally becomes a curve in the transformed space. It is drawn as a subdivided curve in that case.
+
+```@figure
+f = Figure(size = (600, 500))
+
+ax = Axis(f[1, 1], title = "identity")
+ablines!(ax, [0.0, 1.0, 2.0], [1.0, -0.5, 0.25], color = [:orange, :red, :purple], linewidth = 3)
+limits!(ax, 0, 10, -2, 6)
+
+ax = Axis(f[1, 2], xscale = log10, title = "log x")
+ablines!(ax, 0.0, 0.002, color = :orange, linewidth = 3)
+limits!(ax, 1, 1000, 0, 3)
+
+ax = Axis(f[1, 3], yscale = log10, title = "log y, crosses zero")
+ablines!(ax, -50.0, 50.0, color = :orange, linewidth = 3)
+limits!(ax, 1, 4, 1, 200)
+
+ax = Axis(f[2, 1], xscale = log10, yscale = log10, title = "log-log, zero intercept")
+ablines!(ax, [0.0, 0.0, 0.0], [1.0, 3.0, 0.3], color = [:orange, :red, :purple], linewidth = [2, 4, 6])
+limits!(ax, 1, 100, 0.1, 1000)
+
+ax = Axis(f[2, 2], xscale = log10, yscale = log10, title = "log-log, nonzero intercept")
+ablines!(ax, [1.0, 10.0, 100.0], 1.0, color = [:orange, :red, :purple], linewidth = 3)
+limits!(ax, 1, 100, 1, 1000)
+
+ax = Axis(f[2, 3], xscale = sqrt, title = "sqrt x")
+ablines!(ax, 0.0, 1.0, color = :orange, linewidth = 3)
+limits!(ax, 0, 100, 0, 100)
+
+f
+```
+
 ## Attributes
 
 ```@attrdocs


### PR DESCRIPTION
`ablines` used to error on any non-identity axis scale (`ABLines is only defined for the identity transform`). But there's no real reason for that: `f(x) = slope * x + intercept` is defined in data coordinates, so under a transform it just becomes a curve in screen space. This draws it as a subdivided curve (256 points sampled evenly across the visible range), and keeps the cheap 2-point line for the identity transform.

A few details fall out of this:
- On log-log axes a zero-intercept line maps back to a straight line, as you'd expect; with a nonzero intercept it's genuinely curved.
- The line value can leave the y-scale domain (e.g. go negative on a log y axis) even when the axis limits are valid. Those points become `NaN`, so the line breaks there. Since the visible y-range is always inside the domain, the break is always off-screen.
- Per-line `color`/`linewidth` vectors still work, and it now draws with `lines` rather than `linesegments`.

```julia
f = Figure(size = (600, 500))

ax = Axis(f[1, 1], title = "identity")
ablines!(ax, [0.0, 1.0, 2.0], [1.0, -0.5, 0.25], color = [:orange, :red, :purple], linewidth = 3)
limits!(ax, 0, 10, -2, 6)

ax = Axis(f[1, 2], xscale = log10, title = "log x")
ablines!(ax, 0.0, 0.002, color = :orange, linewidth = 3)
limits!(ax, 1, 1000, 0, 3)

ax = Axis(f[1, 3], yscale = log10, title = "log y, crosses zero")
ablines!(ax, -50.0, 50.0, color = :orange, linewidth = 3)
limits!(ax, 1, 4, 1, 200)

ax = Axis(f[2, 1], xscale = log10, yscale = log10, title = "log-log, zero intercept")
ablines!(ax, [0.0, 0.0, 0.0], [1.0, 3.0, 0.3], color = [:orange, :red, :purple], linewidth = [2, 4, 6])
limits!(ax, 1, 100, 0.1, 1000)

ax = Axis(f[2, 2], xscale = log10, yscale = log10, title = "log-log, nonzero intercept")
ablines!(ax, [1.0, 10.0, 100.0], 1.0, color = [:orange, :red, :purple], linewidth = 3)
limits!(ax, 1, 100, 1, 1000)

ax = Axis(f[2, 3], xscale = sqrt, title = "sqrt x")
ablines!(ax, 0.0, 1.0, color = :orange, linewidth = 3)
limits!(ax, 0, 100, 0, 100)

f
```

<img width="600" height="500" alt="ablines under different axis scales" src="https://github.com/user-attachments/assets/230efede-ed8b-4442-9a56-2c3368a0d231">
