### PR TITLE
fix Axis3 title not working with rich text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed plots in `Axis3` not clipping in the correct place when changing aspect due to plot `clip_planes` not getting updated [#5723](https://github.com/MakieOrg/Makie.jl/pull/5723)
 - Fixed `surface` normals sometimes being `NaN` in GLMakie (when vertices collapse to single point on the edge of a surface) [#5725](https://github.com/MakieOrg/Makie.jl/pull/5725)
 - Fixed specialized `args_preferred_axis` methods getting skipped by less specialized Makie defaults [#5722](https://github.com/MakieOrg/Makie.jl/pull/5722)
+- Fixed `Axis3(..., title = rich(...))` not working [#5729](https://github.com/MakieOrg/Makie.jl/pull/5729)
 
 ## [0.24.13] - 2026-07-02
 

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -59,10 +59,10 @@ function register_arguments!(::Type{Text}, attr::ComputeGraph, user_kw, input_ar
     register_computation!(attr, inputs, [:_positions, :input_text]) do inputs, changed, cached
         a_pos, a_text, args... = values(inputs)
         # Note: Could add RichText
-        if args isa Tuple{<:AbstractString}
+        if args isa Tuple{<:Union{AbstractString, RichText}}
             # position data will always be wrapped in a Vector, so strings should too
             return ((a_pos,), Ref{Any}([args[1]]))
-        elseif args isa Tuple{<:AbstractVector{<:AbstractString}}
+        elseif args isa Tuple{<:AbstractVector{<:Union{AbstractString, RichText}}}
             return ((a_pos,), Ref{Any}(args[1]))
         elseif args isa Tuple{<:AbstractVector{<:Tuple{<:Any, <:VecTypes}}}
             # [(text, pos), ...] argument

--- a/Makie/src/makielayout/blocks/axis3d.jl
+++ b/Makie/src/makielayout/blocks/axis3d.jl
@@ -186,8 +186,8 @@ function initialize_block!(ax::Axis3)
     end
 
     titlet = text!(
-        blockscene, ax.title,
-        position = titlepos,
+        blockscene, titlepos,
+        text = ax.title,
         visible = ax.titlevisible,
         fontsize = ax.titlesize,
         align = titlealignnode,


### PR DESCRIPTION
# Description

Fixes #3983 in two ways:
1. fixes `text` not recognizing rich text as a text type when processing it as an argument
2. fixes Axis3 passing it as an argument (which is unofficially deprecated)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
