### PR TITLE
Post reference image status via workflow_run so it works for fork PRs

### DIFF
--- a/.github/workflows/_reference-tests.yml
+++ b/.github/workflows/_reference-tests.yml
@@ -107,7 +107,6 @@ jobs:
     if: always() && needs.consolidation.result == 'success'
     permissions:
       contents: read
-      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -131,18 +130,19 @@ jobs:
           name: reference-image-review
           path: reference_images_site/review/index.html
           archive: false
-      - name: Post reference images status linking to the review page
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      # The commit status is posted by refimage-status.yml (workflow_run), because
+      # fork PRs only get a read-only token here and cannot write statuses.
+      - name: Save status data for the chained status workflow
         env:
-          GH_TOKEN: ${{ github.token }}
-          SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           STATE: ${{ steps.build.outputs.state }}
           N_CHANGED: ${{ steps.build.outputs.n_changed }}
           N_APPROVED: ${{ steps.build.outputs.n_approved }}
-          URL: ${{ steps.upload.outputs.artifact-url }}
-        run: |
-          gh api "repos/${{ github.repository }}/statuses/$SHA" \
-            -f state="$STATE" \
-            -f context="reference images" \
-            -f target_url="$URL" \
-            -f description="$N_APPROVED/$N_CHANGED new/changed images approved via manifest"
+          REVIEW_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        run: >
+          printf '{"state":"%s","n_changed":%s,"n_approved":%s,"review_artifact_id":%s}\n'
+          "$STATE" "$N_CHANGED" "$N_APPROVED" "$REVIEW_ARTIFACT_ID" > refimage_status.json
+      - name: Upload status data
+        uses: actions/upload-artifact@v7
+        with:
+          name: refimage_status
+          path: refimage_status.json

--- a/.github/workflows/refimage-status.yml
+++ b/.github/workflows/refimage-status.yml
@@ -1,0 +1,58 @@
+name: Post reference image status
+
+# Runs in the base repository's context when a CI run completes, so it can post
+# commit statuses even for fork PRs, whose own CI token is read-only.
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  statuses: write
+  actions: read
+
+jobs:
+  post-status:
+    name: Post status linking to the review page
+    runs-on: ubuntu-latest
+    if: contains(fromJSON('["pull_request", "merge_group"]'), github.event.workflow_run.event)
+    steps:
+      - name: Locate status data artifact in the CI run
+        id: locate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts?per_page=100" > artifacts.json
+          echo "status_id=$(jq -r '[.artifacts[] | select(.name == "refimage_status") | .id] | first // ""' artifacts.json)" >> "$GITHUB_OUTPUT"
+      - name: Post status
+        if: steps.locate.outputs.status_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/artifacts/${{ steps.locate.outputs.status_id }}/zip" > refimage_status.zip
+          unzip refimage_status.zip
+
+          # The artifact was produced by the (possibly fork-controlled) CI run,
+          # so validate its contents before using them.
+          state=$(jq -r '.state' refimage_status.json)
+          n_changed=$(jq -r '.n_changed' refimage_status.json)
+          n_approved=$(jq -r '.n_approved' refimage_status.json)
+          review_artifact_id=$(jq -r '.review_artifact_id' refimage_status.json)
+          if ! [[ "$state" =~ ^(success|failure)$ && "$n_changed" =~ ^[0-9]+$ && "$n_approved" =~ ^[0-9]+$ && "$review_artifact_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid status data: state=$state n_changed=$n_changed n_approved=$n_approved review_artifact_id=$review_artifact_id"
+            exit 1
+          fi
+
+          if [ "$n_changed" -eq 0 ]; then
+            description="No image changes, view rendered images under Details"
+          else
+            description="$n_approved/$n_changed new/changed images approved, view them under Details"
+          fi
+
+          gh api "repos/${{ github.repository }}/statuses/$SHA" \
+            -f state="$state" \
+            -f context="reference images" \
+            -f target_url="$RUN_URL/artifacts/$review_artifact_id" \
+            -f description="$description"


### PR DESCRIPTION
Follow-up to #5721: the "reference images" status is posted from the review-page job, which doesn't work for fork PRs since their token is read-only, and without the status the review page artifact is annoying to find. The status is now posted by a separate workflow chained via `workflow_run`, which runs in the base repo's context with a write-capable token once the CI run completes (so the status appears a bit later than before, since there is no per-job trigger).

The review-page job passes state, counts and the review page's artifact id along in a small `refimage_status` artifact. The id is passed through instead of looking the review page up by name because `upload-artifact` with `archive: false` registers the artifact under its file name (`index.html`), not the `name:` input. Fork PRs control the artifact contents, so the chained workflow validates every field before use and never checks out PR code. A fork could still upload a forged "success", but that only greenwashes the informational status; promotion into the release reads the trusted push/merge-queue runs.

The new workflow only triggers once it exists on master, so it can't be seen working on this PR. I dry-ran its steps locally against run 30587680909: artifact lookup, zip download, validation (including rejecting injected content), and the constructed target_url exactly matches what the old mechanism posted for that run.
