### PR TITLE
Fix refimage review page for WGLMakie-only images and improve mobile layout

### DIFF
--- a/ReferenceUpdater/src/JSHelper.bundled.js
+++ b/ReferenceUpdater/src/JSHelper.bundled.js
@@ -14,24 +14,34 @@ function setupImageCycleButton(buttonContainer, mediaRecorded, mediaReference, m
     const button = buttonContainer.querySelector('button');
     const cycle_checkbox = document.querySelectorAll('.cycle-checkbox')[0];
     if (!button) return;
-    button.addEventListener('click', ()=>{
+    const media = [
+        [
+            mediaRecorded,
+            'recorded'
+        ],
+        [
+            mediaReference,
+            'reference'
+        ],
+        [
+            mediaGlmakie,
+            'glmakie'
+        ]
+    ].filter(([el])=>el);
+    const cycle = ()=>{
         const getZ = (el)=>parseInt(el.style.zIndex || window.getComputedStyle(el).zIndex || '0');
-        if (getZ(mediaRecorded) > getZ(mediaReference) && getZ(mediaRecorded) > getZ(mediaGlmakie)) {
-            mediaRecorded.style.zIndex = '1';
-            mediaReference.style.zIndex = '3';
-            mediaGlmakie.style.zIndex = '2';
-            button.textContent = 'Showing: reference';
-        } else if (cycle_checkbox.checked && getZ(mediaReference) > getZ(mediaRecorded) && getZ(mediaReference) > getZ(mediaGlmakie)) {
-            mediaRecorded.style.zIndex = '2';
-            mediaReference.style.zIndex = '1';
-            mediaGlmakie.style.zIndex = '3';
-            button.textContent = 'Showing: glmakie';
-        } else {
-            mediaRecorded.style.zIndex = '3';
-            mediaReference.style.zIndex = '2';
-            mediaGlmakie.style.zIndex = '1';
-            button.textContent = 'Showing: recorded';
-        }
+        const active = media.filter(([, label])=>label !== 'glmakie' || cycle_checkbox.checked);
+        const current = media.reduce((a, b)=>getZ(b[0]) > getZ(a[0]) ? b : a);
+        const [nextEl, nextLabel] = active[(active.indexOf(current) + 1) % active.length];
+        media.forEach(([el])=>{
+            el.style.zIndex = '1';
+        });
+        nextEl.style.zIndex = '3';
+        button.textContent = 'Showing: ' + nextLabel;
+    };
+    button.addEventListener('click', cycle);
+    media.forEach(([el])=>{
+        if (el.tagName === 'IMG') el.addEventListener('click', cycle);
     });
 }
 function sortByBackend(grid, backend) {
@@ -89,7 +99,7 @@ function compareToGLMakie(grid, selectedBackend) {
                 grid.appendChild(card);
             });
         });
-        grid.style.gridTemplateColumns = '1fr 1fr 1fr';
+        grid.style.gridTemplateColumns = '';
         return;
     }
     const groups = new Map();

