### PR TITLE
Fix `PlotSpec` constructor

### DIFF
--- a/Makie/src/specapi.jl
+++ b/Makie/src/specapi.jl
@@ -26,7 +26,7 @@ struct PlotSpec
         if type_str[end] == '!'
             error("PlotSpec objects are supposed to be used without !, unless when using `S.$(type)(axis::P.Axis, args...; kwargs...)`")
         end
-        if !isuppercase(type_str[1])
+        if type !== :plot && !isuppercase(type_str[1])
             func = hasproperty(Makie, type) ? getproperty(Makie, type) : nothing
             func === nothing && error("PlotSpec need to be existing recipes or Makie plot objects. Found: $(type_str)")
             plot_type = Plot{func}
@@ -58,7 +58,7 @@ struct PlotSpec
         end
         return new(type, Any[args...], kw)
     end
-    PlotSpec(args...; kwargs...) = new(:plot, args...; kwargs...)
+    PlotSpec(args...; kwargs...) = PlotSpec(:plot, args...; kwargs...)
 end
 
 

--- a/Makie/test/specapi.jl
+++ b/Makie/test/specapi.jl
@@ -122,6 +122,13 @@ function Makie.convert_arguments(P::Type{<:Plot}, ::TestPlot)
     return PlotSpec(P, Point2f.(1:5, 1:5); color = 1:5, cycle = [])
 end
 
+@testset "PlotSpec without plot type" begin
+    spec = @test_nowarn PlotSpec(1:4; color = :red)
+    @test spec.type === :plot
+    @test spec.args == Any[1:4]
+    @test spec.kwargs[:color] == Makie.to_color(:red)
+end
+
 @testset "PlotSpec with attributes in convert_arguments" begin
     f, ax, pl = scatter(TestPlot())
     @test pl.color[] == 1:5


### PR DESCRIPTION
# Description

Fixes these errors:
```julia
julia> PlotSpec(1:4)
ERROR: ArgumentError: new: too few arguments (expected 3)

julia> PlotSpec(1:4; color = :red)
ERROR: MethodError: no method matching tuple(::Symbol, ::UnitRange{Int64}; color::Symbol)
This method does not support all of the given keyword arguments (and may not support any).
```

and this warning:
```julia
┌ Warning: PlotSpec objects are supposed to be title case. Found: plot. Please use plot instead.
└ @ Makie ~/repos/Makie.jl/Makie/src/specapi.jl:34
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.
