### PR TITLE
Show only actionable entries in the reference image review page

### DIFF
--- a/.github/workflows/_reference-tests.yml
+++ b/.github/workflows/_reference-tests.yml
@@ -50,10 +50,11 @@ jobs:
 
           # Loop through the directories and concatenate the files, and copy recorded folders
           for dir in WGLMakie CairoMakie GLMakie; do
-              # Concatenate scores.tsv, new_files.txt and missing_files.txt
+              # Concatenate scores.tsv, new_files.txt, missing_files.txt and failed_recordings.txt
               cat "${baseDir}/${dir}/scores.tsv" >> "./ReferenceImagesCombined/scores.tsv"
               cat "${baseDir}/${dir}/new_files.txt" >> "./ReferenceImagesCombined/new_files.txt"
               cat "${baseDir}/${dir}/missing_files.txt" >> "./ReferenceImagesCombined/missing_files.txt"
+              cat "${baseDir}/${dir}/failed_recordings.txt" >> "./ReferenceImagesCombined/failed_recordings.txt"
 
               # Copy recorded folder
               mkdir -p "./ReferenceImagesCombined/recorded/${dir}/"

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -213,8 +213,8 @@ functions = [:volume, :volume!, :uv_mesh]
 @testset "refimages" begin
     CairoMakie.activate!(type = "png", px_per_unit = 1)
     ReferenceTests.mark_broken_tests(excludes, functions = functions)
-    recorded_files, recording_dir = @include_reference_tests CairoMakie "refimages.jl" joinpath(@__DIR__, "cairo_refimages.jl")
-    missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "CairoMakie")
+    attempted_tests, recording_dir = @include_reference_tests CairoMakie "refimages.jl" joinpath(@__DIR__, "cairo_refimages.jl")
+    missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "CairoMakie"; attempted_tests)
     ReferenceTests.test_comparison(scores; threshold = 0.05, exempt)
 end
 

--- a/GLMakie/test/runtests.jl
+++ b/GLMakie/test/runtests.jl
@@ -48,8 +48,8 @@ GLMakie.activate!(framerate = 1.0, scalefactor = 1.0)
     @testset "Reference Tests" begin
         @testset "refimages" begin
             ReferenceTests.mark_broken_tests()
-            recorded_files, recording_dir = @include_reference_tests GLMakie "refimages.jl" joinpath(@__DIR__, "glmakie_refimages.jl")
-            missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "GLMakie")
+            attempted_tests, recording_dir = @include_reference_tests GLMakie "refimages.jl" joinpath(@__DIR__, "glmakie_refimages.jl")
+            missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "GLMakie"; attempted_tests)
             ReferenceTests.test_comparison(scores; threshold = 0.05, exempt)
         end
 

--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -43,6 +43,9 @@ macro reference_test(name, code)
                 if $title in $REGISTERED_TESTS
                     error("title must be unique. Duplicate title: $($title)")
                 end
+                # registered before running so a test that errors still counts as attempted,
+                # which is what tells a failed recording apart from a deleted test
+                push!($REGISTERED_TESTS, $title)
                 println("running $(lpad(COUNTER[] += 1, 3)): $($title)")
                 Makie.set_theme!(;
                     size = (500, 500),
@@ -55,7 +58,6 @@ macro reference_test(name, code)
                     $(esc(code))
                 end
                 @test save_result(joinpath(RECORDING_DIR[], $title), result)
-                push!($REGISTERED_TESTS, $title)
                 elapsed = round(time() - t1; digits = 5)
                 total = Sys.total_memory()
                 mem = round((total - Sys.free_memory()) / 10^9; digits = 3)
@@ -121,11 +123,11 @@ macro include_reference_tests(backend::Symbol, path, paths...)
                     include(include_path)
                 end
             end
-            recorded_files = collect(ReferenceTests.REGISTERED_TESTS)
+            attempted_tests = collect(ReferenceTests.REGISTERED_TESTS)
             recording_dir = recording_dir
             empty!(ReferenceTests.REGISTERED_TESTS)
             ReferenceTests.COUNTER[] = 0
-            (recorded_files, recording_dir)
+            (attempted_tests, recording_dir)
         end
     )
 end

