### PR TITLE
CairoMakie: keep the precompile workload out of module scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Scope the CairoMakie precompile workload's figures inside `let`, so rendered `Screen`s and their pixel buffers are no longer serialized into the package image (~150 MB smaller pkgimage) [#XXXX](https://github.com/MakieOrg/Makie.jl/pull/XXXX).
+
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)
 - Adjusted cycled attributes to be marked as `:cycled` instead of `nothing` so that `nothing` doesn't get overridden. This allows e.g. `linestyle = nothing` to be set when `linestyle` is cycled. [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267)
 

--- a/CairoMakie/src/precompiles.jl
+++ b/CairoMakie/src/precompiles.jl
@@ -2,8 +2,16 @@ using PrecompileTools
 
 macro compile(block)
     return quote
-        figlike = $(esc(block))
-        Makie.colorbuffer(figlike)
+        # Run the workload inside a `let` body, matching GLMakie and WGLMakie:
+        # at top level, both the result binding and any assignments made by
+        # the block itself (`f, ax, pl = ...`) would otherwise become hidden
+        # module-level globals, each permanently rooting its Figure, Scene
+        # graph, and rendered Screen (with its multi-megabyte pixel buffer)
+        # into the serialized package image.
+        let
+            figlike = $(esc(block))
+            Makie.colorbuffer(figlike)
+        end
     end
 end
 


### PR DESCRIPTION
The `@compile` macro bound its result to `figlike` directly inside a top-level `quote`, and several shared workload blocks assign temporaries (`f, ax, pl = ...`) at top level. Each such assignment creates a hidden module-level global in CairoMakie, permanently rooting the workload's Figures, Scene graphs, and rendered Screens - including their pixel buffers (23 framebuffers at ~4.3 MB each) - into the serialized package image. Running the workload inside a `let` body (the form GLMakie and WGLMakie already use) makes those bindings collectable again.

Measured on the package image: 189 MB -> 41 MB (-78%), zero serialized Screen/CairoSurfaceImage objects, rendering behavior unchanged.

This change was written with the assistance of generative AI (Claude).