### PR TITLE
Add high-level schematic to the Figures and Blocks architecture docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)
 - Adjusted cycled attributes to be marked as `:cycled` instead of `nothing` so that `nothing` doesn't get overridden. This allows e.g. `linestyle = nothing` to be set when `linestyle` is cycled. [#5267](https://github.com/MakieOrg/Makie.jl/issues/5267)
+- Added a high-level schematic to the "Figures and Blocks" section of the architecture docs [#5695](https://github.com/MakieOrg/Makie.jl/pull/5695).
 
 ## [0.24.12] - 2026-06-18
 

--- a/docs/src/explanations/architecture.md
+++ b/docs/src/explanations/architecture.md
@@ -88,6 +88,40 @@ In practice, Makie users build most data visualizations out of more convenient, 
 
 The `Figure` consists mainly of two elements, a `Scene` and a `GridLayout`. The `Scene` is the root of the figure's scene graph and the `GridLayout` computes the positions of the figure's `Block`s.
 
+An `Axis` added to a `Figure` has a few components of its own, a `Scene` (the `blockscene`) and a `GridContent`, and these connect to the matching components of the `Figure`. For example, when you write `Axis(f[1, 1])`, the axis's `blockscene` attaches to the figure's root `Scene` so the axis is drawn, and its `GridContent` is added to the layout's `content[]` so the axis is positioned in cell `[1, 1]`.
+
+```@graphviz
+digraph {
+    rankdir=TB;
+    compound=true;
+    nodesep=0.4;
+    ranksep=0.6;
+
+    subgraph cluster_figure {
+        label="Figure";
+        style=filled;
+        fillcolor="#fcfcfcff";
+        RS [label="Scene\n(root scene)"];
+        LO [label="Layout"];
+        CO [label="content[]\nwhat the layout holds"];
+    }
+
+    subgraph cluster_axis {
+        label="Axis   —   made with  Axis(f[1, 1])";
+        style=filled;
+        fillcolor="#fcfcfcff";
+        BS [label="Scene\n(blockscene)"];
+        CS [label="Scene\n(axis canvas + your plots)"];
+        GC [label="GridContent\nthe axis's spot in the grid"];
+        BS -> CS [label="  child scenes", dir=none];
+    }
+
+    RS -> BS [label="  draws it  (scene graph)"];
+    LO -> GC [label="  positions it"];
+    GC -> CO [label="  added to", style=dashed];
+}
+```
+
 Every `Block` object consists of a `Scene` called the `blockscene` and an arbitrary number of child plots and child scenes connected to it. When we want to create an `Axis` object in Makie we often do something like:
 
 ```julia


### PR DESCRIPTION
Closes #2866.

At MakieCon, a blackboard sketch of Makie's building blocks (`Figure → Scene / Layout`, and how `Axis(f[1,1])` connects in) helped participants understand the structure; #2866 asked to digitize it for the introductory docs.

This adds a small Graphviz diagram and a short explanation under the [**Figures and Blocks**](https://github.com/MakieOrg/Makie.jl/blob/master/docs/src/explanations/architecture.md#figures-and-blocks) section of `architecture.md` — the location suggested by @asinghvi17 in the issue. It shows how a `Figure`'s `Scene`, `Layout` and `content[]` connect to an `Axis`'s `blockscene` and `GridContent`:

- the axis's `blockscene` attaches to the figure's root `Scene` (so it's drawn)
- the axis's `GridContent` is added to the layout's `content[]` (so it's positioned)

It reuses the docs' existing `@graphviz` block style, so it renders in the same monochrome look as the neighboring diagrams. The change is docs-only and purely additive.
