### PR TITLE
Fix stale WGLMakie pointer positions on button events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed WGLMakie interactions starting from a stale mouse position when a button is pressed or released, particularly over remote browser connections. [#4657](https://github.com/MakieOrg/Makie.jl/issues/4657)
 - `Menu` is now searchable: typing while it is open filters the options. Set `searchable = false` for the old behavior [#5642](https://github.com/MakieOrg/Makie.jl/pull/5642)
 - Added `textcolor_active` and `textcolor_hover` attributes to `Menu`, with the selected entry now white by default [#5642](https://github.com/MakieOrg/Makie.jl/pull/5642)
 - Fixed `Menu` erroring on hover when `cell_color_hover` or `cell_color_active` were not `RGBA` values [#5642](https://github.com/MakieOrg/Makie.jl/pull/5642)

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -63,30 +63,21 @@ function connect_scene_events!(screen::Screen, scene::Scene, comm::Observable)
                 x, y = Float64.((mouseposition...,))
                 e.mouseposition[] = (x, y)
             end
+            @handle msg.pointerdown begin
+                x, y, buttons = pointerdown
+                e.mouseposition[] = Float64.((x, y))
+                update_mousebutton_state!(e, buttons)
+            end
+            @handle msg.pointerup begin
+                x, y, buttons = pointerup
+                e.mouseposition[] = Float64.((x, y))
+                update_mousebutton_state!(e, buttons)
+            end
             @handle msg.mousedown begin
-                # This can probably be done better from the JS side?
-                state = e.mousebuttonstate
-                if mousedown & 1 != 0 && !(Mouse.left in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.left, Mouse.press))
-                end
-                if mousedown & 2 != 0 && !(Mouse.right in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.right, Mouse.press))
-                end
-                if mousedown & 4 != 0 && !(Mouse.middle in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.middle, Mouse.press))
-                end
+                update_mousebutton_state!(e, mousedown)
             end
             @handle msg.mouseup begin
-                state = e.mousebuttonstate
-                if mouseup & 1 == 0 && (Mouse.left in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.left, Mouse.release))
-                end
-                if mouseup & 2 == 0 && (Mouse.right in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.right, Mouse.release))
-                end
-                if mouseup & 4 == 0 && (Mouse.middle in state)
-                    setindex!(e.mousebutton, MouseButtonEvent(Mouse.middle, Mouse.release))
-                end
+                update_mousebutton_state!(e, mouseup)
             end
             @handle msg.scroll begin
                 e.scroll[] = Float64.((sign.(scroll)...,))
@@ -121,6 +112,27 @@ function connect_scene_events!(screen::Screen, scene::Scene, comm::Observable)
         return
     end
 
+    return
+end
+
+function update_mousebutton_state!(e, buttons)
+    buttons = Int(buttons)
+    state = e.mousebuttonstate
+    if buttons & 1 != 0 && !(Mouse.left in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.left, Mouse.press))
+    elseif buttons & 1 == 0 && (Mouse.left in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.left, Mouse.release))
+    end
+    if buttons & 2 != 0 && !(Mouse.right in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.right, Mouse.press))
+    elseif buttons & 2 == 0 && (Mouse.right in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.right, Mouse.release))
+    end
+    if buttons & 4 != 0 && !(Mouse.middle in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.middle, Mouse.press))
+    elseif buttons & 4 == 0 && (Mouse.middle in state)
+        setindex!(e.mousebutton, MouseButtonEvent(Mouse.middle, Mouse.release))
+    end
     return
 end
 