--- a/ReferenceTests/src/runtests.jl
+++ b/ReferenceTests/src/runtests.jl
@@ -1,4 +1,33 @@
-function record_comparison(base_folder::String, backend::String; record_folder_name = "recorded", tag = last_major_version())
+"""
+    recording_title(relative_path)
+
+Recover the reference test title from a path relative to a `recorded`/`reference` folder,
+i.e. `"<Backend>/<title>.png"` or `"<Backend>/<title>/step-1.png"` for stepper tests.
+"""
+function recording_title(relative_path::String)
+    parts = splitpath(relative_path)
+    return length(parts) > 2 ? parts[2] : first(splitext(parts[end]))
+end
+
+"""
+    split_missing_recordings(attempted_tests, recorded_paths, reference_paths, skipped_paths)
+
+Split the reference images that have no recording into the ones whose test ran but errored
+before saving anything (`failed`, reported by title) and the ones no test produced at all
+(`missing_recordings`, i.e. the test was deleted or renamed).
+"""
+function split_missing_recordings(attempted_tests, recorded_paths, reference_paths, skipped_paths)
+    recorded_titles = Set(recording_title.(recorded_paths))
+    failed = Set(title for title in attempted_tests if !(title in recorded_titles))
+    missing_recordings = setdiff(Set(reference_paths), Set(recorded_paths), Set(skipped_paths))
+    filter!(path -> !(recording_title(path) in failed), missing_recordings)
+    return (; failed = sort!(collect(failed)), missing_recordings = sort!(collect(missing_recordings)))
+end
+
+function record_comparison(
+        base_folder::String, backend::String;
+        attempted_tests = String[], record_folder_name = "recorded", tag = last_major_version()
+    )
     record_folder = joinpath(base_folder, record_folder_name)
     @info "Downloading reference images"
     reference_folder = download_refimages(tag)
@@ -25,6 +54,13 @@ function record_comparison(base_folder::String, backend::String; record_folder_n
         )
     end
 
+    backend_ref_dir = joinpath(reference_folder, backend)
+    reference_paths = mapreduce(vcat, walkdir(backend_ref_dir)) do (root, dirs, files)
+        relpath.(joinpath.(root, files), reference_folder)
+    end
+    skipped = [joinpath(backend, "$name.png") for name in SKIPPED_NAMES]
+    failed, missing_recordings = split_missing_recordings(attempted_tests, testimage_paths, reference_paths, skipped)
+
     open(joinpath(base_folder, "new_files.txt"), "w") do file
         for path in missing_refimages
             path in classified.exempt_new && continue