--- a/ReferenceUpdater/src/JSHelper.js
+++ b/ReferenceUpdater/src/JSHelper.js
@@ -17,12 +17,12 @@ export function filterByScore(threshold) {
 }
 
 /**
- * Setup image cycling button for a card
+ * Setup image cycling for a card, triggered by the button or by clicking the image
  * Cycles through: recorded -> reference -> glmakie -> recorded
  * @param {HTMLElement} buttonContainer - Container with the button and images
  * @param {HTMLElement} mediaRecorded - Recorded image element
  * @param {HTMLElement} mediaReference - Reference image element
- * @param {HTMLElement} mediaGlmakie - GLMakie reference image element
+ * @param {HTMLElement|null} mediaGlmakie - GLMakie reference image element, null if it doesn't exist
  */
 export function setupImageCycleButton(buttonContainer, mediaRecorded, mediaReference, mediaGlmakie) {
     const button = buttonContainer.querySelector('button');
@@ -30,35 +30,27 @@ export function setupImageCycleButton(buttonContainer, mediaRecorded, mediaRefer
 
     if (!button) return;
 
-    button.addEventListener('click', () => {
-        // Get current z-index to determine state
-        const getZ = (el) => parseInt(el.style.zIndex || window.getComputedStyle(el).zIndex || '0');
+    const media = [
+        [mediaRecorded, 'recorded'],
+        [mediaReference, 'reference'],
+        [mediaGlmakie, 'glmakie'],
+    ].filter(([el]) => el);
 
-        // Cycle: recorded -> reference -> glmakie -> recorded
-        if (getZ(mediaRecorded) > getZ(mediaReference) && getZ(mediaRecorded) > getZ(mediaGlmakie)) {
-            // Currently showing recorded, switch to reference
-            mediaRecorded.style.zIndex = '1';
-            mediaReference.style.zIndex = '3';
-            mediaGlmakie.style.zIndex = '2';
-            button.textContent = 'Showing: reference';
-        } else if (
-                cycle_checkbox.checked &&
-                getZ(mediaReference) > getZ(mediaRecorded) &&
-                getZ(mediaReference) > getZ(mediaGlmakie)
-            )
-        {
-            // Currently showing reference, switch to glmakie
-            mediaRecorded.style.zIndex = '2';
-            mediaReference.style.zIndex = '1';
-            mediaGlmakie.style.zIndex = '3';
-            button.textContent = 'Showing: glmakie';
-        } else {
-            // Currently showing glmakie, switch to recorded
-            mediaRecorded.style.zIndex = '3';
-            mediaReference.style.zIndex = '2';
-            mediaGlmakie.style.zIndex = '1';
-            button.textContent = 'Showing: recorded';
-        }
+    const cycle = () => {
+        const getZ = (el) => parseInt(el.style.zIndex || window.getComputedStyle(el).zIndex || '0');
+        const active = media.filter(([, label]) => label !== 'glmakie' || cycle_checkbox.checked);
+        const current = media.reduce((a, b) => getZ(b[0]) > getZ(a[0]) ? b : a);
+        // indexOf is -1 if glmakie is showing but its checkbox was just unchecked, wrapping to recorded
+        const [nextEl, nextLabel] = active[(active.indexOf(current) + 1) % active.length];
+        media.forEach(([el]) => { el.style.zIndex = '1'; });
+        nextEl.style.zIndex = '3';
+        button.textContent = 'Showing: ' + nextLabel;
+    };
+
+    button.addEventListener('click', cycle);
+    // only images cycle on click, videos need their clicks for the playback controls
+    media.forEach(([el]) => {
+        if (el.tagName === 'IMG') el.addEventListener('click', cycle);
     });
 }
 
@@ -144,7 +136,7 @@ export function compareToGLMakie(grid, selectedBackend) {
             });
         });
 
-        grid.style.gridTemplateColumns = '1fr 1fr 1fr';
+        grid.style.gridTemplateColumns = '';
         return;
     }
 

--- a/ReferenceUpdater/src/bonito-app.jl
+++ b/ReferenceUpdater/src/bonito-app.jl
@@ -357,6 +357,22 @@ const REFIMG_STYLES = Styles(
         "height" => "auto",
         "grid-area" => "1 / 1"
     ),
