### PR TITLE
Improve axis hints compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#5664](https://github.com/MakieOrg/Makie.jl/pull/5664).
 - Scope the CairoMakie precompile workload's figures inside `let`, so rendered `Screen`s and their pixel buffers are no longer serialized into the package image (~150 MB smaller pkgimage) [#5692](https://github.com/MakieOrg/Makie.jl/pull/5692).
 - `tooltip` now inherits `fontsize` from the theme, sets its default outline `linewidth` to `1.0` to match axis spines, reduces its default `triangle_size` from `10` to `7`, and uses slightly wider horizontal `textpadding` [#5698](https://github.com/MakieOrg/Makie.jl/pull/5698).
+- Fixed specialized `args_preferred_axis` methods getting skipped by less specialized Makie defaults [#5722](https://github.com/MakieOrg/Makie.jl/pull/5722)
 
 ## [0.24.13] - 2026-07-02
 

--- a/Makie/src/figureplotting.jl
+++ b/Makie/src/figureplotting.jl
@@ -143,30 +143,33 @@ args_preferred_axis(args...) = nothing
 preferred_axis_type(::Volume) = LScene
 preferred_axis_type(::Union{Image, Heatmap}) = Axis
 
-# For plots that don't require an axis,
-# E.g. BlockSpec
-struct FigureOnly end
-
-function preferred_axis_type(
-        ::Union{Wireframe, Surface, Contour3d}, x::AbstractArray, y::AbstractArray,
-        z::AbstractArray
+# Keep these as `args_preferred_axis` for backwards compat (i.e. allow more
+# specialized methods of `args_preferred_axis` to win dispatch, instead of cutting
+# them off by with a less specialized `preferred_axis_type`)
+function args_preferred_axis(
+        ::Union{Wireframe, Surface, Contour3d},
+        x::AbstractArray, y::AbstractArray, z::AbstractArray
     )
     return all(x -> z[1] ≈ x, z) ? Axis : LScene
 end
 
-preferred_axis_type(::AbstractVector, ::AbstractVector, ::AbstractVector, ::Function) = LScene
-preferred_axis_type(::AbstractArray{T, 3}) where {T} = LScene
+args_preferred_axis(::AbstractVector, ::AbstractVector, ::AbstractVector, ::Function) = LScene
+args_preferred_axis(::AbstractArray{T, 3}) where {T} = LScene
 
-function preferred_axis_type(::AbstractVector{<:Union{AbstractGeometry{DIM}, GeometryBasics.Mesh{DIM}}}) where {DIM}
+function args_preferred_axis(::AbstractVector{<:Union{AbstractGeometry{DIM}, GeometryBasics.Mesh{DIM}}}) where {DIM}
     return DIM === 2 ? Axis : LScene
 end
 
-function preferred_axis_type(::Union{AbstractGeometry{DIM}, GeometryBasics.Mesh{DIM}}) where {DIM}
+function args_preferred_axis(::Union{AbstractGeometry{DIM}, GeometryBasics.Mesh{DIM}}) where {DIM}
     return DIM === 2 ? Axis : LScene
 end
 
-preferred_axis_type(::AbstractVector{<:Point3}) = LScene
-preferred_axis_type(::AbstractVector{<:Point2}) = Axis
+args_preferred_axis(::AbstractVector{<:Point3}) = LScene
+args_preferred_axis(::AbstractVector{<:Point2}) = Axis
+
+# For plots that don't require an axis,
+# E.g. BlockSpec
+struct FigureOnly end
 
 # axis attributes
 


### PR DESCRIPTION
# Description

Related #5704

Before #5375 you had to implement an `args_preferred_axis` method to specialize further on (converted) argument types. With the changes from #5375, Makie now implements the default paths as `preferred_axis_type` methods, which cut off the `args_preferred_axis` methods. So you now needs to implement more specialized `preferred_axis_type` methods, which you couldn't before.

To make it easier to write code that compatible with Makie before and after #5375, this pr moves the default (converted) argument methods back to `args_preferred_axis`. That way more specialized methods continue to work. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
