### PR TITLE
Remove full GC after every reference test

### DIFF
--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -64,7 +64,6 @@ macro reference_test(name, code)
                 # TODO, write to file and create an overview in the end, similar to the benchmark results!
                 println("Used $(mem)gb of $(round(total / 10^9; digits = 3))gb RAM, time: $(elapsed)s")
             end
-            GC.gc(true) # Run GC, to catch accumulating memory early on (used RAM)
         end
     end
 end


### PR DESCRIPTION
Every `@reference_test` currently ends in `GC.gc(true)`, and a full collection on the CI heaps takes 1-2s. Judging by log timestamps from a recent master run, that adds up to ~11 min of the WGLMakie job and ~8 min of the GLMakie job, so this should be a cheap way to shave off some CI time.

Some history for why the call is there: it was added in #3113 while hunting WGLMakie leaks, then accidentally dropped in #3281, so the suites ran without it from Oct 2023 to Jan 2025 without problems. It was deliberately re-added in #4699, where GLMakie's OpenGL cleanup became explicit, so that the `verify_free` finalizer reports (enabled via `GLMakie.DEBUG[] = true` in tests) print close to the test that leaked an object. That's only useful while actively debugging a leak, and the actual `FAILED_FREE_COUNTER == 0` check at the end of the GLMakie suite keeps working, because its runtests still runs `GLMakie.closeall()` plus a final `GC.gc(true)` before the check. If a leak ever needs hunting again, the per-test GC can be temporarily re-added locally.
