### PR TITLE
WGLMakie: make scene lookup retry window configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- WGLMakie: made scene lookup retry timing configurable via `WGLMAKIE_SCENE_RETRY_DELAY_MS` and `WGLMAKIE_SCENE_RETRY_TOTAL_MS` to avoid timeout failures for slow scene initialization.
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)
 - Adjusted cycled attributes to be marked as `:cycled` instead of `nothing` so that `nothing` doesn't get overridden. This allows e.g. `linestyle = nothing` to be set when `linestyle` is cycled. [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- WGLMakie: made scene lookup retry timing configurable via `WGLMAKIE_SCENE_RETRY_DELAY_MS` and `WGLMAKIE_SCENE_RETRY_TOTAL_MS` to avoid timeout failures for slow scene initialization.
+- WGLMakie: made scene lookup retry timing configurable via `WGLMAKIE_SCENE_RETRY_DELAY_MS` and `WGLMAKIE_SCENE_RETRY_TOTAL_MS` to avoid timeout failures for slow scene initialization. [#5693](https://github.com/MakieOrg/Makie.jl/pull/5693)
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)
 - Adjusted cycled attributes to be marked as `:cycled` instead of `nothing` so that `nothing` doesn't get overridden. This allows e.g. `linestyle = nothing` to be set when `linestyle` is cycled. [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267)
 

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -24,11 +24,16 @@ function Bonito.print_js_code(io::IO, plot::AbstractPlot, context::Bonito.JSSour
 end
 
 function Bonito.print_js_code(io::IO, scene::Scene, context::Bonito.JSSourceContext)
+    # Some large scenes can initialize slowly in app mode; allow configurable retry window.
+    retry_delay_ms = max(1, something(tryparse(Int, get(ENV, "WGLMAKIE_SCENE_RETRY_DELAY_MS", "100")), 100))
+    total_wait_ms = max(retry_delay_ms, something(tryparse(Int, get(ENV, "WGLMAKIE_SCENE_RETRY_TOTAL_MS", "60000")), 60000))
+    max_retries = max(100, cld(total_wait_ms, retry_delay_ms))
+
     code = js"""$(WGL).then(WGL=> {
         function try_find_scene(_retries) {
             let retries = _retries || 0;
-            const max_retries = 100;
-            const retry_delay = 100;
+            const max_retries = $(max_retries);
+            const retry_delay = $(retry_delay_ms);
             const scene = WGL.find_scene($(js_uuid(scene)));
             if (scene) {
                 return Promise.resolve(scene);


### PR DESCRIPTION
## Summary
- make WGL scene lookup retry timing configurable via `WGLMAKIE_SCENE_RETRY_DELAY_MS` and `WGLMAKIE_SCENE_RETRY_TOTAL_MS`
- derive `max_retries` from configured delay and total wait with sane clamping
- replace hard-coded JS retry constants with interpolated values from Julia config

## Motivation
Large scenes in app mode can initialize more slowly than a fixed retry window, causing `Scene not found after retries` errors.

## Notes
- defaults remain conservative (`100ms` retry delay and `60000ms` total wait)
- this PR keeps configuration scoped to `WGLMAKIE_*` env vars only