+    CSS(
+        ".media-container .media-img",
+        "cursor" => "pointer"
+    ),
+    # Card grid - one row per image, one column per backend
+    CSS(
+        ".card-grid",
+        "display" => "grid",
+        "grid-template-columns" => "1fr 1fr 1fr",
+        "gap" => "10px"
+    ),
+    CSS(
+        "@media (max-width: 1000px)",
+        CSS(".card-grid", "grid-template-columns" => "1fr"),
+        CSS(".card-base", "min-width" => "0")
+    ),
     # Main container
     CSS(
         ".main-container",
@@ -457,6 +473,8 @@ function media_element(img_name, local_path, additional_classes = ""; kw...)
     end
     return dom
 end
+
+card_grid(cards) = DOM.div(cards, class = "card-grid")
 
 
 """
@@ -595,15 +613,15 @@ function BackendCard(
         )
     end
 
-    # Create all three media paths
     recorded_path = Bonito.Asset(normpath(joinpath(root_path, "recorded", backend, img_name)))
     reference_path = Bonito.Asset(normpath(joinpath(root_path, "reference", backend, img_name)))
-    glmakie_ref_path = Bonito.Asset(normpath(joinpath(root_path, "reference", "GLMakie", img_name)))
+    # WGLMakie-only tests (e.g. HTML widgets) have no GLMakie reference to cycle to
+    glmakie_ref_file = normpath(joinpath(root_path, "reference", "GLMakie", img_name))
 
-    # Create three media elements (identical CSS and positioning)
     media_recorded = media_element(img_name, recorded_path; style = "z-index: 3")
     media_reference = media_element(img_name, reference_path; style = "z-index: 2")
-    media_glmakie = media_element(img_name, glmakie_ref_path; style = "z-index: 1")
+    media_glmakie = isfile(glmakie_ref_file) ?
+        media_element(img_name, Bonito.Asset(glmakie_ref_file); style = "z-index: 1") : nothing
 
     # Button container (for JS to find and update)
     path_button = Bonito.Button("Showing: recorded", style = BUTTON_STYLE)
@@ -615,9 +633,7 @@ function BackendCard(
 
     # Media container
     media_container = DOM.div(
-        media_recorded,
-        media_reference,
-        media_glmakie,
+        filter(!isnothing, [media_recorded, media_reference, media_glmakie]),
         class = "media-container"
     )
 
@@ -772,9 +788,9 @@ function review_content(root_path, backends, score_thresholds; display_threshold
     isempty(updated_cards) || push!(
         sections, DOM.div(
             DOM.h2("Changed images", class = "section-header"),
-            DOM.div("Each row shows one image per backend. Use the button on a card to toggle between the recorded image and its current reference.", class = "section-description"),
+            DOM.div("Each row shows one image per backend. Click an image or use the button on its card to toggle between the recorded image and its current reference.", class = "section-description"),
             cycle_controls,
-            Grid(updated_cards, columns = "1fr 1fr 1fr"),
+            card_grid(updated_cards),
             class = "section",
         )
     )
@@ -782,7 +798,7 @@ function review_content(root_path, backends, score_thresholds; display_threshold
         sections, DOM.div(
             DOM.h2("New images without references", class = "section-header"),
             DOM.div("These images have no current reference and are added when the PR merges.", class = "section-description"),
-            Grid(new_cards, columns = "1fr 1fr 1fr"),
+            card_grid(new_cards),
             class = "section",
         )
     )
@@ -790,7 +806,7 @@ function review_content(root_path, backends, score_thresholds; display_threshold
         sections, DOM.div(
             DOM.h2("Reference images without recordings", class = "section-header"),
             DOM.div("A reference image exists but no image was recorded (a test was deleted or renamed).", class = "section-description"),
-            Grid(missing_cards, columns = "1fr 1fr 1fr"),
+            card_grid(missing_cards),
             class = "section",
         )
     )
@@ -961,7 +977,7 @@ function create_app_content(session::Session, root_path::String)
     end
 
     # Main grid
-    main_grid = Grid(updated_cards, columns = "1fr 1fr 1fr")
+    main_grid = card_grid(updated_cards)
 
     # Setup JS filtering
     onjs(
@@ -982,7 +998,7 @@ function create_app_content(session::Session, root_path::String)
     )
 
     toggle_all_new = Bonito.Button("Toggle all", style = BUTTON_STYLE)
-    new_grid = Grid(new_cards, columns = "1fr 1fr 1fr")
+    new_grid = card_grid(new_cards)
     onjs(
         session, toggle_all_new.value, js"""
         function(click) {
@@ -992,7 +1008,7 @@ function create_app_content(session::Session, root_path::String)
     )
 
     toggle_all_missing = Bonito.Button("Toggle all", style = BUTTON_STYLE)
-    missing_grid = Grid(missing_cards, columns = "1fr 1fr 1fr")
+    missing_grid = card_grid(missing_cards)
     onjs(
         session, toggle_all_missing.value, js"""
         function(click) {


### PR DESCRIPTION
The self-contained review page of #5717 only showed a Bonito error, `File not found: .../reference/GLMakie/HTML Widgets layout px_per_unit=2.png`. Each card references the GLMakie variant of its image for the comparison cycle, and the static export inlines every referenced asset, so the WGLMakie-only HTML widget tests (which have no GLMakie reference and changed in that PR) crashed the export. Cards now only include the GLMakie image if it exists, and the cycle skips it otherwise.

Two more usability tweaks while I was at it: clicking an image now cycles it as well, not just the button (videos keep their clicks for the playback controls), and the card grids collapse to a single column below 1000px so the page works on a phone, where the fixed three-column layout used to overflow.

Rendered with synthetic data, desktop and narrow:

<img width="1400" height="1200" alt="desktop layout" src="https://github.com/user-attachments/assets/7c1368ac-091c-493e-8859-7b784839f781">

<img width="500" height="1700" alt="narrow layout" src="https://github.com/user-attachments/assets/bb2991eb-c974-4e1b-8c6f-e03109c5ac85">