--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -24822,10 +24822,14 @@ function on_shader_error(gl, program, glVertexShader, glFragmentShader) {
 }
 function add_canvas_events(screen, comm, resize_to) {
     const { canvas , winscale  } = screen;
+    let mouseposition_generation = 0;
     canvas.addEventListener("webglcontextlost", (event)=>{
         dispose_screen(screen);
     });
-    function mouse_callback(event) {
+    function mouse_callback(event, generation) {
+        if (generation !== mouseposition_generation) {
+            return;
+        }
         const [x1, y1] = events2unitless(screen, event);
         comm.notify({
             mouseposition: [
@@ -24836,20 +24840,32 @@ function add_canvas_events(screen, comm, resize_to) {
     }
     const notify_mouse_throttled = Bonito.throttle_function(mouse_callback, 40);
     function mousemove(event) {
-        notify_mouse_throttled(event);
+        notify_mouse_throttled(event, ++mouseposition_generation);
         return false;
     }
     canvas.addEventListener("mousemove", mousemove);
     function mousedown(event) {
+        const [x1, y1] = events2unitless(screen, event);
+        ++mouseposition_generation;
         comm.notify({
-            mousedown: event.buttons
+            pointerdown: [
+                x1,
+                y1,
+                event.buttons
+            ]
         });
         return false;
     }
     canvas.addEventListener("mousedown", mousedown);
     function mouseup(event) {
+        const [x1, y1] = events2unitless(screen, event);
+        ++mouseposition_generation;
         comm.notify({
-            mouseup: event.buttons
+            pointerup: [
+                x1,
+                y1,
+                event.buttons
+            ]
         });
         return false;
     }

--- a/WGLMakie/src/javascript/WGLMakie.js
+++ b/WGLMakie/src/javascript/WGLMakie.js
@@ -367,12 +367,19 @@ function on_shader_error(gl, program, glVertexShader, glFragmentShader) {
 
 function add_canvas_events(screen, comm, resize_to) {
     const { canvas,  winscale } = screen;
+    // A throttled move can be queued when the user presses or releases a button.
+    // Invalidate it so it cannot overwrite the exact pointer position carried by
+    // the button event after that transition has reached Julia.
+    let mouseposition_generation = 0;
 
     canvas.addEventListener("webglcontextlost", (event) => {
         dispose_screen(screen);
     });
 
-    function mouse_callback(event) {
+    function mouse_callback(event, generation) {
+        if (generation !== mouseposition_generation) {
+            return;
+        }
         const [x, y] = events2unitless(screen, event);
         comm.notify({ mouseposition: [x, y] });
     }
@@ -380,23 +387,27 @@ function add_canvas_events(screen, comm, resize_to) {
     const notify_mouse_throttled = Bonito.throttle_function(mouse_callback, 40);
 
     function mousemove(event) {
-        notify_mouse_throttled(event);
+        notify_mouse_throttled(event, ++mouseposition_generation);
         return false;
     }
 
     canvas.addEventListener("mousemove", mousemove);
 
     function mousedown(event) {
+        const [x, y] = events2unitless(screen, event);
+        ++mouseposition_generation;
         comm.notify({
-            mousedown: event.buttons,
+            pointerdown: [x, y, event.buttons],
         });
         return false;
     }
     canvas.addEventListener("mousedown", mousedown);
 
     function mouseup(event) {
+        const [x, y] = events2unitless(screen, event);
+        ++mouseposition_generation;
         comm.notify({
-            mouseup: event.buttons,
+            pointerup: [x, y, event.buttons],
         });
         return false;
     }

--- a/WGLMakie/test/events.jl
+++ b/WGLMakie/test/events.jl
@@ -1,0 +1,28 @@
+@testset "pointer events carry their position" begin
+    scene = Scene()
+    comm = WGLMakie.Observable{Any}(nothing)
+    WGLMakie.connect_scene_events!(WGLMakie.Screen(), scene, comm)
+
+    observed = Tuple{Makie.MouseButtonEvent, Tuple{Float64, Float64}}[]
+    on(events(scene).mousebutton) do event
+        push!(observed, (event, events(scene).mouseposition[]))
+    end
+
+    comm[] = Dict("pointerdown" => [123.0, 456.0, 1])
+    @test Bonito.wait_for(() -> length(observed) == 1; timeout = 2) == :success
+    @test observed[1] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.press), (123.0, 456.0))
+
+    comm[] = Dict("pointerup" => [321.0, 654.0, 0])
+    @test Bonito.wait_for(() -> length(observed) == 2; timeout = 2) == :success
+    @test observed[2] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.release), (321.0, 654.0))
+
+    # Browser sessions created with a previous WGLMakie bundle may still emit
+    # the legacy button-only messages until their page is reloaded.
+    comm[] = Dict("mousedown" => 1)
+    @test Bonito.wait_for(() -> length(observed) == 3; timeout = 2) == :success
+    @test observed[3] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.press), (321.0, 654.0))
+
+    comm[] = Dict("mouseup" => 0)
+    @test Bonito.wait_for(() -> length(observed) == 4; timeout = 2) == :success
+    @test observed[4] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.release), (321.0, 654.0))
+end

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -9,6 +9,8 @@ using ReferenceTests
 using Makie: N0f8, RGBA
 import Electron
 
+include("events.jl")
+
 @testset "mimes" begin
     Makie.inline!(true)
     f, ax, pl = scatter(1:4)
@@ -119,6 +121,80 @@ edisplay = Bonito.use_electron_display(devtools = true)
             @test events(f).window_open[] == false
             @test Makie.isclosed(f.scene) == true
             @test Makie.isopen(f.scene) == false
+        end
+    end
+
+    @testset "browser pointer coordinates" begin
+        scene = Scene(size = (400, 300))
+        scatter!(scene, Point2f(0, 0))
+        observed = Tuple{Makie.MouseButtonEvent, Tuple{Float64, Float64}}[]
+        listener = on(events(scene).mousebutton) do event
+            push!(observed, (event, events(scene).mouseposition[]))
+        end
+
+        try
+            display(edisplay, App(scene))
+            @test Bonito.wait_for(() -> events(scene).window_open[]; timeout = 10) == :success
+
+            expected_press = Tuple(
+                Float64.(
+                    run(
+                        edisplay.window, """
+                            (() => {
+                                const canvas = document.querySelector(\"canvas\");
+                                const rect = canvas.getBoundingClientRect();
+                                const height = canvas.wglmakie_screen.renderer._height;
+                                const dispatch = (type, x, y, buttons) => canvas.dispatchEvent(
+                                    new MouseEvent(type, {
+                                        bubbles: true,
+                                        button: 0,
+                                        buttons,
+                                        clientX: rect.left + x,
+                                        clientY: rect.top + y,
+                                    })
+                                );
+                                dispatch(\"mousemove\", 20, 30, 0);
+                                dispatch(\"mousemove\", 40, 50, 0);
+                                dispatch(\"mousedown\", 120, 140, 1);
+                                return [120, height - 140];
+                            })()
+                        """
+                    )
+                )
+            )
+            @test Bonito.wait_for(() -> !isempty(observed); timeout = 10) == :success
+            @test observed[1] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.press), expected_press)
+
+            expected_release = Tuple(
+                Float64.(
+                    run(
+                        edisplay.window, """
+                            (() => {
+                                const canvas = document.querySelector(\"canvas\");
+                                const rect = canvas.getBoundingClientRect();
+                                const height = canvas.wglmakie_screen.renderer._height;
+                                const dispatch = (type, x, y, buttons) => canvas.dispatchEvent(
+                                    new MouseEvent(type, {
+                                        bubbles: true,
+                                        button: 0,
+                                        buttons,
+                                        clientX: rect.left + x,
+                                        clientY: rect.top + y,
+                                    })
+                                );
+                                dispatch(\"mousemove\", 180, 190, 1);
+                                dispatch(\"mouseup\", 220, 210, 0);
+                                return [220, height - 210];
+                            })()
+                        """
+                    )
+                )
+            )
+            @test Bonito.wait_for(() -> length(observed) == 2; timeout = 10) == :success
+            @test observed[2] == (Makie.MouseButtonEvent(Makie.Mouse.left, Makie.Mouse.release), expected_release)
+        finally
+            off(listener)
+            display(edisplay, App(nothing))
         end
     end
 


### PR DESCRIPTION
Fixes #4657

Press and release now carry their converted WGL position atomically with the DOM button bitmask. The Julia receiver applies that position before emitting its `MouseButtonEvent`.

Queued throttled moves are guarded by a WGL-local generation token, so an older move cannot overwrite a newer button-event position. Legacy button-only messages remain accepted for pages served by an older bundle.

Tests add receiver coverage and an Electron browser regression for queued move + press/release coordinates. The full WGL suite was run under Xvfb; it exercised the new browser test but has one unrelated `textlabel` reference-image mismatch in this environment.