### PR TITLE
Keep Resampler/Pyramid resampling in Float32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed plots in `Axis3` not clipping in the correct place when changing aspect due to plot `clip_planes` not getting updated [#5723](https://github.com/MakieOrg/Makie.jl/pull/5723)
 - Fixed `surface` normals sometimes being `NaN` in GLMakie (when vertices collapse to single point on the edge of a surface) [#5725](https://github.com/MakieOrg/Makie.jl/pull/5725)
 - Fixed specialized `args_preferred_axis` methods getting skipped by less specialized Makie defaults [#5722](https://github.com/MakieOrg/Makie.jl/pull/5722)
-- Fixed `Resampler(Pyramid(data))` resampling to `Float64`/`RGB{Float64}` instead of `Float32`/`RGB{Float32}`, which doubled the size of every resampled image, and stopped `Resampler` from allocating a full throwaway copy of its input just to derive an element type (halves peak allocation for non-`Float32` input) [#5727](https://github.com/MakieOrg/Makie.jl/pull/5727)
+- Fixed `Resampler(Pyramid(data))` resampling to `Float64`/`RGB{Float64}` instead of `Float32`/`RGB{Float32}`, which doubled the size of every resampled image, and stopped `Resampler` from allocating a full throwaway copy of its input just to derive an element type (halves peak allocation for non-`Float32` input) [#5728](https://github.com/MakieOrg/Makie.jl/pull/5728)
 
 ## [0.24.13] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed plots in `Axis3` not clipping in the correct place when changing aspect due to plot `clip_planes` not getting updated [#5723](https://github.com/MakieOrg/Makie.jl/pull/5723)
 - Fixed `surface` normals sometimes being `NaN` in GLMakie (when vertices collapse to single point on the edge of a surface) [#5725](https://github.com/MakieOrg/Makie.jl/pull/5725)
 - Fixed specialized `args_preferred_axis` methods getting skipped by less specialized Makie defaults [#5722](https://github.com/MakieOrg/Makie.jl/pull/5722)
+- Fixed `Resampler(Pyramid(data))` resampling to `Float64`/`RGB{Float64}` instead of `Float32`/`RGB{Float32}`, which doubled the size of every resampled image, and stopped `Resampler` from allocating a full throwaway copy of its input just to derive an element type (halves peak allocation for non-`Float32` input) [#5727](https://github.com/MakieOrg/Makie.jl/pull/5727)
 
 ## [0.24.13] - 2026-07-02
 

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -577,8 +577,10 @@ function Resampler(
     if applicable(data, lr, lr)
         return Resampler(data, res, update_while_button_pressed, lowres_background)
     else
-        dataf32 = el32convert(data)
-        ET = eltype(dataf32)
+        # Only the element type of `el32convert(data)` is needed, so convert an empty
+        # view instead of the whole array - `data` is expected to be huge and the
+        # converted copy would be thrown away immediately.
+        ET = eltype(el32convert(view(data, 1:0)))
         # Interpolations happily converts to Float64 here, but that's not desirable for e.g. RGB{N0f8}, or Float32 data
         # Since we expect these arrays to be huge, this is no laughing matter ;)
         interp = Interpolations.interpolate(eltype(ET), ET, data, Interpolations.BSpline(method))
@@ -757,14 +759,18 @@ struct Pyramid{T, M <: AbstractMatrix{T}} <: AbstractMatrix{T}
 end
 
 function Pyramid(data::AbstractMatrix; min_resolution = 1024, mode = Interpolations.Linear())
-    ranges(d) = (LinRange(1, size(data, 1), size(d, 1)), LinRange(1, size(data, 2), size(d, 2)))
     ET = ImageBase.restrict_eltype(first(data))
+    # The knots have to use the same scalar type as the interpolation weights (WT).
+    # `LinRange(1, ::Int, ::Int)` would give us Float64 knots, which promotes every
+    # sampled image back to Float64 and doubles its size - see the note in `Resampler`.
+    WT = eltype(ET)
+    ranges(d) = (LinRange{WT}(1, size(data, 1), size(d, 1)), LinRange{WT}(1, size(data, 2), size(d, 2)))
     resized = convert(Matrix{ET}, data)
-    pyramid = [Interpolations.interpolate(eltype(ET), ET, ranges(resized), resized, Interpolations.Gridded(mode))]
+    pyramid = [Interpolations.interpolate(WT, ET, ranges(resized), resized, Interpolations.Gridded(mode))]
     while any(x -> x > min_resolution, size(resized))
         resized = ImageBase.restrict(resized)
         interp = Interpolations.interpolate(
-            eltype(ET), ET, ranges(resized), resized,
+            WT, ET, ranges(resized), resized,
             Interpolations.Gridded(mode)
         )
         push!(pyramid, interp)

--- a/Makie/test/plots/datashader.jl
+++ b/Makie/test/plots/datashader.jl
@@ -1,0 +1,51 @@
+@testset "Resampler" begin
+    # Note: `Pyramid` is shadowed by `GeometryBasics.Pyramid` in the test scope,
+    # so the datashader one always has to be qualified.
+
+    # sample through the same path a HeatmapShader uses when it redraws
+    function resample(resampler, n, sz)
+        x = Makie.EndPoints{Float32}(0.0f0, Float32(sz))
+        return Makie.resample_image(x, x, resampler.data, (n, n), Rect2f(0, 0, sz, sz))[3]
+    end
+
+    data32 = [Float32(sin(x) * cos(y)) for x in LinRange(0, 10, 256), y in LinRange(0, 10, 256)]
+    data64 = Float64.(data32)
+    rgb8 = [Makie.RGB{Makie.N0f8}(x / 256, y / 256, 0.5) for x in 1:256, y in 1:256]
+
+    @testset "resampling keeps the element type narrow" begin
+        # Resampling must not widen to Float64 - these images are expected to be huge,
+        # so a promotion doubles the size of every buffer we hand to the backend.
+        @test eltype(resample(Makie.Resampler(data32), 64, 256)) == Float32
+        @test eltype(resample(Makie.Resampler(data64), 64, 256)) == Float32
+        @test eltype(resample(Makie.Resampler(rgb8), 64, 256)) == Makie.RGB{Float32}
+
+        for data in (data32, rgb8)
+            pyramid = Makie.Pyramid(data; min_resolution = 64)
+            @test length(pyramid.data) > 1  # more than one level, so restriction is covered
+            @test eltype(resample(Makie.Resampler(pyramid), 64, 256)) ==
+                (data === data32 ? Float32 : Makie.RGB{Float32})
+        end
+    end
+
+    @testset "Pyramid values are unaffected by the knot type" begin
+        pyramid = Makie.Pyramid(data32; min_resolution = 64)
+        xs = LinRange(1.0f0, 256.0f0, 51)
+        got = pyramid(xs, xs)
+        @test eltype(got) == Float32
+        # the finest level is a plain bilinear interpolation of `data32`
+        finest = Makie.Interpolations.interpolate(
+            Float64, Float64, (LinRange(1, 256, 256), LinRange(1, 256, 256)),
+            data64, Makie.Interpolations.Gridded(Makie.Interpolations.Linear())
+        )
+        @test pyramid.data[1](xs, xs) ≈ finest(Float64.(xs), Float64.(xs)) rtol = 1.0f-6
+    end
+
+    @testset "Resampler does not copy the whole array to get an element type" begin
+        big = rand(Float64, 1024, 1024)
+        Makie.Resampler(big)  # warm up
+        allocated = @allocated Makie.Resampler(big)
+        # `interpolate` builds and keeps one Float32 coefficient array; deriving the
+        # element type must not allocate a second, throwaway copy on top of that.
+        @test allocated < 1.5 * (sizeof(big) ÷ 2)
+    end
+end

--- a/Makie/test/runtests.jl
+++ b/Makie/test/runtests.jl
@@ -46,6 +46,7 @@ end
         include("plots/hist.jl")
         include("plots/poly.jl")
         include("plots/contourf.jl")
+        include("plots/datashader.jl")
         include("plots/tricontour.jl")
         include("plots/voronoiplot.jl")
     end


### PR DESCRIPTION
`Pyramid` built its knots with `LinRange(1, ::Int, ::Int)`, which is `Float64`. Interpolations promotes on evaluation, so sampling a Pyramid-backed `Resampler` returned `Float64`/`RGB{Float64}` even though the coefficients are `Float32` and `resample_image` samples with `Float32` ranges — doubling the size of every resampled image, which is what the note in `Resampler` warns about.

This also made the compute graph inconsistent with itself: `plot!(::HeatmapShader)` declares

```julia
T = eltype(p.image[].data) <: Colors.Colorant ? RGB{Float32} : Float32
```

and uses `T` for the `:limit_image` node's `init` and the low-res background placeholder, while the actual resampled image arrived as `Float64`. Both sides now agree.

Fix: build the knots with the same scalar type that is already passed as the interpolation weight type.

Also drops a wasted allocation next door — `Resampler` called `el32convert(data)` only to read the element type off the result, materializing a full converted copy of an array it assumes is huge and then discarding it. It now converts an empty view instead.

### Verification

- Values unchanged: max `|old - new|` = `1.3e-7`, i.e. `Float32` rounding only.
- Renders pixel-identical: 0 differing pixels across 4 images (1,080,000 px each), covering `Resampler` and `Pyramid` for `Float32` and `RGB{N0f8}`.
- `Resampler(::Matrix{Float64})` on a 128 MiB input: 134,217,888 -> 67,108,944 bytes allocated (two `Float32` copies down to the one coefficient array `interpolate` legitimately keeps).
- New `Makie/test/plots/datashader.jl` (10 tests) passes with the fix; 4 of them fail without it.

`Pyramid` had no reference-image coverage, so CI would not have caught this — hence the unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)