### PR TITLE
Make tooltip styling more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `tooltip` now inherits `fontsize` from the theme, sets its default outline `linewidth` to `1.0` to match axis spines, reduces its default `triangle_size` from `10` to `7`, and uses slightly wider horizontal `textpadding` [#5698](https://github.com/MakieOrg/Makie.jl/pull/5698).
+
 ## [0.24.13] - 2026-07-02
 
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)

--- a/Makie/src/basic_recipes/tooltip.jl
+++ b/Makie/src/basic_recipes/tooltip.jl
@@ -22,11 +22,11 @@ Creates a tooltip pointing at `position` displaying the given `string
 
     # Text
     "Sets the padding around text in the tooltip. This is given as `(left, right, bottom, top)` offsets."
-    textpadding = (4, 4, 4, 4) # LRBT
+    textpadding = (5, 5, 3, 3) # LRBT
     "Sets the text color."
     textcolor = @inherit textcolor
     "Sets the text size in screen units."
-    fontsize = 16
+    fontsize = @inherit fontsize
     "Sets the font."
     font = @inherit font
     "Gives text an outline if set to a positive value."
@@ -40,13 +40,13 @@ Creates a tooltip pointing at `position` displaying the given `string
     "Sets the background color of the tooltip."
     backgroundcolor = :white
     "Sets the size of the triangle pointing at `position`."
-    triangle_size = 10
+    triangle_size = 7
 
     # Outline
     "Sets the color of the tooltip outline."
     outline_color = :black
     "Sets the linewidth of the tooltip outline."
-    outline_linewidth = 2.0f0
+    outline_linewidth = 1.0f0
     "Sets the linestyle of the tooltip outline."
     outline_linestyle = nothing
 


### PR DESCRIPTION
The `tooltip` defaults felt heavier than the rest of Makie. It used a hardcoded `fontsize = 16` (ignoring the theme's `14`), an outline `linewidth` of `2`, and a fairly large triangle. This aligns it with the surrounding style: `fontsize` now inherits from the theme, the outline drops to `1.0` to match axis spines, `triangle_size` goes `10` → `7`, and `textpadding` gets slightly more horizontal than vertical room since fonts already leave visual space above/below. `DataInspector` picks all of this up since it builds on the recipe.

<img width="600" height="350" alt="tooltip before and after" src="https://github.com/user-attachments/assets/02c58d33-c785-434e-8cf1-fc5e9afc5a97">

The `Tooltip` and `DataInspector` reference images will need regenerating.