@@ -32,14 +68,13 @@ function record_comparison(base_folder::String, backend::String; record_folder_n
         end
     end
 
-    open(joinpath(base_folder, "missing_files.txt"), "w") do file
-        backend_ref_dir = joinpath(reference_folder, backend)
-        recorded_paths = mapreduce(vcat, walkdir(backend_ref_dir)) do (root, dirs, files)
-            relpath.(joinpath.(root, files), reference_folder)
+    open(joinpath(base_folder, "failed_recordings.txt"), "w") do file
+        for title in failed
+            println(file, backend, '/', title)
         end
-        skipped = Set([joinpath(backend, "$name.png") for name in SKIPPED_NAMES])
-        missing_recordings = setdiff(Set(recorded_paths), Set(testimage_paths), skipped)
+    end
 
+    open(joinpath(base_folder, "missing_files.txt"), "w") do file
         for path in missing_recordings
             println(file, path)
         end

--- a/ReferenceUpdater/README.md
+++ b/ReferenceUpdater/README.md
@@ -16,7 +16,7 @@ A PR that changes rendering should not upload to the release tarball directly (t
 
 Add entries in one of three ways (none require running the backend tests locally):
 
-- Viewer button: run `ReferenceUpdater.serve_update_page(pr = 1234)`, select the images, and click "Add selection to update manifest".
+- Viewer button: run `ReferenceUpdater.serve_update_page(pr = 1234)`, select the images, and click "Add pin files for selection".
 - Headless (agents): `ReferenceUpdater.add_pr_updates_to_manifest(1234)` picks every image whose score exceeds the threshold plus every new image; pass `select = ["CairoMakie/foo.png", ...]` to choose explicitly. Pins come from the current release tarball, the changed/new classification from the PR's CI artifact.
 - CLI: `reference_updater manifest pr 1234` (or `manifest commit <sha>`).
 

--- a/ReferenceUpdater/src/bonito-app.jl
+++ b/ReferenceUpdater/src/bonito-app.jl
@@ -273,7 +273,7 @@ const REFIMG_STYLES = Styles(
         "margin-bottom" => "4px"
     ),
     CSS(
-        ".manifest-status",
+        ".pin-status",
         "display" => "flex",
         "align-items" => "center",
         "gap" => "4px",
@@ -281,13 +281,26 @@ const REFIMG_STYLES = Styles(
         "font-weight" => "700",
         "margin-bottom" => "6px"
     ),
-    CSS(".manifest-status.covered", "color" => SUCCESS_COLOR),
-    CSS(".manifest-status.uncovered", "color" => WARNING_COLOR),
+    CSS(".pin-status.pinned", "color" => SUCCESS_COLOR),
+    CSS(".pin-status.unpinned", "color" => WARNING_COLOR),
     CSS(
-        ".manifest-check",
+        ".pin-check",
         "accent-color" => SUCCESS_COLOR,
         "transform" => "scale(1.1)",
         "cursor" => "default"
+    ),
+    CSS(
+        ".card-note",
+        "font-size" => "12px",
+        "color" => "#78909C",
+        "margin-bottom" => "6px"
+    ),
+    CSS(
+        ".failed-list",
+        "padding-left" => "24px",
+        "font-family" => "monospace",
+        "font-size" => "13px",
+        "color" => TEXT_DARK
     ),
     # Text field styles
     CSS(
@@ -448,14 +461,39 @@ const UPLOAD_BUTTON_STYLE = Styles(
 # Helper Functions
 # ============================================================================
 
-function manifest_status_dom(covered::Bool)
-    box = covered ?
-        DOM.input(type = "checkbox", checked = true, disabled = true, class = "manifest-check") :
-        DOM.input(type = "checkbox", disabled = true, class = "manifest-check")
+function pin_status_dom(pinned::Bool)
+    box = pinned ?
+        DOM.input(type = "checkbox", checked = true, disabled = true, class = "pin-check") :
+        DOM.input(type = "checkbox", disabled = true, class = "pin-check")
     return DOM.div(
         box,
-        DOM.span(covered ? "in manifest" : "not in manifest — needs adding", class = "manifest-status-text"),
-        class = covered ? "manifest-status covered" : "manifest-status uncovered",
+        DOM.span(pinned ? "pin file present" : "no pin file, needs adding", class = "pin-status-text"),
+        class = pinned ? "pin-status pinned" : "pin-status unpinned",
+    )
+end
+
+comparison_note_dom() = DOM.div("unchanged, shown for comparison", class = "card-note")
+
+"""
+    failed_recordings_section(root_path)
+
+Section listing the tests that errored instead of producing an image, or `nothing` if there
+are none. No images are shown since there is nothing to compare.
+"""
+function failed_recordings_section(root_path)
+    path = joinpath(root_path, "failed_recordings.txt")
+    isfile(path) || return nothing
+    names = sort!(unique(filter(!isempty, strip.(readlines(path)))))
+    isempty(names) && return nothing
+    return DOM.div(
+        DOM.h2("Tests that failed to record", class = "section-header"),
+        DOM.div(
+            "These tests errored, so no image was recorded and no comparison is possible. " *
+                "The stacktrace is in the log of the backend's reference test job.",
+            class = "section-description"
+        ),
+        DOM.ul((DOM.li(name) for name in names), class = "failed-list"),
+        class = "section",
     )
 end
 
@@ -507,7 +545,7 @@ function build_card_grid(img_names, backends, should_include, card_builder)
     return cards
 end
 
-function create_simple_grid_content(root_path, filename, image_folder, backends; extra_paths = String[], review_only::Bool = false, covered_paths = nothing)
+function create_simple_grid_content(root_path, filename, image_folder, backends; extra_paths = String[], review_only::Bool = false, pinned_paths = nothing)
     path = joinpath(root_path, filename)
     files = unique(vcat(isfile(path) ? readlines(path) : String[], collect(extra_paths)))
     filter!(!isempty, files)
@@ -519,11 +557,11 @@ function create_simple_grid_content(root_path, filename, image_folder, backends;
 
     # Card builder for simple cards
     function simple_card_builder(img_name, backend, current_file)
-        # Plain HTML checkbox (no observables); filename + manifest status in review mode
+        # Plain HTML checkbox (no observables); filename + pin status in review mode
         cb = if review_only
             DOM.div(
                 DOM.div(current_file, class = "card-filename"),
-                manifest_status_dom(covered_paths !== nothing && current_file in covered_paths),
+                pin_status_dom(pinned_paths !== nothing && current_file in pinned_paths),
             )
         else
             DOM.div(
@@ -585,9 +623,11 @@ function get_score_class(score::Real, thresholds::Vector{Float64})
 end
 
 """
-    BackendCard(img_name, backend, score, root_path, score_thresholds)
+    BackendCard(img_name, backend, score, root_path, score_thresholds; status)
 
-Create a reference image card for a specific backend.
+Create a reference image card for a specific backend. Passing a `status` DOM element
+replaces the selection checkbox with the file name and that element, which is what the
+read-only review page uses.
 """
 function BackendCard(
         img_name::String,
@@ -595,16 +635,15 @@ function BackendCard(
         score::Float64,
         root_path::String,
         score_thresholds::Vector{Float64};
-        review_only::Bool = false,
-        covered_paths = nothing
+        status = nothing
     )
     current_file = backend * "/" * img_name
 
-    # Checkbox (plain HTML, selection handled in JS); filename + manifest status in review mode
-    cb = if review_only
+    # Checkbox (plain HTML, selection handled in JS); filename + status in review mode
+    cb = if !isnothing(status)
         DOM.div(
             DOM.div(current_file, class = "card-filename"),
-            manifest_status_dom(covered_paths !== nothing && current_file in covered_paths),
+            status,
         )
     else
         DOM.div(
@@ -745,38 +784,41 @@ const JSHelper = Bonito.ES6Module(normpath(joinpath(@__DIR__, "JSHelper.js")))
     review_content(root_path, backends, score_thresholds; display_threshold=0.05)
 
 Static, review-only page content: shows only images that differ (score above
-`display_threshold`) or are listed in the manifest, with a per-card before/after toggle
+`display_threshold`) or have an active pin file, with a per-card before/after toggle
 and no tool controls. Used for the self-contained `export_static` per-PR page.
 """
 function review_content(root_path, backends, score_thresholds; display_threshold = 0.05)
-    manifest_entries = read_manifest(joinpath(root_path, "refimage_updates"))
-    manifest_names = Set(replace(e.path, r"(GLMakie|CairoMakie|WGLMakie)/" => "") for e in manifest_entries)
-    manifest_new = [e.path for e in manifest_entries if e.pin == "new" && isfile(joinpath(root_path, "recorded", e.path))]
+    # inert pin files (their reference changed since the pin was taken) are left out
+    # entirely, since they neither exempt an image nor need any action
+    classified = classify_entries(read_manifest(joinpath(root_path, "refimage_updates")), joinpath(root_path, "reference"))
+    pinned_paths = union(classified.exempt_changed, classified.exempt_new, classified.to_delete)
+    pinned_names = Set(replace(path, r"(GLMakie|CairoMakie|WGLMakie)/" => "") for path in pinned_paths)
+    pinned_new = filter(path -> isfile(joinpath(root_path, "recorded", path)), sort!(collect(classified.exempt_new)))
 
-    classified = classify_entries(manifest_entries, joinpath(root_path, "reference"))
-    covered_paths = union(classified.exempt_changed, classified.exempt_new, classified.to_delete)
-
-    new_cards = create_simple_grid_content(root_path, "new_files.txt", "recorded", backends; extra_paths = manifest_new, review_only = true, covered_paths)
-    missing_cards = create_simple_grid_content(root_path, "missing_files.txt", "reference", backends; review_only = true, covered_paths)
+    new_cards = create_simple_grid_content(root_path, "new_files.txt", "recorded", backends; extra_paths = pinned_new, review_only = true, pinned_paths)
+    missing_cards = create_simple_grid_content(root_path, "missing_files.txt", "reference", backends; review_only = true, pinned_paths)
 
     scores_imgs = readdlm(joinpath(root_path, "scores.tsv"), '\t')
     lookup = Dict(scores_imgs[:, 2] .=> scores_imgs[:, 1])
     imgs_with_score = unique(replace.(string.(scores_imgs[:, 2]), r"(GLMakie|CairoMakie|WGLMakie)/" => ""))
     sort!(imgs_with_score; by = img -> get_score(lookup, backends, img), rev = true)
     filter!(imgs_with_score) do img
-        get_score(lookup, backends, img) > display_threshold || img in manifest_names
+        get_score(lookup, backends, img) > display_threshold || img in pinned_names
     end
 
-    updated_cards = build_card_grid(
-        imgs_with_score, backends,
-        file -> haskey(lookup, file),
-        (img_name, backend, current_file) -> BackendCard(img_name, backend, round(lookup[current_file]; digits = 3), root_path, score_thresholds; review_only = true, covered_paths),
-    )
+    function review_card(img_name, backend, current_file)
+        score = lookup[current_file]
+        state = review_pin_state(current_file, score, pinned_paths; threshold = display_threshold)
+        status = state === :unchanged ? comparison_note_dom() : pin_status_dom(state === :pinned)
+        return BackendCard(img_name, backend, round(score; digits = 3), root_path, score_thresholds; status)
+    end
+
+    updated_cards = build_card_grid(imgs_with_score, backends, file -> haskey(lookup, file), review_card)
 
     cov = approval_coverage(root_path)
     all_approved = cov.n_approved == cov.n_changed
-    summary = "$(cov.n_approved) of $(cov.n_changed) new/changed images approved via manifest" *
-        (all_approved ? "" : " — the rest still need to be added before merge")
+    summary = "$(cov.n_approved) of $(cov.n_changed) new/changed images approved by pin files" *
+        (all_approved ? "" : ", the rest still need to be added before merge")
 
     cycle_controls = DOM.div(
         DOM.input(type = "checkbox", class = "cycle-checkbox"),
@@ -805,12 +847,14 @@ function review_content(root_path, backends, score_thresholds; display_threshold
     isempty(missing_cards) || push!(
         sections, DOM.div(
             DOM.h2("Reference images without recordings", class = "section-header"),
-            DOM.div("A reference image exists but no image was recorded (a test was deleted or renamed).", class = "section-description"),
+            DOM.div("A reference image exists but no image was recorded, so its test was deleted or renamed.", class = "section-description"),
             card_grid(missing_cards),
             class = "section",
         )
     )
-    isempty(sections) && push!(sections, DOM.div("No differing or manifest-listed reference images.", class = "section-description"))
+    failed_section = failed_recordings_section(root_path)
+    isnothing(failed_section) || push!(sections, failed_section)
+    isempty(sections) && push!(sections, DOM.div("No differing or pinned reference images.", class = "section-description"))
 
     header = DOM.div(
         DOM.h1("Reference image review", class = "page-title"),
@@ -886,7 +930,7 @@ function create_app_content(session::Session, root_path::String)
 
     # Upload section
     tag_textfield = Bonito.TextField("$(last_major_version())", class = "textfield-tag")
-    manifest_button = Bonito.Button("Add selection to update manifest", style = UPLOAD_BUTTON_STYLE)
+    manifest_button = Bonito.Button("Add pin files for selection", style = UPLOAD_BUTTON_STYLE)
     upload_button = Bonito.Button("Update reference images directly (maintainers)", style = BUTTON_STYLE)
 
     # Loading overlay
@@ -1074,7 +1118,7 @@ function create_app_content(session::Session, root_path::String)
     update_section = DOM.div(
         DOM.h2("Images to update", class = "section-header"),
         DOM.div(
-            "Select the images to update below, then \"Add selection to update manifest\" to record them in ReferenceTests/refimage_updates/ (they get promoted into the release after the PR merges). \"Update reference images directly\" is the old maintainer path that overwrites the release tarball for the given version immediately. See Julia terminal for progress updates.",
+            "Select the images to update below, then \"Add pin files for selection\" to write one pin file per image into ReferenceTests/refimage_updates/ (they get promoted into the release after the PR merges). \"Update reference images directly\" is the old maintainer path that overwrites the release tarball for the given version immediately. See Julia terminal for progress updates.",
             class = "section-description"
         ),
         DOM.div(
@@ -1153,6 +1197,8 @@ function create_app_content(session::Session, root_path::String)
         class = "section"
     )
 
+    failed_section = something(failed_recordings_section(root_path), DOM.div())
+
     return DOM.div(
         REFIMG_STYLES,
         loading_overlay,
@@ -1161,6 +1207,7 @@ function create_app_content(session::Session, root_path::String)
         glmakie_compare_section,
         new_image_section,
         missing_recordings_section,
+        failed_section,
         main_section,
         class = "main-container"
     )

--- a/ReferenceUpdater/src/manifest.jl
+++ b/ReferenceUpdater/src/manifest.jl
@@ -15,6 +15,18 @@ end
 add_to_manifest(paths, reference_folder; manifest_dir = refimage_manifest_dir()) =
     add_manifest_selection(paths, String[], reference_folder; manifest_dir)
 
+"""
+    review_pin_state(path, score, pinned_paths; threshold = 0.05)
+
+What a reviewed image needs: `:pinned` when an active pin file already covers it,
+`:unpinned` when it differs enough to need one, and `:unchanged` when it is only shown to
+compare against another backend that differs.
+"""
+function review_pin_state(path, score, pinned_paths; threshold = 0.05)
+    path in pinned_paths && return :pinned
+    return score > threshold ? :unpinned : :unchanged
+end
+
 function manifest_candidates(artifact_dir, select; threshold, backends)
     if select isa AbstractVector
         paths = Set(String.(select))

--- a/ReferenceUpdater/test/runtests.jl
+++ b/ReferenceUpdater/test/runtests.jl
@@ -111,6 +111,14 @@ end
     @test result.missing_recordings == [joinpath("GLMakie", "deleted.png")]
 end
 
+@testset "review_pin_state" begin
+    pinned = Set(["CairoMakie/pinned.png"])
+    @test review_pin_state("CairoMakie/pinned.png", 0.9, pinned; threshold = 0.05) == :pinned
+    @test review_pin_state("CairoMakie/pinned.png", 0.0, pinned; threshold = 0.05) == :pinned
+    @test review_pin_state("GLMakie/changed.png", 0.9, pinned; threshold = 0.05) == :unpinned
+    @test review_pin_state("GLMakie/same.png", 0.0, pinned; threshold = 0.05) == :unchanged
+end
+
 @testset "approval_coverage" begin
     mktempdir() do dir
         refdir = make_reference_tree(

--- a/ReferenceUpdater/test/runtests.jl
+++ b/ReferenceUpdater/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 
 include(joinpath(@__DIR__, "..", "..", "ReferenceTests", "src", "refimage_manifest.jl"))
+include(joinpath(@__DIR__, "..", "..", "ReferenceTests", "src", "runtests.jl"))
 include(joinpath(@__DIR__, "..", "src", "manifest.jl"))
 
 function make_reference_tree(dir, files)
@@ -87,6 +88,27 @@ end
         explicit = manifest_candidates(dir, ["CairoMakie/x.png"]; threshold = 0.05, backends = ("CairoMakie",))
         @test explicit == ["CairoMakie/x.png"]
     end
+end
+
+@testset "recording_title" begin
+    @test recording_title(joinpath("GLMakie", "Standard deviation band.png")) == "Standard deviation band"
+    @test recording_title(joinpath("WGLMakie", "Menu search", "step-1.png")) == "Menu search"
+    @test recording_title(joinpath("CairoMakie", "Record Video.mp4")) == "Record Video"
+end
+
+@testset "split_missing_recordings" begin
+    attempted = ["errored", "recorded", "stepper"]
+    recorded = [joinpath("GLMakie", "recorded.png"), joinpath("GLMakie", "stepper", "step-1.png")]
+    reference = [
+        joinpath("GLMakie", "recorded.png"), joinpath("GLMakie", "stepper", "step-1.png"),
+        joinpath("GLMakie", "errored.png"), joinpath("GLMakie", "deleted.png"),
+        joinpath("GLMakie", "excluded.png"),
+    ]
+    skipped = [joinpath("GLMakie", "excluded.png")]
+
+    result = split_missing_recordings(attempted, recorded, reference, skipped)
+    @test result.failed == ["errored"]
+    @test result.missing_recordings == [joinpath("GLMakie", "deleted.png")]
 end
 
 @testset "approval_coverage" begin

--- a/ReferenceUpdater/test/runtests.jl
+++ b/ReferenceUpdater/test/runtests.jl
@@ -97,17 +97,19 @@ end
 end
 
 @testset "split_missing_recordings" begin
-    attempted = ["errored", "recorded", "stepper"]
+    attempted = ["errored", "errored stepper", "recorded", "stepper"]
     recorded = [joinpath("GLMakie", "recorded.png"), joinpath("GLMakie", "stepper", "step-1.png")]
     reference = [
         joinpath("GLMakie", "recorded.png"), joinpath("GLMakie", "stepper", "step-1.png"),
         joinpath("GLMakie", "errored.png"), joinpath("GLMakie", "deleted.png"),
         joinpath("GLMakie", "excluded.png"),
+        joinpath("GLMakie", "errored stepper", "step-1.png"),
+        joinpath("GLMakie", "errored stepper", "step-2.png"),
     ]
     skipped = [joinpath("GLMakie", "excluded.png")]
 
     result = split_missing_recordings(attempted, recorded, reference, skipped)
-    @test result.failed == ["errored"]
+    @test result.failed == ["errored", "errored stepper"]
     @test result.missing_recordings == [joinpath("GLMakie", "deleted.png")]
 end
 

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -51,8 +51,8 @@ edisplay = Bonito.use_electron_display(devtools = true)
 
     @testset "refimages" begin
         ReferenceTests.mark_broken_tests(excludes)
-        recorded_files, recording_dir = @include_reference_tests WGLMakie "refimages.jl" joinpath(@__DIR__, "html_widgets_refimages.jl")
-        missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "WGLMakie")
+        attempted_tests, recording_dir = @include_reference_tests WGLMakie "refimages.jl" joinpath(@__DIR__, "html_widgets_refimages.jl")
+        missing_images, scores, exempt = ReferenceTests.record_comparison(recording_dir, "WGLMakie"; attempted_tests)
         ReferenceTests.test_comparison(scores; threshold = 0.05, exempt)
     end
 

--- a/reference_images_site/build_review.jl
+++ b/reference_images_site/build_review.jl
@@ -13,6 +13,14 @@ mkpath(build_dir)
 
 backends = ["GLMakie", "CairoMakie", "WGLMakie"]
 thresholds = [0.05, 0.03, 0.01]
+
+inert = ReferenceUpdater.classify_entries(
+    ReferenceUpdater.read_manifest(joinpath(root_path, "refimage_updates")),
+    joinpath(root_path, "reference")
+).inert
+isempty(inert) || @info "Ignoring $(length(inert)) inert pin file(s) (their reference changed since the pin was taken):\n" *
+    join(("  " * e.path for e in inert), '\n')
+
 app = Bonito.App(_ -> ReferenceUpdater.review_content(root_path, backends, thresholds))
 Bonito.export_static(joinpath(build_dir, "index.html"), app)
 @info "Self-contained review page written to $build_dir"


### PR DESCRIPTION
The review page showed entries that need no action and mislabelled some of the ones it did show. On #5727 for example, `menus.png` sat in the changed section for all three backends with score 0 and "not in manifest — needs adding", even though recording and reference are byte-identical there.

Those cards came from pin files that went inert because the reference they pinned had already been promoted. Inert pins exempt nothing and need no action, so the page leaves them out now and only logs them (the reference test jobs already warn about them too).

A card whose own score is below the threshold is only in its row because some other backend differs, so instead of asking for a pin file it now says it is shown for comparison.

A test that errors records nothing, and that used to land in "Reference images without recordings", right below a description claiming the test was deleted or renamed. Test titles are now registered before the test body runs, so a title without a recording is known to have failed and goes to its own `failed_recordings.txt`, which the page lists by name. No images there, since there is nothing to compare. WGLMakie's "Standard deviation band" on #5727 is the case that prompted this.

Also dropped "manifest" from the page, given there is no manifest file: cards say "pin file present" or "no pin file, needs adding", and the button in the interactive tool is now "Add pin files for selection".

Rebuilding the page from #5727's artifact gives what you'd want to see: no `menus.png` cards, CairoMakie's "Standard deviation band" marked as shown for comparison, GLMakie's as needing a pin file, and the WGLMakie one under the failed tests. The pin file classification and the failed/deleted split are covered by tests in `ReferenceUpdater/test/runtests.jl`, which no workflow runs yet.
