### PR TITLE
Restore CJK fallback font artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Restored the bundled CJK fallback font so text rendering can represent Japanese, Chinese, and Korean characters again. [#5139](https://github.com/MakieOrg/Makie.jl/issues/5139)
 - Scope the CairoMakie precompile workload's figures inside `let`, so rendered `Screen`s and their pixel buffers are no longer serialized into the package image (~150 MB smaller pkgimage) [#5692](https://github.com/MakieOrg/Makie.jl/pull/5692).
 - `tooltip` now inherits `fontsize` from the theme, sets its default outline `linewidth` to `1.0` to match axis spines, reduces its default `triangle_size` from `10` to `7`, and uses slightly wider horizontal `textpadding` [#5698](https://github.com/MakieOrg/Makie.jl/pull/5698).
 

--- a/Makie/Artifacts.toml
+++ b/Makie/Artifacts.toml
@@ -1,6 +1,6 @@
 [MakieAssets]
-git-tree-sha1 = "ad4e594b35357bcfafa2ed97db3137382a3f09bb"
+git-tree-sha1 = "4bb2dd2b956c8eb4e3c3756cb064a71d769dc591"
 
     [[MakieAssets.download]]
-    sha256 = "b275a61d923be81b6e7b8f3338c9506d71c55a6dc207342e32ea6e43eed3add9"
-    url = "https://github.com/MakieOrg/Makie.jl/releases/download/assets-v1.0.0/MakieAssets.tar.gz"
+    sha256 = "86e40286f5fa546e3b247bb4a4a09361232572b49e137e3c568fe9def6c176fa"
+    url = "https://github.com/MakieOrg/Makie.jl/releases/download/assets-v1.0.1/MakieAssets.tar.gz"

--- a/Makie/src/utilities/texture_atlas.jl
+++ b/Makie/src/utilities/texture_atlas.jl
@@ -188,6 +188,7 @@ function alternativefonts()
             alternatives = [
                 "TeXGyreHerosMakie-Regular.otf",
                 "DejaVuSans.ttf",
+                "NotoSansCJKkr-Regular.otf",
                 "NotoSansCuneiform-Regular.ttf",
                 "NotoSansSymbols-Regular.ttf",
                 "FiraMono-Medium.ttf",


### PR DESCRIPTION
I had some AI tokens to spare, and I've been wanting a solution to #5139. The root cause was https://github.com/MakieOrg/Makie.jl/pull/5074

This PR is incomplete because apparently I/we cannot modify the artifacts at https://github.com/MakieOrg/Makie.jl/releases/download/assets-v1.0.1/MakieAssets.tar.gz without permission? So this PR exists to confirm that Simon Danish's https://github.com/MakieOrg/Makie.jl/issues/5139#issuecomment-3022692853 is correct, and to publish instructions in the hope that somebody with the access rights picks it up!

Locally it works, in any case:
<img width="782" height="539" alt="image" src="https://github.com/user-attachments/assets/99d2b8b0-96e9-43ee-9770-36729ca9f0c6" />

From Codex:

> Maintainers need to publish a new Makie asset artifact matching Makie/Artifacts.toml:
>
>   - URL expected by the branch:
>     https://github.com/MakieOrg/Makie.jl/releases/download/assets-v1.0.1/MakieAssets.tar.gz
> 
>   - Artifact tree hash:
>     4bb2dd2b956c8eb4e3c3756cb064a71d769dc591
> 
>   - Tarball SHA256:
>     86e40286f5fa546e3b247bb4a4a09361232572b49e137e3c568fe9def6c176fa
> 
>   That tarball must contain the restored file:
> 
>   fonts/NotoSansCJKkr-Regular.otf
> 
>   Once that release asset exists, Pkg can install MakieAssets, and the branch’s added fallback entry:
> 
>   "NotoSansCJKkr-Regular.otf",
> 
>   will work normally.

>   I restored that file from git history.
> 
>   Specifically, from the parent of the asset-removal commit:
> 
>   61c2c3c268fe9c262d2aaeeebc4e4063160c184a^:Makie/assets/fonts/NotoSansCJKkr-Regular.otf
> 
>   The blob is:
> 
>   a98f833ce28931adcaa8c92bb5f7320d782e6441
> 
>   I extracted it into the local artifact staging directory:
> 
>   .scratch/restore-cjk/unpacked/fonts/NotoSansCJKkr-Regular.otf
> 
>   It is not currently tracked in the repo; it used to be tracked before PR #5074 removed the checked-in assets.

> From the current branch, the tarball I built was made like this:
```
  # From C:\Users\a1058035\dev\Makie.jl
  New-Item -ItemType Directory -Force .scratch\restore-cjk\base, .scratch\restore-cjk\unpacked | Out-Null

  # Download and unpack the current artifact.
  gh release download assets-v1.0.0 `
    --repo MakieOrg/Makie.jl `
    --pattern MakieAssets.tar.gz `
    --dir .scratch\restore-cjk\base `
    --clobber

  tar -xzf .scratch\restore-cjk\base\MakieAssets.tar.gz `
    -C .scratch\restore-cjk\unpacked

  # Restore the historical font blob.
  $blob = git rev-parse 61c2c3c268fe9c262d2aaeeebc4e4063160c184a^:Makie/assets/fonts/NotoSansCJKkr-Regular.otf
  $font = (Resolve-Path .scratch\restore-cjk\unpacked\fonts).Path + '\NotoSansCJKkr-Regular.otf'
  cmd /c "git cat-file blob $blob > `"$font`""

  # Build the new tarball.
  tar -czf .scratch\restore-cjk\MakieAssets.tar.gz `
    -C .scratch\restore-cjk\unpacked .
```
 Then verify hashes in Julia:

```
  using Pkg.GitTools

  source = raw"C:\Users\a1058035\dev\Makie.jl\.scratch\restore-cjk\unpacked"
  bytes2hex(GitTools.tree_hash(source))
  # should be "4bb2dd2b956c8eb4e3c3756cb064a71d769dc591"
```
>  And SHA256 in PowerShell:
```
  Get-FileHash .scratch\restore-cjk\MakieAssets.tar.gz -Algorithm SHA256
  # should be 86E40286F5FA546E3B247BB4A4A09361232572B49E137E3C568FE9DEF6C176FA
```
>  The resulting file is:
```
  .scratch\restore-cjk\MakieAssets.tar.gz
```